### PR TITLE
docs: fix hallucinated/incorrect citations in Bounds & Feasibility

### DIFF
--- a/docs/src/bounds/index.md
+++ b/docs/src/bounds/index.md
@@ -147,7 +147,7 @@ structure — established by
 [Bolognani & Zampieri (2016)](https://doi.org/10.1109/TPWRS.2015.2395452),
 [Simpson-Porco (2018), Parts I–II](https://arxiv.org/abs/1701.02045), and, for
 distribution feeders,
-[Wang et al. (2018)](https://doi.org/10.1109/TSG.2016.2588541).
+[Wang et al. (2018)](https://doi.org/10.1109/TSG.2016.2572060).
 
 The second half is the deeper and more useful fact, and it is why the objective matters
 so much: the high-voltage solution is *the last one to vanish as the system is loaded
@@ -197,7 +197,7 @@ well-posedness in Section 1.
       \mathcal{F}_{\text{AC}} \neq \varnothing$ — a feasible relaxation says nothing,
       on its own, about AC feasibility.
 
-    [Madani, Sojoudi & Lavaei (2015)](https://doi.org/10.1109/TPWRS.2014.2387234) show
+    [Kocuk, Dey & Sun (2016)](https://doi.org/10.1109/TPWRS.2015.2402640) show
     that even a two-bus, one-generator system can exhibit all three outcomes: the SDP
     relaxation can be exact, inexact, or **feasible while the OPF instance is
     infeasible**. This is the hinge into the next section.
@@ -214,7 +214,7 @@ well-posedness in Section 1.
 
 Voltage collapse is a saddle-node bifurcation: the high- and low-voltage solutions
 coalesce and disappear at the nose, and the power-flow Jacobian is singular there
-([Dobson & Lu, 1993](https://doi.org/10.1109/9.222302);
+([Dobson & Lu, 1993](https://doi.org/10.1109/59.260912);
 [Simpson-Porco, Dörfler & Bullo, 2016](https://doi.org/10.1038/ncomms10790)). Beyond the
 nose the AC equations have **no real solution** — genuine infeasibility. So with
 constant-power loads, feasibility silently encodes the stability limit.
@@ -281,8 +281,8 @@ the solution is no longer physical
     reducing a line's loss increases every upstream reverse flow.
 
     The recurring technical conditions in the exactness literature —
-    [no generator lower bounds, or allowing **load over-satisfaction**](https://doi.org/10.1109/TPWRS.2014.2387234)
-    ([Sojoudi & Lavaei, 2012](https://doi.org/10.1109/Allerton.2012.6483445);
+    [no generator lower bounds, or allowing **load over-satisfaction**](https://doi.org/10.1109/TPWRS.2015.2402640)
+    ([Sojoudi & Lavaei, 2012](https://doi.org/10.1109/PESGM.2012.6345272);
     [Gan et al., 2015](https://arxiv.org/abs/1311.7170)) — are exactly the assumptions
     that *simultaneously* guarantee boundedness (Section 1), keep you on the
     high-voltage branch (Section 2), and hold you away from collapse (Section 4). They

--- a/docs/src/bounds/known_traps.md
+++ b/docs/src/bounds/known_traps.md
@@ -66,7 +66,7 @@ enlarges the feasible set beyond the true AC boundary, so it can certify feasibi
 a loading the network cannot serve.
 
 **Construction:** the two-bus, one-generator characterization of
-[Madani, Sojoudi & Lavaei (2015)](https://doi.org/10.1109/TPWRS.2014.2387234). Pick a
+[Kocuk, Dey & Sun (2016)](https://doi.org/10.1109/TPWRS.2015.2402640). Pick a
 load just beyond the nose (radicand $< 0$).
 
 **Expected behaviour:**
@@ -81,7 +81,7 @@ per-branch cone gap ([Diagnostics §3](diagnostics.md)). This is the headline re
 feasible relaxation is only a one-sided certificate.
 
 *Instance:* the two-bus, one-generator system of
-[Madani, Sojoudi & Lavaei (2015)](https://doi.org/10.1109/TPWRS.2014.2387234) with a
+[Kocuk, Dey & Sun (2016)](https://doi.org/10.1109/TPWRS.2015.2402640) with a
 load just past the nose; verify the AC side with [`solve_feasibility_opf`](../validation.md)
 (non-zero `total_slack_magnitude_A`). Not yet a named case.
 
@@ -112,7 +112,7 @@ a named case.
 [§5](index.md) — exactness proofs often assume *no
 generator lower bounds* or *load over-satisfaction*; reintroducing a lower bound can make
 the relaxation inexact, exact, or feasible-while-AC-infeasible
-([Madani, Sojoudi & Lavaei, 2015](https://doi.org/10.1109/TPWRS.2014.2387234)).
+([Kocuk, Dey & Sun, 2016](https://doi.org/10.1109/TPWRS.2015.2402640)).
 
 **Construction:** the same two-bus, one-generator system with a binding
 $\underline{P}^g > 0$; sweep the lower bound to move between the three outcomes.

--- a/docs/src/bounds/references.md
+++ b/docs/src/bounds/references.md
@@ -20,8 +20,8 @@ formal list.
   [arXiv](https://arxiv.org/abs/1706.05290)
 - C. Wang, A. Bernstein, J.-Y. Le Boudec, and M. Paolone, "Explicit conditions on
   existence and uniqueness of load-flow solutions in distribution networks," *IEEE
-  Transactions on Smart Grid*, vol. 9, no. 2, 2018.
-  [DOI](https://doi.org/10.1109/TSG.2016.2588541)
+  Transactions on Smart Grid*, vol. 9, no. 2, pp. 953–962, 2018.
+  [DOI](https://doi.org/10.1109/TSG.2016.2572060)
 - A. Bernstein, C. Wang, E. Dall'Anese, J.-Y. Le Boudec, and C. Zhao, "Load flow in
   multiphase distribution networks: existence, uniqueness, non-singularity and linear
   models," *IEEE Transactions on Power Systems*, 2018.
@@ -36,12 +36,12 @@ formal list.
   in radial networks," *IEEE Transactions on Automatic Control*, vol. 60, no. 1, 2015.
   [arXiv](https://arxiv.org/abs/1311.7170)
 - S. Sojoudi and J. Lavaei, "Physics of power networks makes hard optimization problems
-  easy to solve," *IEEE PES General Meeting / Allerton*, 2012.
-  [DOI](https://doi.org/10.1109/Allerton.2012.6483445)
-- R. Madani, S. Sojoudi, and J. Lavaei, "Inexactness of SDP relaxation and valid
+  easy to solve," *IEEE PES General Meeting*, 2012.
+  [DOI](https://doi.org/10.1109/PESGM.2012.6345272)
+- B. Kocuk, S. S. Dey, and X. A. Sun, "Inexactness of SDP relaxation and valid
   inequalities for optimal power flow" (two-bus characterization of the three
-  approximation outcomes), *IEEE Transactions on Power Systems*, vol. 30, no. 1, 2015.
-  [DOI](https://doi.org/10.1109/TPWRS.2014.2387234)
+  approximation outcomes), *IEEE Transactions on Power Systems*, vol. 31, no. 1,
+  pp. 642–651, 2016. [DOI](https://doi.org/10.1109/TPWRS.2015.2402640)
 - Z. Yuan and M. Paolone, "Properties of convex optimal power flow model based on power
   loss relaxation" (objective-monotonicity ⇒ exactness), *Electric Power Systems
   Research*, 2020. [arXiv](https://arxiv.org/abs/1906.06105)
@@ -57,7 +57,7 @@ formal list.
 
 - I. Dobson and L. Lu, "New methods for computing a closest saddle-node bifurcation and
   worst-case load power margin for voltage collapse," *IEEE Transactions on Power
-  Systems*, 1993. [DOI](https://doi.org/10.1109/9.222302)
+  Systems*, vol. 8, no. 3, pp. 905–913, 1993. [DOI](https://doi.org/10.1109/59.260912)
 - J. W. Simpson-Porco, F. Dörfler, and F. Bullo, "Voltage collapse in complex power
   grids," *Nature Communications*, vol. 7, 10790, 2016.
   [DOI](https://doi.org/10.1038/ncomms10790)


### PR DESCRIPTION
Four IEEE references in the bounds section had wrong DOIs, two of them also misattributed. Verified each against Crossref/arXiv and corrected:

- Wang et al. (2018), load-flow existence/uniqueness: 10.1109/TSG.2016.2588541 (404) -> 10.1109/TSG.2016.2572060
- Dobson & Lu (1993), closest saddle-node bifurcation: 10.1109/9.222302 (resolved to an unrelated paper) -> 10.1109/59.260912
- Sojoudi & Lavaei (2012), "Physics of power networks...": 10.1109/Allerton.2012.6483445 (unrelated paper) -> 10.1109/PESGM.2012.6345272
- The two-bus, three-outcome SDP characterization was attributed to "Madani, Sojoudi & Lavaei (2015)" with DOI 10.1109/TPWRS.2014.2387234; this is actually Kocuk, Dey & Sun, "Inexactness of SDP Relaxation and Valid Inequalities for OPF," IEEE TPWRS 31(1):642-651, 2016, 10.1109/TPWRS.2015.2402640. Fixed author and DOI in index.md, known_traps.md, and references.md.

All remaining DOIs and arXiv IDs in the section were re-verified and are correct. Docs build clean.