### PR TITLE
Fix n_winding OPF core-loss crash: nW → n (#271)

### DIFF
--- a/ext/BMOPFOpfExt/nwinding.jl
+++ b/ext/BMOPFOpfExt/nwinding.jl
@@ -210,7 +210,7 @@ function _add_nwinding_constraints!(model, net, vars, kcl_r, kcl_i; branch_inj=n
         # referred to winding 2's coil voltage.
         g = Float64(get(xfmr, "_g_no_load_pu", get(xfmr, "g_no_load", 0.0)))
         b = Float64(get(xfmr, "_b_no_load_pu", get(xfmr, "b_no_load", 0.0)))
-        if (g != 0.0 || b != 0.0) && nW >= 2
+        if (g != 0.0 || b != 0.0) && n >= 2
             w2 = ws[2]; phs2, neu2 = BMOPFTools._nw_phase_terminals(w2.terminal_map)
             for pk in 1:nph
                 ur, ui = upn(2, pk)

--- a/test/nwinding_tests.jl
+++ b/test/nwinding_tests.jl
@@ -284,6 +284,27 @@ if _HAS_JUMP_IPOPT
         # returns the unconstrained (over-limit) current as a clean solve.
         @test rt["termination_status"] ∉ ("LOCALLY_SOLVED", "OPTIMAL") ||
               rt["transformer"]["t1"]["w2"]["1"]["cm"] <= 0.5 * i2 * (1 + 1e-3)
+
+        # Regression (issue #271): the no-load (magnetising) shunt branch
+        # guarded on an undefined variable `nW` (the local is `n`), so any
+        # n_winding transformer with nonzero g_no_load/b_no_load threw
+        # UndefVarError at model build. No fixture exercised it. Build the
+        # same transformer with a core-loss branch on winding 2 and confirm
+        # it (a) solves and (b) adds real loss vs the lossless-core baseline.
+        xf_core = _nw_xfmr([("hv", 115.0, 0.3), ("mv", 24.9, 0.4), ("lv", 4.16, 0.4)],
+                           Dict("1_2" => 8.0, "1_3" => 8.0, "2_3" => 6.0);
+                           g = 2e-4, b = 1e-3)   # SI siemens across the MV coil
+        net_core = deepcopy(net)
+        net_core["transformer"]["n_winding"]["t1"] = xf_core
+        rc = solve_pf(net_core; optimizer = Ipopt.Optimizer)
+        @test rc["termination_status"] in ("LOCALLY_SOLVED", "OPTIMAL")
+        @test haskey(rc["transformer"]["t1"], "w1")
+        # Core conductance g>0 dissipates real power → transformer real loss
+        # strictly exceeds the g=b=0 baseline (the device-loss identity sums
+        # the magnetising-branch injection).
+        p_base = res["transformer"]["t1"]["loss"]["p_loss"]
+        p_core = rc["transformer"]["t1"]["loss"]["p_loss"]
+        @test p_core > p_base + 1.0
     end
 
 end


### PR DESCRIPTION
Closes #271.

The no-load (magnetising) shunt branch in `_add_nwinding_constraints!` guarded on `nW`, which is undefined in that scope — the local winding count is `n` (`nW` only exists in `to_ybus.jl`'s `nwinding_yprim`). Any `n_winding` transformer with nonzero `g_no_load`/`b_no_load` threw `UndefVarError` at model build. It stayed latent because every n_winding fixture zeroed the core-loss branch and exercised g/b only through the Ybus path.

**Fix:** `nW` → `n` (one character).

**Test:** extends the n_winding OPF/PF self-consistency testset with a core-loss variant (nonzero g/b on the MV coil); it solves and shows transformer real loss strictly above the lossless-core baseline. Verified discriminating: reverting the rename reproduces `UndefVarError: nW not defined`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)