### PR TITLE
powerio-bidirectional-tests

### DIFF
--- a/scripts/roundtrip_fidelity.jl
+++ b/scripts/roundtrip_fidelity.jl
@@ -1,0 +1,266 @@
+"""
+    roundtrip_fidelity.jl
+
+Map out where the BMOPF → OpenDSS export (`to_dss`) loses fidelity, by round-
+tripping the test corpus DSS → BMOPF → DSS and diagnosing the differences with
+three signal sources (PowerIO warnings, semantic BMOPF diff, OpenDSS power-flow
+cross-check). See test/roundtrip_helpers.jl for the machinery.
+
+Corpus tiers:
+  Tier A — all 33 test/data/pf_comparison/*.dss (one feature per case).
+  Tier B — a curated sample of real networks (LV / SWER / meshed / ENWL / dsuite).
+  Tier C — the full ~854-file corpus (opt-in via --all).
+
+Outputs (under output/roundtrip_fidelity/):
+  case_matrix.md      per-case × per-signal table
+  failure_map.md      grouped by (component_type, failure_mode)
+  case_reports.json   full machine-readable CaseReport array
+  diffs.csv           one row per semantic Diff
+  pf.csv              one row per case PF result
+
+The power-flow cross-check needs OpenDSSDirect, which is a *test-only* extra of
+BMOPFTools. Running with `--project` (the main project) therefore skips the PF
+gate. To exercise it, run from an environment that provides both BMOPFTools and
+OpenDSSDirect, e.g.:
+    julia -e 'using Pkg; Pkg.activate(temp=true); Pkg.develop(path="."); \\
+              Pkg.add("OpenDSSDirect"); include("scripts/roundtrip_fidelity.jl"); main()'
+The committed regression testset (test/runtests.jl) always runs the PF gate,
+since the package test target includes OpenDSSDirect.
+
+Usage:
+    julia --project scripts/roundtrip_fidelity.jl                 # Tier A + B
+    julia --project scripts/roundtrip_fidelity.jl --tier-a-only
+    julia --project scripts/roundtrip_fidelity.jl --all           # + full corpus
+    julia --project scripts/roundtrip_fidelity.jl --cases pf_1ph_line,pf_yd_xfmr
+    julia --project scripts/roundtrip_fidelity.jl --out /tmp/rt
+"""
+
+using Pkg
+# Only fall back to the main project when the active environment does not already
+# provide BMOPFTools (so a test/temp env carrying OpenDSSDirect is respected and
+# the PF gate can fire).
+if isnothing(Base.identify_package("BMOPFTools"))
+    Pkg.activate(joinpath(@__DIR__, ".."))
+end
+
+using BMOPFTools
+using JSON3
+using Logging
+
+const _HAS_ODS = !isnothing(Base.identify_package("OpenDSSDirect"))
+if _HAS_ODS
+    @eval using OpenDSSDirect
+end
+
+include(joinpath(@__DIR__, "..", "test", "roundtrip_helpers.jl"))
+
+const DATA_DIR   = normpath(joinpath(@__DIR__, "..", "test", "data"))
+const OUTPUT_DIR = normpath(joinpath(@__DIR__, "..", "output", "roundtrip_fidelity"))
+
+# ── Corpus enumeration ──────────────────────────────────────────────────────
+
+"All 33 systematic feature cases."
+function tier_a_paths()
+    dir = joinpath(DATA_DIR, "pf_comparison")
+    [(joinpath(dir, f), :A) for f in sort(readdir(dir)) if endswith(f, ".dss")]
+end
+
+"Curated representative real networks (kept small for the default run)."
+function tier_b_paths()
+    rel = [
+        joinpath("LV", "LV14_13bus", "Master.dss"),      # smallest LV
+        joinpath("LV", "LV1_14bus", "Master.dss"),       # known-good fixture
+        joinpath("LV", "LV15_137bus", "Master.dss"),     # mid
+        joinpath("LV", "LV17_279bus", "Master.dss"),     # large
+        joinpath("SWER", "Master.dss"),
+        joinpath("MVLVmeshed", "Master.dss"),
+        joinpath("ENWL", "network_1", "Feeder_1", "Master.dss"),
+        joinpath("dsuite_networks_scaled_v1.1", "spd_r", "master_scaled.dss"),
+        joinpath("dsuite_networks_scaled_v1.1", "spm_u", "master_scaled.dss"),
+    ]
+    [(joinpath(DATA_DIR, r), :B) for r in rel if isfile(joinpath(DATA_DIR, r))]
+end
+
+"Every Master.dss across the full corpus (Tier C, opt-in)."
+function all_real_paths()
+    out = Tuple{String,Symbol}[]
+    for (root, _, files) in walkdir(DATA_DIR)
+        occursin(joinpath("data", "pf_comparison"), root) && continue
+        for f in files
+            (f == "Master.dss" || f == "master_scaled.dss") &&
+                push!(out, (joinpath(root, f), :C))
+        end
+    end
+    sort!(out; by=first)
+    out
+end
+
+# ── Report writers ──────────────────────────────────────────────────────────
+
+_pfmark(pf::PFResult) = pf.skipped ? "–" : (pf_ok(pf) ? "✓" : "✗")
+_dvstr(pf::PFResult)  = pf.skipped || isnan(pf.max_dV) ? "—" : string(round(pf.max_dV, digits=3))
+
+function write_case_matrix(reports, path)
+    open(path, "w") do io
+        println(io, "# Round-trip fidelity — per-case × per-signal matrix\n")
+        println(io, "| case | tier | parse_warn | export_warn | sem_diffs | pf | max_ΔV (V) | over_tol | errors |")
+        println(io, "|------|------|-----------:|------------:|----------:|:--:|-----------:|---------:|-------:|")
+        for r in reports
+            println(io, "| $(r.case) | $(r.tier) | $(length(r.parse_warnings)) | ",
+                    "$(length(r.export_warnings)) | $(length(r.semantic_diffs)) | ",
+                    "$(_pfmark(r.pf)) | $(_dvstr(r.pf)) | $(length(r.pf.over_tol_nodes)) | ",
+                    "$(length(r.errors)) |")
+        end
+    end
+end
+
+# Bucket every signal into (component_type, failure_mode) => Vector of (case, detail).
+function _failure_buckets(reports)
+    buckets = Dict{Tuple{Symbol,Symbol},Vector{Tuple{String,String}}}()
+    push_b!(k, v) = push!(get!(buckets, k, Tuple{String,String}[]), v)
+    for r in reports
+        for d in r.semantic_diffs
+            push_b!((d.component_type, classify_diff(d)), (r.case, d.path))
+        end
+        for w in unique(vcat(r.parse_warnings, r.export_warnings))
+            push_b!(classify_warning(w), (r.case, first(w, min(length(w), 90))))
+        end
+        if !r.pf.skipped && !r.pf.solved
+            push_b!((:network, :non_convergence), (r.case, r.pf.note))
+        elseif !r.pf.skipped && r.pf.solved && !r.pf.matched
+            push_b!((:network, :voltage_drift_over_tolerance),
+                    (r.case, "max ΔV=$(round(r.pf.max_dV, digits=3)) V, $(length(r.pf.over_tol_nodes)) node(s)"))
+        end
+        for e in r.errors
+            mode = occursin("to_dss", e) ? :export_error : :reparse_error
+            push_b!((:network, mode), (r.case, first(e, min(length(e), 90))))
+        end
+    end
+    buckets
+end
+
+function write_failure_map(reports, path)
+    buckets = _failure_buckets(reports)
+    open(path, "w") do io
+        println(io, "# Round-trip fidelity — failure map\n")
+        n_clean = count(r -> isempty(r.semantic_diffs) && isempty(r.errors) &&
+                             pf_ok(r.pf), reports)
+        println(io, "$(length(reports)) cases; $n_clean clean; ",
+                "$(length(buckets)) (component × mode) failure groups.\n")
+        for k in sort(collect(keys(buckets)); by=x -> (string(x[1]), string(x[2])))
+            examples = buckets[k]
+            cases = unique(first.(examples))
+            println(io, "## $(k[1]) / $(k[2])  ($(length(cases)) case(s))")
+            for (case, detail) in first(examples, min(length(examples), 3))
+                println(io, "  - `$case` — $detail")
+            end
+            println(io)
+        end
+    end
+end
+
+_csv(x) = replace(string(x), "\"" => "'", "," => ";", "\n" => " ")
+
+function write_diffs_csv(reports, path)
+    open(path, "w") do io
+        println(io, "case,component_type,subtype,id,field,kind,mode,v1,v2")
+        for r in reports, d in r.semantic_diffs
+            println(io, join(_csv.((r.case, d.component_type, d.subtype, d.id, d.field,
+                                    d.kind, classify_diff(d), d.v1, d.v2)), ","))
+        end
+    end
+end
+
+function write_pf_csv(reports, path)
+    open(path, "w") do io
+        println(io, "case,tier,solved,matched,skipped,max_dV,n_nodes,over_tol,note")
+        for r in reports
+            p = r.pf
+            println(io, join(_csv.((r.case, r.tier, p.solved, p.matched, p.skipped, p.max_dV,
+                                    p.n_nodes_compared, length(p.over_tol_nodes), p.note)), ","))
+        end
+    end
+end
+
+function write_json(reports, path)
+    payload = [(
+        case = r.case, path = r.path, tier = r.tier,
+        parse_warnings = r.parse_warnings, export_warnings = r.export_warnings,
+        semantic_diffs = [(
+            path = d.path, component_type = d.component_type, subtype = d.subtype,
+            id = d.id, field = d.field, kind = d.kind, mode = classify_diff(d),
+            v1 = string(d.v1), v2 = string(d.v2)) for d in r.semantic_diffs],
+        pf = (solved = r.pf.solved, matched = r.pf.matched, skipped = r.pf.skipped,
+              max_dV = isnan(r.pf.max_dV) ? nothing : r.pf.max_dV,
+              n_nodes_compared = r.pf.n_nodes_compared,
+              over_tol_nodes = [(node = n, dV = dv) for (n, dv) in r.pf.over_tol_nodes],
+              note = r.pf.note),
+        errors = r.errors,
+    ) for r in reports]
+    open(path, "w") do io
+        JSON3.pretty(io, payload)
+    end
+end
+
+function write_reports(reports, outdir)
+    mkpath(outdir)
+    write_case_matrix(reports, joinpath(outdir, "case_matrix.md"))
+    write_failure_map(reports, joinpath(outdir, "failure_map.md"))
+    write_diffs_csv(reports, joinpath(outdir, "diffs.csv"))
+    write_pf_csv(reports, joinpath(outdir, "pf.csv"))
+    write_json(reports, joinpath(outdir, "case_reports.json"))
+end
+
+# ── Entry point ─────────────────────────────────────────────────────────────
+
+function _parse_args(args)
+    opts = Dict{Symbol,Any}(:tier_a_only => false, :all => false,
+                            :cases => String[], :out => OUTPUT_DIR)
+    i = 1
+    while i <= length(args)
+        a = args[i]
+        if a == "--tier-a-only"
+            opts[:tier_a_only] = true
+        elseif a == "--all"
+            opts[:all] = true
+        elseif a == "--cases"
+            opts[:cases] = split(args[i += 1], ",")
+        elseif a == "--out"
+            opts[:out] = args[i += 1]
+        else
+            @warn "unknown argument" arg=a
+        end
+        i += 1
+    end
+    opts
+end
+
+function _select_paths(opts)
+    paths = tier_a_paths()
+    opts[:tier_a_only] || append!(paths, tier_b_paths())
+    opts[:all] && append!(paths, all_real_paths())
+    if !isempty(opts[:cases])
+        want = Set(opts[:cases])
+        paths = filter(p -> first(splitext(basename(first(p)))) in want, paths)
+    end
+    paths
+end
+
+function main(args=ARGS)
+    opts = _parse_args(args)
+    paths = _select_paths(opts)
+    _HAS_ODS || @warn "OpenDSSDirect not available — power-flow cross-check skipped."
+    @info "round-trip fidelity sweep" n_cases=length(paths) has_ods=_HAS_ODS out=opts[:out]
+
+    workdir = joinpath(opts[:out], "tmp")
+    mkpath(workdir)
+    reports = run_corpus(paths; has_ods=_HAS_ODS, workdir=workdir)
+    write_reports(reports, opts[:out])
+
+    n_clean = count(r -> isempty(r.semantic_diffs) && isempty(r.errors) &&
+                         pf_ok(r.pf), reports)
+    @info "done" clean=n_clean total=length(reports) out=opts[:out]
+    return reports
+end
+
+abspath(PROGRAM_FILE) == abspath(@__FILE__) && main()

--- a/test/roundtrip_fidelity_tests.jl
+++ b/test/roundtrip_fidelity_tests.jl
@@ -1,0 +1,85 @@
+# roundtrip_fidelity_tests.jl
+#
+# Regression guard for the BMOPF → OpenDSS export (`to_dss`). For every
+# pf_comparison feature case we round-trip DSS → BMOPF → DSS and check two
+# signals:
+#
+#   1. Semantic diff — the re-parsed BMOPF dict (net2) must match the original
+#      (net1) structurally. Cases that round-trip cleanly today are asserted to
+#      STAY clean (@test); known-lossy cases are documented with @test_broken so
+#      a future fix surfaces as an unexpected pass.
+#   2. OpenDSS power-flow cross-check — solve original vs regenerated DSS in
+#      OpenDSS and compare node voltages (gated on OpenDSSDirect). A *coarse*
+#      tolerance (atol=2 V, rtol=2%) is used deliberately: it ignores the benign
+#      systemic drift (`to_dss` currently writes DefaultBaseFrequency=60 and adds
+#      line charging) while still catching the severe failures — islanding from a
+#      dropped transformer, or a regenerated deck that will not converge.
+#
+# The allowlists below are a snapshot of today's fidelity. When `to_dss`
+# improves, the corresponding @test_broken flips to an unexpected pass and this
+# file must be updated to lock in the gain. See scripts/roundtrip_fidelity.jl for
+# the full diagnostic sweep (per-case matrix + failure map) this distills.
+
+include(joinpath(@__DIR__, "roundtrip_helpers.jl"))
+
+const _RT_PF_DIR = joinpath(@__DIR__, "data", "pf_comparison")
+
+# Cases whose DSS → BMOPF → DSS round trip is structurally lossless today.
+const RT_SEMANTIC_CLEAN = Set([
+    "pf_1ph_freeneutral", "pf_1ph_impedanceneutral", "pf_1ph_line",
+    "pf_1ph_perfectneutral", "pf_3ph_line", "pf_3wdg_dyn", "pf_4wdg_dyyn",
+    "pf_delta_load", "pf_exp_1ph", "pf_open_delta_reg", "pf_pv_1ph",
+    "pf_pv_4leg", "pf_zip_1ph", "pf_zip_3ph", "pf_zip_delta",
+])
+
+# Cases that survive the OpenDSS power-flow cross-check at the coarse tolerance
+# (solve + match, or legitimately skipped). Everything else either islands
+# (dropped transformer) or fails to converge — see the failure map.
+const RT_PF_SOUND = Set([
+    "pf_1ph_line", "pf_exp_1ph", "pf_zip_1ph", "pf_open_delta_reg",
+])
+
+const RT_PF_ATOL = 2.0
+const RT_PF_RTOL = 0.02
+
+@testset "to_dss round-trip fidelity" begin
+    cases = sort(filter(f -> endswith(f, ".dss"), readdir(_RT_PF_DIR)))
+    @test !isempty(cases)
+    workdir = mktempdir()
+
+    @testset "semantic diff — $(first(splitext(case)))" for case in cases
+        stem = first(splitext(case))
+        net1 = from_dss(joinpath(_RT_PF_DIR, case))
+        regen = joinpath(workdir, "$stem.dss")
+        to_dss(net1, regen)
+        net2 = from_dss(regen)
+        diffs = semantic_diff(net1, net2)
+        if stem in RT_SEMANTIC_CLEAN
+            @test isempty(diffs)
+        else
+            # Documented round-trip loss. If this passes, to_dss improved —
+            # move the case into RT_SEMANTIC_CLEAN.
+            @test_broken isempty(diffs)
+        end
+    end
+
+    if _HAS_ODS
+        @testset "PF cross-check — $(first(splitext(case)))" for case in cases
+            stem = first(splitext(case))
+            net1 = from_dss(joinpath(_RT_PF_DIR, case))
+            regen = joinpath(workdir, "$stem.dss")
+            to_dss(net1, regen)
+            pf = pf_cross_check(joinpath(_RT_PF_DIR, case), regen;
+                                atol=RT_PF_ATOL, rtol=RT_PF_RTOL)
+            if stem in RT_PF_SOUND
+                @test pf_ok(pf)
+            else
+                # Islanding or non-convergence in the regenerated deck. If this
+                # passes, to_dss improved — move the case into RT_PF_SOUND.
+                @test_broken pf_ok(pf)
+            end
+        end
+    else
+        @test_skip "PF cross-check requires OpenDSSDirect"
+    end
+end

--- a/test/roundtrip_helpers.jl
+++ b/test/roundtrip_helpers.jl
@@ -1,0 +1,476 @@
+# roundtrip_helpers.jl
+#
+# Shared machinery for the BMOPF ↔ OpenDSS round-trip fidelity study
+# (DSS → BMOPF → DSS). Both the standalone diagnostic script
+# (scripts/roundtrip_fidelity.jl) and the committed regression testset in
+# test/runtests.jl `include` this file so they diagnose fidelity identically.
+#
+# The file references `from_dss`/`to_dss` (BMOPFTools, must be `using`-ed by the
+# includer) and, for the optional power-flow gate, `OpenDSSDirect` — resolved
+# lazily at call time, so this file includes cleanly even when OpenDSSDirect is
+# absent. PF functions must simply not be *called* in that case.
+#
+# Three signal sources, in priority order:
+#   1. PowerIO warnings  — from_dss parse warnings + to_dss export warnings.
+#   2. Semantic diff     — structural diff of net1 (from original) vs net2 (from
+#                          regenerated DSS); both normalized by from_dss, so any
+#                          difference is real round-trip information loss.
+#   3. PF cross-check    — solve original vs regenerated DSS in OpenDSS, compare
+#                          node voltages (isolates export fidelity).
+
+# ── Data structures ─────────────────────────────────────────────────────────
+
+"""
+A single structural difference between two `from_dss`-normalized network dicts.
+`kind ∈ (:missing, :extra, :topology_mismatch, :numeric_mismatch, :type_mismatch)`.
+`v1`/`v2` are the values in the original / regenerated net (`nothing` if absent).
+"""
+struct Diff
+    path::String                       # e.g. "transformer.wye_delta.t1.r_series_to"
+    component_type::Symbol             # :bus :line :transformer ...
+    subtype::Union{Symbol,Nothing}    # transformer subtype, else nothing
+    id::Union{String,Nothing}          # component id, nothing for collection-level miss
+    field::Union{String,Nothing}       # leaf field, nothing for whole-component miss
+    kind::Symbol
+    v1::Any
+    v2::Any
+end
+
+"Result of the OpenDSS power-flow cross-check for one case."
+struct PFResult
+    solved::Bool                       # regenerated DSS converged in OpenDSS
+    matched::Bool                      # all compared nodes within tolerance
+    skipped::Bool                      # OpenDSSDirect absent, or original didn't solve
+    max_dV::Float64                    # max |V_orig - V_regen| over compared nodes (V)
+    n_nodes_compared::Int
+    over_tol_nodes::Vector{Tuple{String,Float64}}
+    note::String
+end
+
+# A PF result is "clean" only when it solved and matched (or was legitimately not
+# run). skipped results are neither pass nor fail — they carry no verdict.
+pf_ok(pf::PFResult) = pf.skipped || (pf.solved && pf.matched)
+
+"Full per-case diagnostic bundle across all three signal sources."
+struct CaseReport
+    case::String                       # stem, e.g. "pf_yd_xfmr"
+    path::String                       # absolute source .dss path
+    tier::Symbol                       # :A or :B
+    parse_warnings::Vector{String}
+    export_warnings::Vector{String}
+    semantic_diffs::Vector{Diff}
+    pf::PFResult
+    errors::Vector{String}
+end
+
+# ── Field classification ────────────────────────────────────────────────────
+
+# Top-level keys that are tool-private / non-semantic — never diffed.
+const EXCLUDE_TOP_KEYS = Set(["_meta", "name", "meta"])
+
+# Component collections walked by semantic_diff (transformer handled specially).
+const COMPONENT_TYPES = [:bus, :linecode, :line, :transformer, :switch, :load,
+                         :generator, :voltage_source, :shunt, :capacitor, :ibr]
+
+# Fields that must match EXACTLY (structure/topology). Everything else numeric
+# is compared with isapprox.
+const TOPOLOGY_FIELDS = Set([
+    "bus_from", "bus_to", "bus", "terminal_map", "terminal_map_from",
+    "terminal_map_to", "terminal_names", "neutral_terminal",
+    "perfectly_grounded_terminals", "configuration", "linecode", "open_switch",
+    "model", "delta_roll", "prime_mover", "topology"])
+
+_isnumberish(x::Number) = true
+_isnumberish(x::AbstractArray) = !isempty(x) && all(_isnumberish, x)
+_isnumberish(::Any) = false
+
+# ── Semantic diff ───────────────────────────────────────────────────────────
+
+"""
+    semantic_diff(net1, net2; rtol=1e-6, atol=0.0) -> Vector{Diff}
+
+Structurally diff two BMOPF network dicts, both assumed `from_dss`-normalized.
+Topology fields compare exactly; numeric fields with `isapprox`. Any difference
+is round-trip information loss localized to a component/field.
+"""
+function semantic_diff(net1::AbstractDict, net2::AbstractDict; rtol=1e-6, atol=0.0)::Vector{Diff}
+    diffs = Diff[]
+    for ctype in COMPONENT_TYPES
+        c1 = get(net1, string(ctype), nothing)
+        c2 = get(net2, string(ctype), nothing)
+        (c1 === nothing && c2 === nothing) && continue
+        if ctype == :transformer
+            _diff_transformers(c1, c2, diffs; rtol, atol)
+        elseif ctype == :voltage_source
+            _diff_voltage_sources(c1, c2, diffs; rtol, atol)
+        else
+            _diff_collection(ctype, nothing, _asdict(c1), _asdict(c2), diffs; rtol, atol)
+        end
+    end
+    diffs
+end
+
+_asdict(::Nothing) = Dict{String,Any}()
+_asdict(d::AbstractDict) = d
+
+# Flat collection: {id => component-dict}.
+function _diff_collection(ctype::Symbol, subtype, c1::AbstractDict, c2::AbstractDict,
+                          diffs::Vector{Diff}; rtol, atol)
+    pfx = subtype === nothing ? string(ctype) : "$(ctype).$(subtype)"
+    for id in union(keys(c1), keys(c2))
+        in1, in2 = haskey(c1, id), haskey(c2, id)
+        if in1 && !in2
+            push!(diffs, Diff("$pfx.$id", ctype, subtype, id, nothing, :missing, c1[id], nothing))
+        elseif in2 && !in1
+            push!(diffs, Diff("$pfx.$id", ctype, subtype, id, nothing, :extra, nothing, c2[id]))
+        else
+            _diff_component("$pfx.$id", ctype, subtype, id, c1[id], c2[id], diffs; rtol, atol)
+        end
+    end
+end
+
+# One component: {field => value}.
+function _diff_component(path::String, ctype::Symbol, subtype, id::String,
+                         a::AbstractDict, b::AbstractDict, diffs::Vector{Diff}; rtol, atol)
+    for field in union(keys(a), keys(b))
+        ina, inb = haskey(a, field), haskey(b, field)
+        fpath = "$path.$field"
+        if ina && !inb
+            push!(diffs, Diff(fpath, ctype, subtype, id, field, :missing, a[field], nothing))
+        elseif inb && !ina
+            push!(diffs, Diff(fpath, ctype, subtype, id, field, :extra, nothing, b[field]))
+        else
+            d = _cmp_field(fpath, ctype, subtype, id, field, a[field], b[field]; rtol, atol)
+            d === nothing || push!(diffs, d)
+        end
+    end
+end
+
+# Leaf comparison: topology → exact, numeric → isapprox, nested dict → recurse.
+function _cmp_field(fpath, ctype, subtype, id, field, v1, v2; rtol, atol)
+    if v1 isa AbstractDict && v2 isa AbstractDict
+        # Nested sub-dict (e.g. load "cost" or n_winding windings): recurse and
+        # fold child diffs up under this field's kind if any differ.
+        child = Diff[]
+        _diff_component(fpath, ctype, subtype, id, v1, v2, child; rtol, atol)
+        isempty(child) && return nothing
+        return Diff(fpath, ctype, subtype, id, field, :numeric_mismatch, v1, v2)
+    end
+    if field in TOPOLOGY_FIELDS
+        return isequal(v1, v2) ? nothing :
+               Diff(fpath, ctype, subtype, id, field, :topology_mismatch, v1, v2)
+    end
+    if _isnumberish(v1) && _isnumberish(v2)
+        if v1 isa AbstractArray || v2 isa AbstractArray
+            if size(v1) != size(v2)
+                return Diff(fpath, ctype, subtype, id, field, :topology_mismatch, v1, v2)
+            end
+            return all(isapprox.(v1, v2; rtol, atol)) ? nothing :
+                   Diff(fpath, ctype, subtype, id, field, :numeric_mismatch, v1, v2)
+        end
+        return isapprox(v1, v2; rtol, atol) ? nothing :
+               Diff(fpath, ctype, subtype, id, field, :numeric_mismatch, v1, v2)
+    end
+    # Fallback: differing types or non-numeric scalars (strings/bools).
+    isequal(v1, v2) && return nothing
+    kind = (typeof(v1) == typeof(v2)) ? :topology_mismatch : :type_mismatch
+    Diff(fpath, ctype, subtype, id, field, kind, v1, v2)
+end
+
+# Transformers: nested by subtype. Match ids ACROSS subtypes first so a subtype
+# change is reported as such, not as a drop+add.
+function _diff_transformers(t1, t2, diffs::Vector{Diff}; rtol, atol)
+    t1 = _asdict(t1); t2 = _asdict(t2)
+    loc1 = _xfmr_locations(t1)          # id => subtype
+    loc2 = _xfmr_locations(t2)
+    for id in union(keys(loc1), keys(loc2))
+        s1 = get(loc1, id, nothing)
+        s2 = get(loc2, id, nothing)
+        if s1 === nothing
+            push!(diffs, Diff("transformer.$s2.$id", :transformer, Symbol(s2), id, nothing,
+                              :extra, nothing, t2[s2][id]))
+        elseif s2 === nothing
+            push!(diffs, Diff("transformer.$s1.$id", :transformer, Symbol(s1), id, nothing,
+                              :missing, t1[s1][id], nothing))
+        elseif s1 != s2
+            push!(diffs, Diff("transformer.$id.subtype", :transformer, Symbol(s1), id,
+                              "subtype", :topology_mismatch, s1, s2))
+        else
+            _diff_component("transformer.$s1.$id", :transformer, Symbol(s1), id,
+                            t1[s1][id], t2[s2][id], diffs; rtol, atol)
+        end
+    end
+end
+
+# id => subtype map across all transformer subtypes.
+function _xfmr_locations(t::AbstractDict)
+    loc = Dict{String,String}()
+    for (subtype, bank) in t
+        bank isa AbstractDict || continue
+        for id in keys(bank)
+            loc[id] = subtype
+        end
+    end
+    loc
+end
+
+# Voltage sources: the DSS writer may rename/re-split merged sources, so match
+# id-agnostically on (bus, sorted terminal_map) before falling back to id.
+function _diff_voltage_sources(v1, v2, diffs::Vector{Diff}; rtol, atol)
+    v1 = _asdict(v1); v2 = _asdict(v2)
+    key(vs) = (get(vs, "bus", nothing), sort(string.(get(vs, "terminal_map", String[]))))
+    idx2 = Dict(key(vs) => id for (id, vs) in v2)
+    matched2 = Set{String}()
+    for (id1, vs1) in v1
+        k = key(vs1)
+        if haskey(idx2, k)
+            id2 = idx2[k]
+            push!(matched2, id2)
+            _diff_component("voltage_source.$id1", :voltage_source, nothing, id1,
+                            vs1, v2[id2], diffs; rtol, atol)
+        else
+            push!(diffs, Diff("voltage_source.$id1", :voltage_source, nothing, id1,
+                              nothing, :missing, vs1, nothing))
+        end
+    end
+    for (id2, vs2) in v2
+        id2 in matched2 && continue
+        push!(diffs, Diff("voltage_source.$id2", :voltage_source, nothing, id2,
+                          nothing, :extra, nothing, vs2))
+    end
+end
+
+# ── Failure-mode taxonomy ───────────────────────────────────────────────────
+
+"""
+    classify_diff(d::Diff) -> Symbol
+
+Map a structural Diff to an actionable failure mode.
+"""
+function classify_diff(d::Diff)::Symbol
+    f = d.field
+    if d.field == "subtype"
+        return :transformer_subtype_changed
+    elseif d.kind == :missing && d.field === nothing
+        return d.component_type in (:shunt,) ? :grounding_neutral_lost : :component_dropped
+    elseif d.kind == :extra && d.field === nothing
+        return d.component_type == :voltage_source ? :source_split_mismatch : :component_added
+    elseif f !== nothing && (occursin("terminal_map", f) || f == "terminal_names")
+        return :terminal_map_altered
+    elseif f in ("neutral_terminal", "perfectly_grounded_terminals")
+        return :grounding_neutral_lost
+    elseif f in ("configuration", "delta_roll")
+        return :configuration_changed
+    elseif f == "linecode"
+        return :linecode_ref_broken
+    elseif f == "model"
+        return :load_model_changed
+    elseif f !== nothing && (occursin("r_series", f) || occursin("x_series", f) ||
+                             occursin("R_series", f) || occursin("X_series", f) ||
+                             occursin("x_sc", f) || occursin("r_winding", f))
+        return :impedance_drifted
+    elseif f !== nothing && (occursin("no_load", f) || startswith(f, "G_") ||
+                             startswith(f, "B_") || occursin("shunt", f))
+        return :admittance_drifted
+    elseif d.component_type == :voltage_source
+        return :source_split_mismatch
+    elseif d.component_type == :load
+        return :load_model_changed
+    else
+        return :other_mismatch
+    end
+end
+
+# Keyword → (component_type, failure_mode) for PowerIO warning strings.
+const _WARN_RULES = [
+    (r"reactor|phases\s*=\s*1|grounding|neutral"i, (:shunt, :grounding_neutral_lost)),
+    (r"shunt admittance|susceptance|capacit"i,    (:shunt, :admittance_drifted)),
+    (r"regcontrol|tap|regulator"i,                (:transformer, :unrepresentable_warned)),
+    (r"loadshape|time.?series|profile"i,          (:load, :unrepresentable_warned)),
+    (r"transformer|winding|leakage"i,             (:transformer, :impedance_drifted)),
+]
+
+"""
+    classify_warning(w::String) -> Tuple{Symbol,Symbol}
+
+Map a raw PowerIO warning string to (component_type, failure_mode). Falls back to
+(:network, :unrepresentable_warned) for unmatched warnings.
+"""
+function classify_warning(w::AbstractString)::Tuple{Symbol,Symbol}
+    for (re, tag) in _WARN_RULES
+        occursin(re, w) && return tag
+    end
+    (:network, :unrepresentable_warned)
+end
+
+# ── OpenDSS power-flow gate ─────────────────────────────────────────────────
+# References `OpenDSSDirect` (must be in the includer's scope when CALLED).
+
+"""
+    ods_solve_volts(dss_path) -> (converged::Bool, Dict{String,ComplexF64})
+
+Clear, redirect and explicitly Solve the DSS file in OpenDSS. Returns whether the
+solution converged and a dict of lowercased non-earth node name → complex volts.
+Node names are lowercased so an original (mixed-case) and its regenerated
+(case-folded) counterpart align.
+"""
+function ods_solve_volts(dss_path::String)
+    OpenDSSDirect.dss("Clear")
+    # Keep any Export/Show output the deck emits out of the working directory.
+    OpenDSSDirect.dss("Set DataPath=\"$(tempdir())\"")
+    OpenDSSDirect.dss("Redirect \"$(normpath(dss_path))\"")
+    OpenDSSDirect.dss("Solve")
+    conv = OpenDSSDirect.Solution.Converged()
+    names = OpenDSSDirect.Circuit.AllNodeNames()
+    volts = OpenDSSDirect.Circuit.AllBusVolts()
+    d = Dict{String,ComplexF64}(lowercase(n) => v for (n, v) in zip(names, volts))
+    return conv, d
+end
+
+"""
+    pf_cross_check(orig_path, regen_path; atol=0.3, rtol=1e-3) -> PFResult
+
+Solve original and regenerated DSS in OpenDSS and compare node voltages. Skips
+nodes with |V_orig| < 1e-4 (earth reference) and nodes not present in both.
+"""
+function pf_cross_check(orig_path::String, regen_path::String; atol=0.3, rtol=1e-3)::PFResult
+    conv1, V1 = ods_solve_volts(orig_path)
+    if !conv1
+        return PFResult(false, false, true, NaN, 0, Tuple{String,Float64}[],
+                        "original DSS did not converge; PF gate skipped")
+    end
+    local conv2, V2
+    try
+        conv2, V2 = ods_solve_volts(regen_path)
+    catch e
+        return PFResult(false, false, false, NaN, 0, Tuple{String,Float64}[],
+                        "regenerated DSS failed to load/solve: $(sprint(showerror, e))")
+    end
+    if !conv2
+        return PFResult(false, false, false, NaN, 0, Tuple{String,Float64}[],
+                        "regenerated DSS did not converge")
+    end
+    max_dV = 0.0
+    n = 0
+    over = Tuple{String,Float64}[]
+    for (node, v1) in V1
+        haskey(V2, node) || continue
+        abs(v1) < 1e-4 && continue
+        n += 1
+        dV = abs(v1 - V2[node])
+        max_dV = max(max_dV, dV)
+        isapprox(V2[node], v1; atol, rtol) || push!(over, (node, dV))
+    end
+    note = isempty(over) ? "" : "$(length(over)) node(s) over tolerance"
+    PFResult(true, isempty(over), false, max_dV, n, over, note)
+end
+
+# ── Per-case runner ─────────────────────────────────────────────────────────
+
+"""
+    diagnose_case(dss_path; tier=:A, has_ods=false, workdir,
+                  rtol_num=1e-6, atol_v=0.3, rtol_v=1e-3) -> CaseReport
+
+Run the full DSS → BMOPF → DSS pipeline for one case, collecting all three signal
+sources. Each stage is isolated so one failure degrades gracefully into `errors`.
+"""
+function diagnose_case(dss_path::String; tier::Symbol=:A, has_ods::Bool=false,
+                       workdir::String=mktempdir(),
+                       rtol_num=1e-6, atol_v=0.3, rtol_v=1e-3)::CaseReport
+    stem = _case_stem(dss_path)
+    errors = String[]
+    parse_warnings = String[]
+    export_warnings = String[]
+    diffs = Diff[]
+    pf = PFResult(false, false, true, NaN, 0, Tuple{String,Float64}[], "not run")
+
+    net1 = nothing
+    regen_path = joinpath(workdir, "$stem.dss")
+    try
+        net1 = from_dss(dss_path)
+        append!(parse_warnings, _meta_warnings(net1))
+    catch e
+        push!(errors, "from_dss(original): $(sprint(showerror, e))")
+        return CaseReport(stem, dss_path, tier, parse_warnings, export_warnings, diffs, pf, errors)
+    end
+
+    try
+        export_warnings = to_dss(net1, regen_path)   # path form returns just warnings
+    catch e
+        push!(errors, "to_dss: $(sprint(showerror, e))")
+        return CaseReport(stem, dss_path, tier, parse_warnings, export_warnings, diffs, pf, errors)
+    end
+
+    net2 = nothing
+    try
+        net2 = from_dss(regen_path)
+        append!(parse_warnings, _meta_warnings(net2))
+    catch e
+        push!(errors, "from_dss(regenerated): $(sprint(showerror, e))")
+    end
+
+    if net2 !== nothing
+        try
+            diffs = semantic_diff(net1, net2; rtol=rtol_num)
+        catch e
+            push!(errors, "semantic_diff: $(sprint(showerror, e))")
+        end
+    end
+
+    if has_ods
+        # Tighten transformer cases to atol=0.1 V, mirroring powerflow_comparison_tests.
+        atol = occursin(r"_(dy|yd)_", stem) ? 0.1 : atol_v
+        try
+            pf = pf_cross_check(dss_path, regen_path; atol, rtol=rtol_v)
+        catch e
+            push!(errors, "pf_cross_check: $(sprint(showerror, e))")
+            pf = PFResult(false, false, false, NaN, 0, Tuple{String,Float64}[],
+                          "PF gate errored")
+        end
+    end
+
+    CaseReport(stem, dss_path, tier, parse_warnings, export_warnings, diffs, pf, errors)
+end
+
+_meta_warnings(net) = collect(String, get(get(net, "_meta", Dict{String,Any}()),
+                                          "powerio_warnings", String[]))
+
+# Case id from a DSS path. Generic entry-point names (Master.dss, master_scaled)
+# are disambiguated by the parent directory so real networks don't all collapse
+# to "Master".
+function _case_stem(dss_path::String)::String
+    stem = first(splitext(basename(dss_path)))
+    if lowercase(stem) in ("master", "master_scaled")
+        return "$(basename(dirname(dss_path)))/$stem"
+    end
+    stem
+end
+
+# ── Corpus driver ───────────────────────────────────────────────────────────
+
+"""
+    run_corpus(paths; has_ods=false, workdir, verbose=true, kwargs...) -> Vector{CaseReport}
+
+`paths` is a vector of `(abspath, tier)` tuples. Runs `diagnose_case` over each,
+isolating per-case exceptions so one bad case never aborts the run.
+"""
+function run_corpus(paths; has_ods::Bool=false, workdir::String=mktempdir(),
+                    verbose::Bool=true, kwargs...)::Vector{CaseReport}
+    reports = CaseReport[]
+    for (path, tier) in paths
+        r = try
+            diagnose_case(path; tier, has_ods, workdir, kwargs...)
+        catch e
+            stem = _case_stem(path)
+            CaseReport(stem, path, tier, String[], String[], Diff[],
+                       PFResult(false, false, true, NaN, 0, Tuple{String,Float64}[], "harness error"),
+                       ["diagnose_case threw: $(sprint(showerror, e))"])
+        end
+        push!(reports, r)
+        if verbose
+            pfstr = r.pf.skipped ? "–" : (pf_ok(r.pf) ? "✓" : "✗")
+            @info "roundtrip" case=r.case tier=r.tier diffs=length(r.semantic_diffs) pf=pfstr max_dV=round(r.pf.max_dV, digits=3) warns=(length(r.parse_warnings)+length(r.export_warnings)) errs=length(r.errors)
+        end
+    end
+    reports
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3470,6 +3470,12 @@ const IEEE13_FIXTURE = """
         end
     end
 
+    # -----------------------------------------------------------------------
+    # to_dss (BMOPF → OpenDSS) round-trip fidelity regression. Semantic diff
+    # always runs; the OpenDSS PF cross-check self-gates on _HAS_ODS.
+    # -----------------------------------------------------------------------
+    include("roundtrip_fidelity_tests.jl")
+
     include("admittance_tests.jl")
 
     # -----------------------------------------------------------------------


### PR DESCRIPTION
Direction A — bmopf → dss writer (to_format(net,"dss") / convert_str(…,"dss","bmopf"))
A1. DefaultBaseFrequency=60 emitted unconditionally. Every generated deck starts with Set DefaultBaseFrequency=60, even when the source network is 50 Hz. Root cause is arguably the BMOPF format carrying no base-frequency field, so the writer defaults to 60 — but the effect is that all reactances/susceptances silently rescale by 1.2×.

Repro: a 50 Hz single-phase line (Set DefaultBaseFreq=50, Line r1/x1) round-trips to a deck with =60 and a ~2 V (1.2%) voltage shift, despite the model being otherwise structurally identical.
Ask: add a base-frequency field to the BMOPF schema (and preserve it), or make the writer's frequency configurable rather than hardcoded.
A2. Delta / phase-to-phase loads are written as conn=wye. A BMOPF load with terminal_map=["a","b"] (2 conductors, no neutral — a phase-to-phase load) is emitted as New Load … bus1=lb.1.2 phases=1 conn=wye kv=0.415, dropping the delta/phase-to-phase connection. The regenerated deck fails to converge in OpenDSS.

Repro: pf_delta_load.dss, pf_zip_delta.dss — three phase-to-phase loads; original converges, regenerated does not.
Ask: emit conn=delta (or a correctly-referenced phase-to-phase load) for 2-terminal no-neutral loads.
A3. Transformer impedances written as zero. On bmopf→dss, PowerIO warns: "transformer t1: s_rating or v_ref missing or nonpositive; impedances read as zero." The per-winding resistance/reactance present in the BMOPF dict are not reconstructed, so the transformer is exported lossless-then-impedanceless.

Repro: pf_dy_xfmr.dss, pf_yd_xfmr.dss.
Ask: derive impedances from the per-winding ohm fields, or clearly document which s_rating/v_ref fields the writer requires.
A4. Voltage-source neutral is not round-trip stable. The writer emits phases=4 for a source whose BMOPF terminal_map lists 4 of 5 conductors; PowerIO's own warnings note "a reparse energizes all 4" and "dss materializes a grounded neutral terminal and the reparsed model gains one" — so dss→bmopf→dss→bmopf adds a node.

Repro: any 3-phase source case, e.g. pf_cap_wye.dss.
Direction B — dss → bmopf exporter (to_format(net,"bmopf"))
B1. 3+ winding transformers are dropped entirely. Explicit warning: "transformer t1: 3 phase with 3 windings ([Wye, Wye, Wye]); not representable in the four BMOPF subtypes, dropped from the output." The transformer vanishes from the BMOPF, so everything downstream is islanded (0 V).

Repro: pf_3wdg_nwinding.dss, pf_4wdg_nwinding.dss, pf_3wdg_dyn*.dss (regenerated buses de-energize; ΔV ≈ 14–64 kV vs the original).
Ask: represent N-winding transformers in the BMOPF format (or at minimum, treat a dropped series element as an error rather than a warning, since it silently disconnects the network).
B2. Transformer no-load loss is dropped. Warnings "%noloadloss has no place in the BMOPF schema; dropped" and "%imag … dropped." Core/magnetizing shunt is lost on ingest.

Cross-cutting note (schema divergence, not strictly a bug)
BMOPFTools extends the BMOPF schema with fields PowerIO doesn't model — g_no_load, b_no_load, v_nom_from, v_nom_to, neutral_terminal — which PowerIO reports as "outside the schema; kept in extras" then "not a dss property; dropped." And BMOPF letter terminals (a/b/c/n) trigger a per-node "not a dss node number; emitted as node N, its position on the bus" warning for every terminal (high volume, but handled correctly by position). Worth aligning on which of these the BMOPF format should carry natively.

Tagging @samtalki 