### PR TITLE
Fix capacitor result sign and per-unit conversion (#272, #273)

### DIFF
--- a/ext/BMOPFOpfExt/per_unit.jl
+++ b/ext/BMOPFOpfExt/per_unit.jl
@@ -644,8 +644,8 @@ function _from_per_unit(result_pu::Dict{String,Any}, bases, net::Dict{String,Any
                     haskey(cvals, f) && (cvals[f] = cvals[f] * ib)
                 end
                 continue
-            elseif tk == "loss"        # complex loss (W/var): × s_base
-                for f in ("p_loss", "q_loss")
+            elseif tk == "loss"        # complex loss + throughput (W/var/VA): × s_base
+                for f in ("p_loss", "q_loss", "s_through")
                     haskey(cvals, f) && (cvals[f] = cvals[f] * sb)
                 end
                 continue
@@ -750,6 +750,24 @@ function _from_per_unit(result_pu::Dict{String,Any}, bases, net::Dict{String,Any
         end
     end
 
+    # Capacitor banks: per-terminal currents ← × I_base[bus]; delivered q ← × s_base
+    caps = get(net, "capacitor", Dict())
+    for (cid, cvals) in get(result, "capacitor", Dict())
+        cvals isa Dict || continue
+        bus = get(get(caps, cid, Dict()), "bus", "")
+        ib  = get(bases.i_base, bus, 1.0)
+        term_d = get(cvals, "terminals", Dict())
+        if term_d isa Dict
+            for (_, tvals) in term_d
+                tvals isa Dict || continue
+                for f in ("cr", "ci", "cm")
+                    haskey(tvals, f) && (tvals[f] = tvals[f] * ib)
+                end
+            end
+        end
+        haskey(cvals, "q") && (cvals["q"] = cvals["q"] * sb)
+    end
+
     # Transformer currents: from-side ← I_base[bus_from], to-side ← I_base[bus_to]
     xfmr_dict = get(net, "transformer", Dict())
     for (tid, winding_dict) in get(result, "transformer", Dict())
@@ -778,10 +796,10 @@ function _from_per_unit(result_pu::Dict{String,Any}, bases, net::Dict{String,Any
             g = winding_dict["ground"]
             for f in ("cg_r", "cg_i", "cgm"); haskey(g, f) && (g[f] = g[f] * ib_fr); end
         end
-        # Complex loss (W/var): × s_base
+        # Complex loss + throughput (W/var/VA): × s_base
         if haskey(winding_dict, "loss") && winding_dict["loss"] isa Dict
             l = winding_dict["loss"]
-            for f in ("p_loss", "q_loss"); haskey(l, f) && (l[f] = l[f] * sb); end
+            for f in ("p_loss", "q_loss", "s_through"); haskey(l, f) && (l[f] = l[f] * sb); end
         end
     end
 

--- a/ext/BMOPFOpfExt/results.jl
+++ b/ext/BMOPFOpfExt/results.jl
@@ -719,8 +719,11 @@ function _extract_results(model, net, bus_terminals, grounded, vars,
                 "cr" => cr[k], "ci" => ci[k], "cm" => sqrt(cr[k]^2 + ci[k]^2))
             if feasible && haskey(vr_v, (bus, tm[k]))
                 vrk = val(vr_v[(bus, tm[k])]); vik = val(vi_v[(bus, tm[k])])
-                # Current INTO the bus is −(cr,ci); Q injected = vr·ci_in − vi·cr_in.
-                q_tot += vrk * (-ci[k]) - vik * (-cr[k])
+                # `cr,ci` is the current leaving the bus into the bank. The
+                # reactive power the bank *delivers* to the bus is
+                # Q = vr·ci − vi·cr (= +B|V|² for a capacitor, i.e. injected),
+                # the same sign convention as every other element's reported q.
+                q_tot += vrk * ci[k] - vik * cr[k]
             end
         end
         cap_res[cid] = Dict{String,Any}("terminals" => term_d, "q" => q_tot)

--- a/test/capacitor_tests.jl
+++ b/test/capacitor_tests.jl
@@ -89,3 +89,72 @@ end
     @test rep.results[:inventory]["capacitor"]["total"] == 1
     @test rep.results[:inventory]["capacitor"]["q_rated_total"] ≈ 1.8e6
 end
+
+if _HAS_JUMP_IPOPT
+    @testset "capacitor — solved result sign & per-unit round-trip (#272/#273)" begin
+        vpn = 230.0
+        q0  = 1.0e3   # var per phase
+        net = Dict{String,Any}("name" => "cap1",
+            "bus" => Dict{String,Any}(
+                "src" => Dict{String,Any}("terminal_names" => ["a","b","c","n"],
+                    "perfectly_grounded_terminals" => ["n"]),
+                "b1"  => Dict{String,Any}("terminal_names" => ["a","b","c","n"],
+                    "perfectly_grounded_terminals" => ["n"])),
+            "voltage_source" => Dict{String,Any}("s" => Dict{String,Any}(
+                "bus" => "src", "terminal_map" => ["a","b","c","n"],
+                "v_magnitude" => [vpn, vpn, vpn, 0.0],
+                "v_angle" => [0.0, -2.0943951, 2.0943951, 0.0])),
+            "linecode" => Dict{String,Any}("lc" => Dict{String,Any}(
+                "R_series_1_1" => 0.01, "R_series_2_2" => 0.01, "R_series_3_3" => 0.01,
+                "R_series_4_4" => 0.01)),
+            "line" => Dict{String,Any}("l1" => Dict{String,Any}(
+                "bus_from" => "src", "bus_to" => "b1",
+                "terminal_map_from" => ["a","b","c","n"],
+                "terminal_map_to"   => ["a","b","c","n"],
+                "linecode" => "lc", "length" => 100.0)),
+            "load" => Dict{String,Any}("ld" => Dict{String,Any}(
+                "bus" => "b1", "terminal_map" => ["a","b","c","n"],
+                "configuration" => "WYE", "model" => "constant_power",
+                "p_nom" => [500.0,500.0,500.0], "q_nom" => [0.0,0.0,0.0])),
+            "capacitor" => Dict{String,Any}("c1" => Dict{String,Any}(
+                "bus" => "b1", "terminal_map" => ["a","b","c","n"],
+                "configuration" => "WYE",
+                "q_rated" => [q0, q0, q0], "v_nom" => vpn)))
+
+        res = solve_pf(net; optimizer = Ipopt.Optimizer, per_unit = true)
+        @test res["termination_status"] in ("LOCALLY_SOLVED", "OPTIMAL")
+
+        # (#272) A capacitor DELIVERS reactive power: reported q > 0, and equals
+        # +B·Σ|V|² recomputed from the solved SI voltages (the physical sign).
+        Bph = q0 / vpn^2
+        vsq = 0.0
+        for ph in ("a","b","c")
+            vr = res["bus"]["b1"][ph]["vr"]; vi = res["bus"]["b1"][ph]["vi"]
+            vsq += vr^2 + vi^2
+        end
+        q_expected = Bph * vsq
+        @test res["capacitor"]["c1"]["q"] > 0
+        @test isapprox(res["capacitor"]["c1"]["q"], q_expected; rtol = 1e-3)
+
+        # (#273) Currents are reported in SI amps (≈ B·|V| ≈ 4.3 A), not p.u.
+        va  = abs(res["bus"]["b1"]["a"]["vr"] + im * res["bus"]["b1"]["a"]["vi"])
+        cma = res["capacitor"]["c1"]["terminals"]["a"]["cm"]
+        @test cma > 1.0
+        @test isapprox(cma, Bph * va; rtol = 1e-3)
+
+        # (#273) The per-unit path (default) must round-trip to the same SI q and
+        # current as a native-SI solve — the capacitor block was missing from
+        # _from_per_unit, so q was off by s_base and the current by i_base.
+        res_si = solve_pf(net; optimizer = Ipopt.Optimizer, per_unit = false)
+        @test isapprox(res["capacitor"]["c1"]["q"],
+                       res_si["capacitor"]["c1"]["q"]; rtol = 1e-4)
+        @test isapprox(cma, res_si["capacitor"]["c1"]["terminals"]["a"]["cm"]; rtol = 1e-4)
+
+        # (#273) The line-loss `s_through` (VA) must also round-trip through the
+        # per-unit path — it was omitted from the loss rescale, leaving it off
+        # by s_base while p_loss/q_loss were correct.
+        st_pu = res["line"]["l1"]["loss"]["s_through"]
+        @test st_pu > 1.0   # SI VA, not p.u.
+        @test isapprox(st_pu, res_si["line"]["l1"]["loss"]["s_through"]; rtol = 1e-4)
+    end
+end


### PR DESCRIPTION
Closes #272. Closes #273.

**#272 — capacitor `q` sign.** The extracted capacitor reactive power was negated. With the leaving current (`cr=-B·vi`, `ci=B·vr`) the *delivered* (injected) reactive power is `Q = vr·ci - vi·cr = +B|V|²` — the same sign convention every other element's reported `q` uses. The code computed `-B|V|²`, so a capacitor was reported as *absorbing* VArs. The KCL stamp was already correct; only the report was wrong.

**#273 — capacitor per-unit + `s_through`.** `_from_per_unit` had no capacitor block, so with the default `per_unit=true` the capacitor currents came back off by `i_base` and `q` off by `s_base` while every sibling result was SI. Added the rescale block. Also added `s_through` to the line and transformer loss rescales — `p_loss`/`q_loss` were scaled but `s_through` (VA) was not.

**Test** (`capacitor_tests.jl`, JuMP/Ipopt-gated): a solved capacitor cross-checks reported `q` against `+B·Σ|V|²` recomputed from SI voltages (sign + magnitude), asserts currents are SI amps, and requires the `per_unit=true` path to round-trip to a native-SI (`per_unit=false`) solve for `q`, current, and line-loss `s_through`. Verified discriminating: 6/7 (then 8/9) assertions fail against the pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)