### PR TITLE
correctly using independent variables and expressions in branch flow

### DIFF
--- a/ext/BMOPFOpfExt/BMOPFOpfExt.jl
+++ b/ext/BMOPFOpfExt/BMOPFOpfExt.jl
@@ -16,9 +16,10 @@ Variables (all rectangular, SI units — V and A):
 - `cr_xf / ci_xf` — transformer branch current (from- and to-side)
 - `cr_sw / ci_sw` — switch current (zeroed when open)
 
-The to-side series current `cr_to = −cr_fr` is an `AffExpr`, not a variable.
-The total branch current at each end (series + π-shunt) is also an `AffExpr`
-in `cr_fr` and `vr`/`vi`, substituted directly into KCL and thermal limits.
+The to-side series currents `cr_to = −cr_fr` and `ci_to = −ci_fr` are
+`AffExpr`s, not variables. The total branch current at each end
+(series + π-shunt) is likewise an `AffExpr` in `cr_fr`/`ci_fr` and
+`vr`/`vi`, substituted directly into KCL and thermal limits.
 
 KCL sign convention: positive current flows **into** the bus.  Every component
 function adds its contribution to the KCL accumulator dicts `(kcl_r, kcl_i)`;

--- a/ext/BMOPFOpfExt/BMOPFOpfExt.jl
+++ b/ext/BMOPFOpfExt/BMOPFOpfExt.jl
@@ -9,13 +9,16 @@ Julia package extension that implements the four-wire rectangular current-voltag
 
 Variables (all rectangular, SI units — V and A):
 - `vr / vi`       — real/imaginary voltage at every bus terminal
-- `cr_fr / ci_fr` — series current leaving each line's from-terminal
-- `cr_to / ci_to` — series current entering each line's to-terminal
+- `cr_fr / ci_fr` — series current in each line, from-terminal direction (independent variable)
 - `crd / cid`     — load current (one per phase conductor)
 - `crg / cig`     — generator current (one per phase conductor)
 - `cr_src/ci_src` — slack-bus injection current (unconstrained)
 - `cr_xf / ci_xf` — transformer branch current (from- and to-side)
 - `cr_sw / ci_sw` — switch current (zeroed when open)
+
+The to-side series current `cr_to = −cr_fr` is an `AffExpr`, not a variable.
+The total branch current at each end (series + π-shunt) is also an `AffExpr`
+in `cr_fr` and `vr`/`vi`, substituted directly into KCL and thermal limits.
 
 KCL sign convention: positive current flows **into** the bus.  Every component
 function adds its contribution to the KCL accumulator dicts `(kcl_r, kcl_i)`;

--- a/ext/BMOPFOpfExt/branch.jl
+++ b/ext/BMOPFOpfExt/branch.jl
@@ -11,25 +11,29 @@
 #   vr_fr[k] − vr_to[k]  =  Σ_j ( R[k,j]·cr_fr[j] − X[k,j]·ci_fr[j] )
 #   vi_fr[k] − vi_to[k]  =  Σ_j ( R[k,j]·ci_fr[j] + X[k,j]·cr_fr[j] )
 #
-# Series current is identical at both ends (no current lost in the ideal
-# series element):
-#   cr_to[k] = −cr_fr[k],  ci_to[k] = −ci_fr[k]
+# cr_fr[k] is the only independent series current variable (from → to direction).
+# The to-side series current is the AffExpr alias:
+#   cr_to[k] := −cr_fr[k],  ci_to[k] := −ci_fr[k]
 #
-# π-shunt current leaving bus b at conductor k (linear in voltage variables):
-#   I^r_k = Σ_j ( G_kj · vr[b,t_j] − B_kj · vi[b,t_j] )
-#   I^i_k = Σ_j ( G_kj · vi[b,t_j] + B_kj · vr[b,t_j] )
+# π-shunt current leaving bus b at conductor k (AffExpr, linear in vr/vi):
+#   ish^r_k = Σ_j ( G_kj · vr[b,t_j] − B_kj · vi[b,t_j] )
+#   ish^i_k = Σ_j ( G_kj · vi[b,t_j] + B_kj · vr[b,t_j] )
 #
-# KCL contributions (positive = into bus):
-#   bus_from, tmfr[k]: −cr_fr[k] − I^r_sh_fr[k]   (series + shunt leave)
-#   bus_to,   tmto[k]: −cr_to[k] − I^r_sh_to[k]   (series arrives, shunt leaves)
+# Total current (series + shunt) — AffExpr, substituted directly into KCL and limits:
+#   I^tot_fr[k] = cr_fr[k] + ish^r_fr[k]      (leaving from-bus)
+#   I^tot_to[k] = −cr_fr[k] + ish^r_to[k]     (leaving to-bus)
 #
-# Current magnitude limit (total current at each end):
-#   |cr_fr[k] + I^r_sh_fr[k]|² + |ci_fr[k] + I^i_sh_fr[k]|² ≤ I_max[k]²
-#   |cr_to[k] + I^r_sh_to[k]|² + |ci_to[k] + I^i_sh_to[k]|² ≤ I_max[k]²
+# KCL contributions (sign convention: positive = into bus):
+#   bus_from, tmfr[k]: −I^tot_fr[k]
+#   bus_to,   tmto[k]: −I^tot_to[k]
 #
-# When G_from = B_from = G_to = B_to = 0 (no shunt), the π-shunt terms vanish,
-# the two magnitude constraints are identical (since cr_to = −cr_fr), and the
-# result reduces to the original series-only formulation.
+# Current magnitude limits:
+#   (I^tot_fr[k])² ≤ I_max[k]²
+#   (I^tot_to[k])² ≤ I_max[k]²
+#
+# When shunts are zero, I^tot_fr = cr_fr and I^tot_to = −cr_fr, so the two
+# limits are symmetric and either alone would suffice; both are kept for
+# generality when shunts are non-zero.
 
 """
     _add_line_constraints!(model, net, vars, kcl_r, kcl_i)
@@ -39,10 +43,11 @@ contributions.
 
 For each line this adds:
 - KVL across the series impedance (real and imaginary parts per conductor)
-- Series current balance: `cr_to = −cr_fr`
 - π-shunt KCL contributions at both buses (linear in voltage variables)
 - Thermal current magnitude limits on the **total** current (series + π-shunt)
   at both the from- and to-ends
+
+`cr_to`/`ci_to` are `AffExpr` aliases (`−cr_fr`) — no equality constraints needed.
 
 Shunt conductance (`G_from`, `G_to`) and susceptance (`B_from`, `B_to`) are
 read from the linecode and scaled by line length. Missing or all-zero shunt
@@ -67,7 +72,7 @@ function _add_line_constraints!(model, net, vars, kcl_r, kcl_i)
         tmto  = Vector{String}(get(line, "terminal_map_to",   String[]))
         n_map = min(length(tmfr), length(tmto), n_c)
 
-        # ── KVL + series current balance ──────────────────────────────────────
+        # ── KVL ───────────────────────────────────────────────────────────────
         for k in 1:n_map
             t_fr = tmfr[k]; t_to = tmto[k]
             @constraint(model,
@@ -76,8 +81,6 @@ function _add_line_constraints!(model, net, vars, kcl_r, kcl_i)
             @constraint(model,
                 vi[(b_fr, t_fr)] - vi[(b_to, t_to)] ==
                 sum(R[k,j]*ci_fr[(lid,j)] + X[k,j]*cr_fr[(lid,j)] for j in 1:n_map))
-            @constraint(model, cr_to[(lid,k)] == -cr_fr[(lid,k)])
-            @constraint(model, ci_to[(lid,k)] == -ci_fr[(lid,k)])
         end
 
         # ── π-shunt currents (linear in voltage variables) ────────────────────

--- a/ext/BMOPFOpfExt/variables.jl
+++ b/ext/BMOPFOpfExt/variables.jl
@@ -3,7 +3,7 @@
 # Index conventions:
 #   vr/vi        : Dict{Tuple{String,String}, VariableRef}  (bus_id, terminal)
 #   cr_fr/ci_fr  : Dict{Tuple{String,Int},    VariableRef}  (line_id, conductor_pos)
-#   cr_to/ci_to  : same
+#   cr_to/ci_to  : Dict{Tuple{String,Int},    AffExpr}      (line_id, conductor_pos) = -cr_fr
 #   crd/cid      : Dict{Tuple{String,Int},    VariableRef}  (load_id, conductor_pos)
 #   crg/cig      : Dict{Tuple{String,Int},    VariableRef}  (gen_id,  conductor_pos)
 #   cr_src/ci_src: Dict{Tuple{String,Int},    VariableRef}  (src_id,  conductor_pos)
@@ -32,22 +32,25 @@ function _add_voltage_variables!(model, bus_terminals, grounded)
     vr, vi
 end
 
-"Declare `cr_fr`/`ci_fr` and `cr_to`/`ci_to` series current variables for each line conductor."
+"Declare `cr_fr`/`ci_fr` series current variables for each line conductor.
+`cr_to`/`ci_to` are returned as `AffExpr` aliases equal to `-cr_fr` — there
+is only one independent series current per branch."
 function _add_line_variables!(model, net)
     cr_fr = Dict{Tuple{String,Int}, JuMP.VariableRef}()
     ci_fr = Dict{Tuple{String,Int}, JuMP.VariableRef}()
-    cr_to = Dict{Tuple{String,Int}, JuMP.VariableRef}()
-    ci_to = Dict{Tuple{String,Int}, JuMP.VariableRef}()
+    cr_to = Dict{Tuple{String,Int}, JuMP.AffExpr}()
+    ci_to = Dict{Tuple{String,Int}, JuMP.AffExpr}()
 
     for (lid, line) in get(net, "line", Dict())
         n_c = length(get(line, "terminal_map_from", String[]))
         for k in 1:n_c
             cr_fr[(lid,k)] = @variable(model, base_name = "cr_fr_$(lid)_$(k)")
             ci_fr[(lid,k)] = @variable(model, base_name = "ci_fr_$(lid)_$(k)")
-            cr_to[(lid,k)] = @variable(model, base_name = "cr_to_$(lid)_$(k)")
-            ci_to[(lid,k)] = @variable(model, base_name = "ci_to_$(lid)_$(k)")
+            cr_to[(lid,k)] = JuMP.AffExpr(0.0, cr_fr[(lid,k)] => -1.0)
+            ci_to[(lid,k)] = JuMP.AffExpr(0.0, ci_fr[(lid,k)] => -1.0)
         end
     end
+
     cr_fr, ci_fr, cr_to, ci_to
 end
 
@@ -242,11 +245,7 @@ function _set_level_aware_start_values!(vars, net, bus_terminals, grounded)
     end
 end
 
-"""
-    _build_vars(model, net, bus_terminals, grounded) -> Dict{Symbol,Any}
-
-Declare all JuMP variables and return them in a single dict.
-"""
+"Declare all JuMP variables and return them in a single dict."
 function _build_vars(model, net, bus_terminals, grounded)
     vr,    vi    = _add_voltage_variables!(model, bus_terminals, grounded)
     cr_fr, ci_fr,

--- a/ext/BMOPFOpfExt/variables.jl
+++ b/ext/BMOPFOpfExt/variables.jl
@@ -3,7 +3,7 @@
 # Index conventions:
 #   vr/vi        : Dict{Tuple{String,String}, VariableRef}  (bus_id, terminal)
 #   cr_fr/ci_fr  : Dict{Tuple{String,Int},    VariableRef}  (line_id, conductor_pos)
-#   cr_to/ci_to  : Dict{Tuple{String,Int},    AffExpr}      (line_id, conductor_pos) = -cr_fr
+#   cr_to/ci_to  : Dict{Tuple{String,Int},    AffExpr}      (line_id, conductor_pos) = -cr_fr / -ci_fr
 #   crd/cid      : Dict{Tuple{String,Int},    VariableRef}  (load_id, conductor_pos)
 #   crg/cig      : Dict{Tuple{String,Int},    VariableRef}  (gen_id,  conductor_pos)
 #   cr_src/ci_src: Dict{Tuple{String,Int},    VariableRef}  (src_id,  conductor_pos)

--- a/src/analysis/provenance.jl
+++ b/src/analysis/provenance.jl
@@ -62,8 +62,10 @@ function _classify_linecodes(net::Dict{String,Any},
     linecodes = get(net, "linecode", Dict())
     by_lc = Dict{String,Any}()
     verdict_counts = Dict{String,Int}()
-    seq_ids = String[]
-    dec_ids = String[]
+    seq_ids   = String[]
+    dec_ids   = String[]
+    no_shunt_ids  = String[]   # linecodes with all-zero/absent π-shunt admittance
+    has_shunt_ids = String[]   # linecodes with at least one non-zero shunt entry
 
     for (id, lc) in linecodes
         lc isa Dict || continue
@@ -218,6 +220,19 @@ function _classify_linecodes(net::Dict{String,Any},
 
         verdict_counts[entry["verdict"]] = get(verdict_counts, entry["verdict"], 0) + 1
         by_lc[id] = entry
+
+        # π-shunt presence tracking: keys present but all-zero counts as no shunt
+        shunt_present = any(
+            begin
+                M = _pattern_keys_to_matrix(lc, p)
+                M isa AbstractMatrix && any(!=(0.0), M)
+            end
+            for p in ("G_from_", "B_from_", "G_to_", "B_to_"))
+        if shunt_present
+            push!(has_shunt_ids, id)
+        else
+            push!(no_shunt_ids, id)
+        end
     end
 
     if !isempty(seq_ids)
@@ -237,6 +252,24 @@ function _classify_linecodes(net::Dict{String,Any},
             "phases decouple into independent single-phase networks: " *
             "$(join(sort(dec_ids), ", ")).",
             Dict{String,Any}("linecodes" => sort(dec_ids))))
+    end
+    if !isempty(no_shunt_ids) && isempty(has_shunt_ids)
+        push!(findings, Finding(INFO, "I.PROV.NO_PI_SHUNT", :provenance,
+            :linecode, nothing,
+            "All $(length(no_shunt_ids)) linecode(s) have no π-shunt admittance " *
+            "(G_from/B_from/G_to/B_to absent or zero) — the line model reduces " *
+            "to a series impedance only. Shunt capacitance is typically negligible " *
+            "for short LV cables but may be significant for long MV/HV lines.",
+            Dict{String,Any}("linecodes" => sort(no_shunt_ids))))
+    elseif !isempty(no_shunt_ids)
+        push!(findings, Finding(INFO, "I.PROV.PARTIAL_PI_SHUNT", :provenance,
+            :linecode, nothing,
+            "$(length(no_shunt_ids)) of $(length(no_shunt_ids) + length(has_shunt_ids)) " *
+            "linecode(s) have no π-shunt admittance — mixed model: some lines are " *
+            "series-only, others include shunt capacitance/conductance: " *
+            "$(join(sort(no_shunt_ids), ", ")).",
+            Dict{String,Any}("linecodes_without_shunt" => sort(no_shunt_ids),
+                             "linecodes_with_shunt"    => sort(has_shunt_ids))))
     end
 
     Dict{String,Any}("by_linecode" => by_lc, "verdict_counts" => verdict_counts)


### PR DESCRIPTION
This should close https://github.com/frederikgeth/BMOPFTools.jl/issues/40.

I.e. only one series current variable per line, 
the reverse direction is handled by an expression,
line shunt currents are expressions of the bus voltage,
total currents therefore are expressions of bus voltage and line series current
KCL and current magnitude limits take expressions as an input, nott variables

@martavanin can add a version with explicit total current variables at a later stage - didn't benchmark