### PR TITLE
support split phase tap changing

### DIFF
--- a/docs/src/tutorial_tap.md
+++ b/docs/src/tutorial_tap.md
@@ -20,11 +20,16 @@ numbers are real.
 A transformer tap is exposed with the same *implicit* free-variable pattern as
 generators and IBRs: **bounds make it optimisable**.
 
-- Ordinary transformers (`single_phase`, `delta_wye`, `wye_delta`) take a
-  dimensionless multiplier `tap` on the nominal from-side ratio
-  ``N_0 = v_{\text{ref,from}}/v_{\text{ref,to}}``, with `tap_min`/`tap_max`.
+- Ordinary transformers (`single_phase`, `center_tap`, `delta_wye`, `wye_delta`)
+  take a dimensionless multiplier `tap` on the nominal from-side ratio
+  ``N_0 = v_{\text{ref,from}}/v_{\text{ref,to}}``, with `tap_min`/`tap_max`. For
+  `center_tap` this taps the HV winding, so both LV legs scale together.
 - Regulator subtypes (`single_phase_autotransformer`, `open_delta_regulator`) make
   their native `tap_ratio` free with `tap_ratio_min`/`tap_ratio_max`.
+
+`n_winding` is the one subtype **without** tap support: its ratio is always held at
+the nominal turns ratio. Supplying a tap field on an `n_winding` raises a warning at
+OPF-build time (rather than silently fixing the ratio).
 
 If `tap_min < tap_max` the tap becomes a decision variable; otherwise it is fixed
 (so existing data is unchanged). Internally the solved tap enters the winding
@@ -194,16 +199,24 @@ to *every* transformer:
   leakage and a voltage drop that is linear-in-current and quadratic-in-tap — and it
   matches the OpenDSS turns-scaled `Yprim` at the optimised tap to the usual ~0.3 V
   validation floor.
+- **The split-phase (`center_tap`) tap also admits an exact, degree-2 model.** Its
+  free tap reuses the same coupled-coil `Yprim` as the fixed model, but with the HV
+  ratio promoted to a variable and the voltage drop written in the degree-2 T-model
+  form (``N\cdot v`` and ``N\cdot Z_2 I`` products only). It is algebraically
+  identical to the fixed `Yprim` — re-solving with the tap fixed to ``t^\star``
+  reproduces the free solution to **0.0 V** — so the leakage referral is exact, not
+  approximate, even under heavy drop and leg unbalance.
 - **The Dy coupled delta-arm model currently holds the leakage at the nominal
   ratio.** This is a second-order approximation: exact at ``t = 1`` and within the
   validation tolerance at a few-percent tap, but the error grows with tap deviation.
-  Carrying the ``t^2`` referral through the coupled delta-arm transformation — and
-  the analogous treatment for `center_tap` and `n_winding`, plus to-side taps and
-  discrete steps — is the natural **general-picture** follow-up.
+  Carrying the ``t^2`` referral through the coupled delta-arm transformation — plus
+  free taps for `n_winding`, to-side taps and discrete steps — is the natural
+  **general-picture** follow-up.
 
 The optimiser, the JSON schema and the result reporting are already uniform across
 all the covered subtypes; what remains to generalise is purely the *leakage
-referral* of the coupled multi-winding cores.
+referral* of the coupled `delta_wye`/`wye_delta` cores and the unsupported
+`n_winding` subtype.
 
 ## Validation
 
@@ -213,6 +226,12 @@ bus voltages are compared to the OPF solution (see
 `test/powerflow_comparison_tests.jl`, *optimised tap vs OpenDSS*). Because the
 variable-tap model is the fixed-tap model with the ratio promoted to a variable,
 agreement at ``t^\star`` is the validation of the feature.
+
+For `center_tap` the cross-check is deliberately stressed: a 5 km feeder with heavy,
+**unequal** 120 V leg loads (high voltage drop + unbalance) — node voltages agree
+with the OpenDSS turns-scaled `Yprim` at ``t^\star`` to ≈ 0.25 V and **total losses
+to ≈ 2.5 %**, and the free T-model reproduces the fixed-`Yprim` re-solve at
+``t^\star`` exactly (0.0 V).
 ```@example tap
 nothing # hide
 ```

--- a/docs/src/validation.md
+++ b/docs/src/validation.md
@@ -231,6 +231,15 @@ of fixtures pins it down rather than a single light-load case:
   builder and the Ybus exporter implement the device independently, so a test
   asserts the centre-tap KCL closes on the `_yprim_center_tap` admittance — a
   guard against the two paths drifting apart again.
+- **Continuous tap optimisation under drop + unbalance** (*optimised tap vs
+  OpenDSS (center_tap)*): a free HV tap on `pf_center_tap_loaded` (5 km feeder,
+  heavy unequal legs) is optimised, then OpenDSS is solved with that tap set on
+  winding 1. Node voltages match to **≈ 0.25 V** and **total losses to ≈ 2.5 %**
+  (`rtol = 0.05`), and a wide-band internal-exactness check confirms the free
+  degree-2 T-model reproduces the fixed-`Yprim` re-solve at ``t^\star`` to
+  **0.0 V** — so promoting the ratio to a variable adds no modelling error. The
+  free tap reuses the *exact* coupled-coil leakage (not the nominal-ratio
+  approximation that the `delta_wye`/`wye_delta` free taps still carry).
 
 ### Parse-path and primitive-admittance gates
 

--- a/ext/BMOPFOpfExt/nwinding.jl
+++ b/ext/BMOPFOpfExt/nwinding.jl
@@ -50,6 +50,25 @@ function _add_nwinding_variables!(model, net)
     cr_nw, ci_nw
 end
 
+# Tap optimisation is NOT supported for n_winding (the ratio is held fixed at the
+# nominal turns ratio). If the data carries tap field(s) — on the transformer or
+# any winding — warn loudly so the unsupported request is not silently dropped.
+const _NW_TAP_KEYS = ("tap", "tap_min", "tap_max",
+                      "tap_ratio", "tap_ratio_min", "tap_ratio_max")
+function _warn_nwinding_unsupported_tap(tid, xfmr)
+    hit = any(haskey(xfmr, k) for k in _NW_TAP_KEYS)
+    if !hit
+        ws = get(xfmr, "windings", nothing)
+        ws isa AbstractVector && (hit = any(
+            w isa AbstractDict && any(haskey(w, k) for k in _NW_TAP_KEYS) for w in ws))
+    end
+    hit && @warn "n_winding transformer '$(tid)' carries tap field(s), but tap " *
+        "optimisation is not supported for n_winding — the ratio is held FIXED at " *
+        "the nominal turns ratio. Remove the tap fields, or model the regulated " *
+        "winding with a supported subtype (single_phase, center_tap, wye_delta, " *
+        "delta_wye, single_phase_autotransformer, open_delta_regulator)."
+end
+
 """
     _add_nwinding_constraints!(model, net, vars, kcl_r, kcl_i; branch_inj=nothing)
 
@@ -64,6 +83,7 @@ function _add_nwinding_constraints!(model, net, vars, kcl_r, kcl_i; branch_inj=n
     nwd = get(get(net, "transformer", Dict()), "n_winding", Dict())
     for (tid, xfmr) in nwd
         xfmr isa Dict || continue
+        _warn_nwinding_unsupported_tap(tid, xfmr)
         ws = BMOPFTools._nw_windings(xfmr)
         n  = length(ws)
         n < 2 && continue

--- a/ext/BMOPFOpfExt/transformer.jl
+++ b/ext/BMOPFOpfExt/transformer.jl
@@ -67,7 +67,7 @@ function _add_transformer_constraints!(model, net, vars, kcl_r, kcl_i; branch_in
     end
     for (tid, xfmr) in get(xfmr_dict, "center_tap", Dict())
         _add_center_tap_transformer!(model, tid, xfmr, vr, vi, cr_xf, ci_xf, kcl_r, kcl_i;
-                              branch_inj=branch_inj)
+                              tap=get(tapd, tid, nothing), branch_inj=branch_inj)
     end
 
     for (tid, xfmr) in get(xfmr_dict, "wye_delta", Dict())
@@ -307,13 +307,16 @@ Physics (coupled-coil / primitive-admittance model):
   No-load shunt (G+jB) at HV terminals (placed on winding-1 from side).
 """
 function _add_center_tap_transformer!(model, tid, xfmr, vr, vi, cr_xf, ci_xf, kcl_r, kcl_i;
-                                      branch_inj=nothing)
+                                      tap=nothing, branch_inj=nothing)
     kadd = _xf_kadd(kcl_r, kcl_i, branch_inj, tid)
     b_fr       = get(xfmr, "bus_from", "")
     b_to       = get(xfmr, "bus_to",   "")
     tmfr       = Vector{String}(get(xfmr, "terminal_map_from", String[]))
     tmto       = Vector{String}(get(xfmr, "terminal_map_to",   String[]))
-    N          = _xfmr_turns_ratio(xfmr)
+    # Effective HV→LV-leg ratio N. Fixed: N0·tap multiplier (default 1.0, so legacy
+    # data is unchanged). Free: the tap variable IS N (= N0·tap), warm-started at N0.
+    N0         = _xfmr_turns_ratio(xfmr)
+    N          = tap === nothing ? N0 * BMOPFTools._xfmr_tap_mult(xfmr) : tap
     i_max_fr   = Float64.(get(xfmr, "i_max_from", Float64[]))
     i_max_to_v = Float64.(get(xfmr, "i_max_to",   Float64[]))
 
@@ -361,7 +364,13 @@ function _add_center_tap_transformer!(model, tid, xfmr, vr, vi, cr_xf, ci_xf, kc
     # CRITICAL: winding 3 is dotted at the centre tap, so its voltage is
     # V(t_lv_n) − V(t_lv_2) (NOT V(t_lv_2) − V(t_lv_n)). The opposite sign makes
     # the two LV legs identical instead of series-aiding, the original bug.
-    if has_series
+    #
+    # This analytical Yprim folds N into y1 = N²/Z1 and C = ±1/N, so it is only
+    # used when the ratio is a FIXED number. A free tap (variable N) takes the
+    # degree-2 T-model branch below, which is algebraically identical at N = N0
+    # (derived from this same Yprim) but linear-in-leakage so the products stay
+    # quadratic for Ipopt.
+    if has_series && tap === nothing
         Z1 = R1 + im * X1            # HV star arm  (HV side, Ω/pu)
         Z2 = R2 + im * X2            # each LV star arm (LV side, Ω/pu)
         y1 = N^2 / Z1
@@ -422,22 +431,29 @@ function _add_center_tap_transformer!(model, tid, xfmr, vr, vi, cr_xf, ci_xf, kc
         return
     end
 
-    # ── Ideal core (zero series impedance) ────────────────────────────────────
-    # Both LV legs are pinned to V_hv/N (winding 3 dotted at the centre tap), so
-    # the legs are automatically symmetric; the ampere-turn and centre-tap KCL
-    # below route the currents.
-    @constraint(model,
-        vr[(b_fr, t_fr_ph)] - vr[(b_fr, t_fr_n)] ==
-        N * (vr[(b_to, t_lv_1)] - vr[(b_to, t_lv_n)]))
-    @constraint(model,
-        vi[(b_fr, t_fr_ph)] - vi[(b_fr, t_fr_n)] ==
-        N * (vi[(b_to, t_lv_1)] - vi[(b_to, t_lv_n)]))
-    @constraint(model,
-        vr[(b_fr, t_fr_ph)] - vr[(b_fr, t_fr_n)] ==
-        N * (vr[(b_to, t_lv_n)] - vr[(b_to, t_lv_2)]))
-    @constraint(model,
-        vi[(b_fr, t_fr_ph)] - vi[(b_fr, t_fr_n)] ==
-        N * (vi[(b_to, t_lv_n)] - vi[(b_to, t_lv_2)]))
+    # ── T-model core (free tap, or zero series impedance) ─────────────────────
+    # Degree-2 voltage drop derived from the SAME coupled-coil Yprim as the fixed
+    # path above: with the HV core EMF E = V_hv − Z1·Is and the star node V* = E/N,
+    #   leg1:  V_hv − N·v1 = Z1·Is − N·Z2·Il1
+    #   leg2:  V_hv − N·v2 = Z1·Is + N·Z2·Il2   (winding 3 reversed at the centre tap)
+    # where v1 = V_t1 − V_tn, v2 = V_tn − V_t2, Z1 = R1+jX1 (HV Ω, HV winding) and
+    # Z2 = R2+jX2 (each LV leg, LV Ω). The shared Z1·Is term carries the
+    # half-winding mutual coupling that the 5×5 Yprim captured. At Z = 0 this
+    # collapses to the ideal V_hv = N·v1 = N·v2; at N = N0 it reproduces the fixed
+    # Yprim exactly. The only nonlinear terms are the bilinear N·v and N·Z2·Il
+    # products, so the constraint set stays quadratic when N is a free tap.
+    vr_hv = @expression(model, vr[(b_fr, t_fr_ph)] - vr[(b_fr, t_fr_n)])
+    vi_hv = @expression(model, vi[(b_fr, t_fr_ph)] - vi[(b_fr, t_fr_n)])
+    vr_l1 = @expression(model, vr[(b_to, t_lv_1)] - vr[(b_to, t_lv_n)])
+    vi_l1 = @expression(model, vi[(b_to, t_lv_1)] - vi[(b_to, t_lv_n)])
+    vr_l2 = @expression(model, vr[(b_to, t_lv_n)] - vr[(b_to, t_lv_2)])
+    vi_l2 = @expression(model, vi[(b_to, t_lv_n)] - vi[(b_to, t_lv_2)])
+    z1r_Is = @expression(model, R1 * Isr - X1 * Isi)   # Re(Z1·Is)
+    z1i_Is = @expression(model, R1 * Isi + X1 * Isr)   # Im(Z1·Is)
+    @constraint(model, vr_hv - N * vr_l1 == z1r_Is - N * (R2 * Il1r - X2 * Il1i))
+    @constraint(model, vi_hv - N * vi_l1 == z1i_Is - N * (R2 * Il1i + X2 * Il1r))
+    @constraint(model, vr_hv - N * vr_l2 == z1r_Is + N * (R2 * Il2r - X2 * Il2i))
+    @constraint(model, vi_hv - N * vi_l2 == z1i_Is + N * (R2 * Il2i + X2 * Il2r))
 
     # ── Current coupling (power conservation) ────────────────────────────────
     # Power balance at ideal core: V_hv·conj(I_s) + (V_leg1·conj(−Il1) + V_leg2·conj(−Il2)) = 0
@@ -482,6 +498,16 @@ function _add_center_tap_transformer!(model, tid, xfmr, vr, vi, cr_xf, ci_xf, kc
     # current-coupling above, which needs −Il2 for the reversed winding's MMF).
     @constraint(model, Inr + Il1r + Il2r == 0)
     @constraint(model, Ini + Il1i + Il2i == 0)
+
+    # ── Pin the HV neutral winding-current variable (fr,2) ────────────────────
+    # The HV coil is phase-to-neutral and the no-load shunt is phase-to-ground, so
+    # the series current returns entirely through the neutral: I_neutral = −I_s.
+    # The fixed Yprim path pins this via the nodal injection; the T-model path
+    # pins it explicitly so the result writer and loss accounting (which read the
+    # fr,2 variable) see the physical neutral current.
+    I2r = cr_xf[(tid,"fr",2)]; I2i = ci_xf[(tid,"fr",2)]
+    @constraint(model, I2r == -Isr)
+    @constraint(model, I2i == -Isi)
 
     # ── HV side KCL (terminal current = series + shunt) ──────────────────────
     if has_shunt

--- a/ext/BMOPFOpfExt/variables.jl
+++ b/ext/BMOPFOpfExt/variables.jl
@@ -215,7 +215,7 @@ per-regulator taps. Bounded and warm-started at the nominal coefficient.
 function _add_tap_variables!(model, net)
     tap = Dict{Any, JuMP.VariableRef}()
     xfmr_dict = get(net, "transformer", Dict())
-    for subtype in ("single_phase", "wye_delta", "delta_wye",
+    for subtype in ("single_phase", "center_tap", "wye_delta", "delta_wye",
                     "single_phase_autotransformer")
         for (tid, xfmr) in get(xfmr_dict, subtype, Dict())
             xfmr isa Dict || continue

--- a/src/BMOPFTools.jl
+++ b/src/BMOPFTools.jl
@@ -340,7 +340,7 @@ monotone, so the coefficient bounds are the sorted images of the tap bounds. For
 `open_delta_regulator` use `_odr_ratio_coeff_bounds` (per regulator).
 """
 function _xfmr_ratio_coeff_bounds(subtype::AbstractString, xfmr::Dict{String,Any})
-    if subtype in ("single_phase", "wye_delta", "delta_wye")
+    if subtype in ("single_phase", "center_tap", "wye_delta", "delta_wye")
         (haskey(xfmr, "tap_min") && haskey(xfmr, "tap_max")) || return nothing
         tlo = Float64(xfmr["tap_min"]); thi = Float64(xfmr["tap_max"])
         tlo < thi || return nothing
@@ -387,7 +387,7 @@ tap (`tap` for ordinary transformers, `tap_ratio` for regulators) for reporting.
 Scale-invariant: in per-unit `coeff = N0_pu·t`, so the recovered `t` is dimensionless.
 """
 function _xfmr_tap_from_coeff(subtype::AbstractString, xfmr::Dict{String,Any}, coeff::Float64)
-    if subtype == "single_phase"
+    if subtype in ("single_phase", "center_tap")
         N0 = _xfmr_turns_ratio(xfmr); return iszero(N0) ? coeff : coeff / N0
     elseif subtype == "delta_wye"
         N0 = _xfmr_turns_ratio(xfmr); return iszero(N0) ? coeff : coeff / (sqrt(3.0) * N0)

--- a/src/validation/schemas/draft_bmopf_schema.json
+++ b/src/validation/schemas/draft_bmopf_schema.json
@@ -1122,7 +1122,7 @@
                     },
                     "tap": {
                         "$ref": "#/$defs/nonnegative_number",
-                        "description": "Dimensionless tap multiplier on the from-side ratio; N_eff = (v_ref_from/v_ref_to)*tap. Default 1.0. Ignored for center_tap."
+                        "description": "Dimensionless tap multiplier on the from-side (HV) ratio; N_eff = (v_ref_from/v_ref_to)*tap. Default 1.0. For center_tap this taps the HV winding (both LV legs scale together)."
                     },
                     "tap_min": {
                         "$ref": "#/$defs/nonnegative_number",

--- a/test/powerflow_comparison_tests.jl
+++ b/test/powerflow_comparison_tests.jl
@@ -2133,6 +2133,22 @@ end
     _cmp_volts(V_ods, V_bm; label="pf-3wdg-nwinding: ")
 end
 
+@testset "n_winding tap fields warn (unsupported, not silently fixed)" begin
+    # Tap optimisation is not supported for n_winding. A tap field on a winding
+    # must raise a warning at OPF build, rather than silently holding the ratio
+    # fixed. Without the field, that warning must not fire.
+    warned(net) = any(
+        l -> occursin("tap optimisation is not supported", string(l.message)),
+        first(Test.collect_test_logs(() -> solve_opf(net; optimizer=Ipopt.Optimizer))))
+
+    @test !warned(_net_3wdg_nwinding())                 # clean net: no such warning
+
+    nettap = _net_3wdg_nwinding()
+    w = first(values(nettap["transformer"]["n_winding"]))
+    w["tap_min"] = 0.9; w["tap_max"] = 1.1
+    @test warned(nettap)                                # tap field ⇒ warning fires
+end
+
 @testset "PF (solve_pf) comparison — 3-winding transformer, unbalanced loads" begin
     # Per-phase star independence: single-phase loads on different phases must
     # still match OpenDSS's 3-winding solve (the n≤3 star is exact).
@@ -2726,6 +2742,20 @@ function _ods_volts_tap(dss_path::String, xfname::String, wdg::Int, tapval::Real
     return Dict(n => v for (n, v) in zip(names, volts))
 end
 
+"""
+    _ods_losses_tap(dss_path, xfname, wdg, tapval) -> Float64
+
+Like `_ods_losses_W` but sets transformer `xfname` winding `wdg` tap to `tapval`
+before solving — the OpenDSS loss oracle at the OPF-optimised tap.
+"""
+function _ods_losses_tap(dss_path::String, xfname::String, wdg::Int, tapval::Real)::Float64
+    OpenDSSDirect.dss("Clear")
+    OpenDSSDirect.dss("Redirect \"$(normpath(dss_path))\"")
+    OpenDSSDirect.dss("Edit Transformer.$xfname wdg=$wdg tap=$tapval")
+    OpenDSSDirect.dss("Solve")
+    return real(Circuit.Losses())
+end
+
 @testset "PF comparison — optimised tap vs OpenDSS (single_phase)" begin
     path = joinpath(_PF_CMP_DIR, "pf_1ph_xfmr.dss")
     net  = _net_1ph_xfmr()
@@ -2772,6 +2802,73 @@ end
     # turns-scaled Yprim to within the rtol floor (~0.24 V on the 233 V secondary);
     # the exact tap² referral for the coupled arm is the general-picture follow-up.
     _cmp_volts(V_ods, V_bm; label="Dy-tap-opt: ", atol=0.1)
+end
+
+@testset "PF comparison — optimised tap vs OpenDSS (center_tap: drop + unbalance + losses)" begin
+    # Split-phase OLTC on the HV winding. The loaded fixture is a 5 km feeder with
+    # heavy, UNEQUAL 120 V leg loads → strong voltage drop and leg unbalance, plus
+    # copper (%r), leakage (XHL/XLT/XHT) and core (%noloadloss) losses. The free
+    # tap is the coupled-coil Yprim model with the HV ratio promoted to a degree-2
+    # variable; agreement with the OpenDSS turns-scaled Yprim at the optimised tap,
+    # in BOTH node voltages AND total losses, is the validation. A narrow LV-leg
+    # window forces an interior boost so the tap genuinely moves.
+    path = joinpath(_PF_CMP_DIR, "pf_center_tap_loaded.dss")
+    net  = from_dss(path)
+    net["voltage_source"]["source"]["cost"] = [1.0]
+    ct = net["transformer"]["center_tap"]["t1"]
+    ct["tap"] = 1.0; ct["tap_min"] = 0.9; ct["tap_max"] = 1.1
+    # LV legs are phase terminals (a, b); lift them into a narrow window.
+    net["bus"]["lv"]["v_min"] = [120.0, 120.0]
+    net["bus"]["lv"]["v_max"] = [130.0, 130.0]
+
+    res = solve_opf(net; optimizer=Ipopt.Optimizer)
+    @test res["termination_status"] in ("LOCALLY_SOLVED", "OPTIMAL")
+    tstar = res["transformer"]["t1"]["tap"]
+    @test 0.9 < tstar < 0.99                 # interior boost (lower ratio raises LV)
+    @test haskey(res["transformer"]["t1"], "tap_binding")
+
+    # Node voltages vs the OpenDSS oracle at the optimised tap (winding 1 = HV).
+    phmap = Dict("a"=>"1", "b"=>"2", "n"=>"4")
+    V_bm  = Dict(bid * "." * phmap[t] => tv["vr"] + im*tv["vi"]
+                 for (bid, td) in res["bus"] for (t, tv) in td if haskey(phmap, t))
+    _cmp_volts(_ods_volts_tap(path, "t1", 1, tstar), V_bm; label="ct-tap-opt: ", atol=0.5)
+
+    # Losses must be passive and match OpenDSS at the optimised tap — the explicit
+    # acceptance bar: correct losses under high drop + unbalance.
+    @test res["losses"]["p_loss"] > 0
+    @test isapprox(res["losses"]["p_loss"], _ods_losses_tap(path, "t1", 1, tstar); rtol=0.05)
+end
+
+@testset "center_tap free tap — internal exactness (T-model ≡ fixed Yprim at t*)" begin
+    # The degree-2 free-tap T-model and the fixed coupled-coil Yprim are the same
+    # network; re-solving with the tap FIXED to t* must reproduce the free solution
+    # to solver tolerance (and drop the tap variable). This links the new free path
+    # to the OpenDSS-validated fixed model. A WIDE tap band stresses the referral.
+    path = joinpath(_PF_CMP_DIR, "pf_center_tap_loaded.dss")
+    nf = from_dss(path); nf["voltage_source"]["source"]["cost"] = [1.0]
+    ctf = nf["transformer"]["center_tap"]["t1"]
+    ctf["tap"] = 1.0; ctf["tap_min"] = 0.85; ctf["tap_max"] = 1.15
+    nf["bus"]["lv"]["v_min"] = [120.0, 120.0]; nf["bus"]["lv"]["v_max"] = [130.0, 130.0]
+    rf = solve_opf(nf; optimizer=Ipopt.Optimizer)
+    @test rf["termination_status"] in ("LOCALLY_SOLVED", "OPTIMAL")
+    tstar = rf["transformer"]["t1"]["tap"]
+    @test 0.85 - 1e-6 <= tstar <= 1.15 + 1e-6
+
+    nfix = from_dss(path)
+    nfix["transformer"]["center_tap"]["t1"]["tap"] = tstar
+    rfix = solve_opf(nfix; optimizer=Ipopt.Optimizer)
+    @test !haskey(rfix["transformer"]["t1"], "tap")        # fixed ⇒ no variable
+    vm(r, b, t) = (v = r["bus"][b][t]; sqrt(v["vr"]^2 + v["vi"]^2))
+    for b in keys(rf["bus"]), t in keys(rf["bus"][b])
+        @test vm(rf, b, t) ≈ vm(rfix, b, t) atol = 1e-3
+    end
+
+    # The OpenDSS oracle at the wide-band optimum still agrees → the N-referral of
+    # the leakage holds at this tap excursion (≈8-9 % off nominal).
+    phmap = Dict("a"=>"1", "b"=>"2", "n"=>"4")
+    V_bm  = Dict(bid * "." * phmap[t] => tv["vr"] + im*tv["vi"]
+                 for (bid, td) in rf["bus"] for (t, tv) in td if haskey(phmap, t))
+    _cmp_volts(_ods_volts_tap(path, "t1", 1, tstar), V_bm; label="ct-tap-wide: ", atol=0.6)
 end
 
 @testset "PF comparison — free regulator taps (internal exactness)" begin


### PR DESCRIPTION
Promote the HV ratio of split-phase (center_tap) transformers to a free OPF variable, closing the last common distribution-transformer gap in the continuous-tap feature. n_winding remains the only subtype without tap support.