### PR TITLE
Enforce to-side line current limit for from-side-only π-shunt (#274)

### DIFF
--- a/ext/BMOPFOpfExt/branch.jl
+++ b/ext/BMOPFOpfExt/branch.jl
@@ -181,10 +181,14 @@ function _add_line_constraints!(model, net, vars, kcl_r, kcl_i;
         end
 
         # ── Thermal current limits on total current at each end ───────────────
-        # When the to-side π-shunt is zero, cr_to = −cr_fr and ish_to = 0, so
-        # the to-side magnitude equals the from-side magnitude and only one
-        # constraint is needed. Both are added only when G_to or B_to is present.
-        has_to_shunt = !(G_to === nothing && B_to === nothing)
+        # The to-side total current is cr_to + ish_to = −cr_fr + ish_to. It has
+        # the same magnitude as the from-side total (cr_fr + ish_fr) only when
+        # BOTH π-shunts vanish (then both ends are ±cr_fr). If either side has a
+        # shunt the two magnitudes differ, so the to-side needs its own cone;
+        # otherwise the from-side cone alone would leave |cr_fr| unbounded up to
+        # i_max + |ish_fr|. Add the to-side cone whenever any shunt is present.
+        has_any_shunt = !(G_fr === nothing && B_fr === nothing &&
+                          G_to === nothing && B_to === nothing)
         lc = get(linecodes, get(line, "linecode", ""), nothing)
         # line-level i_max overrides the linecode's (and is the only rating
         # source for lines carrying inline absolute matrices)
@@ -207,7 +211,7 @@ function _add_line_constraints!(model, net, vars, kcl_r, kcl_i;
                     cfr_r = @expression(model, cr_fr[(lid,k)] + ish_fr_r[k])
                     cfr_i = @expression(model, ci_fr[(lid,k)] + ish_fr_i[k])
                     @constraint(model, cfr_r^2 + cfr_i^2 <= ilim^2)
-                    if has_to_shunt
+                    if has_any_shunt
                         cto_r = @expression(model, cr_to[(lid,k)] + ish_to_r[k])
                         cto_i = @expression(model, ci_to[(lid,k)] + ish_to_i[k])
                         @constraint(model, cto_r^2 + cto_i^2 <= ilim^2)
@@ -237,7 +241,7 @@ function _add_line_constraints!(model, net, vars, kcl_r, kcl_i;
                 _apparent_power_limit!(model,
                     vr[(b_fr, tmfr[k])], vi[(b_fr, tmfr[k])], cfr_r, cfr_i, slim;
                     base_name = "$(lid)_fr_$(k)")
-                if has_to_shunt
+                if has_any_shunt
                     cto_r = @expression(model, cr_to[(lid,k)] + ish_to_r[k])
                     cto_i = @expression(model, ci_to[(lid,k)] + ish_to_i[k])
                     _apparent_power_limit!(model,

--- a/test/network_limit_tests.jl
+++ b/test/network_limit_tests.jl
@@ -219,6 +219,62 @@
     end
 
     # ─────────────────────────────────────────────────────────────────────────
+    # L-A5b: to-side thermal bound with a FROM-side-only π-shunt (#274)
+    #
+    # The to-side total current is −c_series (no to-shunt), whose magnitude
+    # differs from the from-side total c_series + I_shunt_fr whenever a from-side
+    # shunt exists. Here a capacitive from-side shunt shrinks the from-side
+    # magnitude below the (inductive) load-driven series current, so the from-side
+    # cone alone would let the to-end exceed i_max. A local generator can relieve
+    # the line, so the correct model clamps the to-end at i_max; the buggy model
+    # (from-cone only) reports cm_to > i_max.
+    # ─────────────────────────────────────────────────────────────────────────
+    @testset "L-A5b: to-side i_max with from-side-only shunt (#274)" begin
+        # A line whose linecode carries a from-side-only capacitive π-shunt feeds
+        # an inductive constant-power load. The capacitive shunt shrinks the
+        # from-end total current below the (inductive) series current, so the two
+        # ends differ: |I_to| = |series| ≈ 22 A, |I_fr| = |series + I_shunt| ≈ 17 A.
+        # Only the to-side cone can catch an over-limit to-end; the pre-#274 model
+        # added it only when a *to*-side shunt was present, leaving the to-end
+        # unbounded here.
+        #
+        # NOTE: run in SI (per_unit=false). In the default per-unit path a line's
+        # i_max cone is currently dropped entirely when its linecode carries a
+        # π-shunt (a separate bug, filed alongside this); once that is fixed this
+        # test should also hold under per_unit=true.
+        mknet(ilim) = parse_bmopf("""
+        {"bus":{"src":{"terminal_names":["1","2","3","n"],"perfectly_grounded_terminals":["n"]},
+                "b":{"terminal_names":["1","2","3","n"],"perfectly_grounded_terminals":["n"],
+                     "v_min":[150.0,150.0,150.0],"v_max":[260.0,260.0,260.0]}},
+         "voltage_source":{"vs":{"bus":"src","terminal_map":["1","2","3"],
+             "v_magnitude":[230.0,230.0,230.0],"v_angle":[0.0,-2.0943951,2.0943951]}},
+         "linecode":{"lc":{"R_series_1_1":0.1,"R_series_2_2":0.1,"R_series_3_3":0.1,"R_series_4_4":0.1,
+             "X_series_1_1":0.05,"X_series_2_2":0.05,"X_series_3_3":0.05,"X_series_4_4":0.05,
+             "B_from_1_1":0.03,"B_from_2_2":0.03,"B_from_3_3":0.03}},
+         "line":{"l":{"bus_from":"src","bus_to":"b","linecode":"lc","length":1.0,
+             "terminal_map_from":["1","2","3","n"],"terminal_map_to":["1","2","3","n"],
+             "i_max":[$(ilim),$(ilim),$(ilim),1000.0]}},
+         "load":{"ld":{"bus":"b","terminal_map":["1","2","3","n"],"configuration":"WYE",
+             "model":"constant_power","p_nom":[3000.0,3000.0,3000.0],"q_nom":[4000.0,4000.0,4000.0]}}}
+        """; from_string=true)
+
+        # Positive control: a slack limit (25 A > both ends) solves, and the
+        # from-side shunt genuinely makes the to-end the larger of the two.
+        ok = solve_opf(mknet(25.0); per_unit = false)
+        @test ok["termination_status"] in ("LOCALLY_SOLVED", "OPTIMAL")
+        cm_fr = ok["line"]["l"]["1"]["cm_fr"]
+        cm_to = ok["line"]["l"]["1"]["cm_to"]
+        @test cm_to > cm_fr + 1.0                     # ends differ; to-end is larger
+        @test cm_to <= 25.0 * (1 + 5e-3)
+
+        # Binding case: i_max = 19 A sits between |I_fr| (≈17) and |I_to| (≈22).
+        # With the to-side cone the fixed load cannot be met (infeasible); without
+        # it (the bug) the solve succeeds with the to-end ≈22 A over the 19 A cap.
+        lim = solve_opf(mknet(19.0); per_unit = false)
+        @test lim["termination_status"] ∉ ("LOCALLY_SOLVED", "OPTIMAL")
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────
     # L-A9: neutral-conductor current limit (trailing per-conductor `i_max` entry)
     #
     # Class A on the IMPLICIT neutral current. A star device's neutral return


### PR DESCRIPTION
Closes #274.

The to-side thermal cone (both the `i_max` and `s_max` limits) was gated on `has_to_shunt` — added only when the *to*-side π-shunt was present. But the two end-current magnitudes are equal only when **both** shunts vanish (then both ends are ±`cr_fr`). With a from-side-only shunt the to-end total is `−cr_fr` while the from-end is `cr_fr + ish_fr`, so the from-side cone alone leaves `|cr_fr|` — the physical to-end current — unbounded up to `i_max + |ish_fr|`.

**Fix:** gate the to-side cone on any shunt present on *either* side (`has_any_shunt`).

**Test** (`network_limit_tests.jl`, L-A5b): a line whose linecode carries a from-side capacitive shunt feeds an inductive constant-power load, giving `|I_to| ≈ 22 A > |I_fr| ≈ 17 A`. A positive control at `i_max = 25 A` solves and confirms the two ends differ; the binding case at `i_max = 19 A` (between the two) is correctly **infeasible** with the fix, whereas the pre-fix model solved it with the to-end ~22 A over the 19 A cap. Verified discriminating against the stashed pre-fix code.

### Note: a separate, related bug found while writing this test
The regression runs in SI (`per_unit = false`) because in the **default** `per_unit = true` path a line's `i_max` cone is dropped **entirely** whenever its linecode carries a π-shunt (a tight `i_max` that should be infeasible instead solves). That is orthogonal to this fix — it suppresses *both* end cones — and is filed as its own issue. Once fixed, L-A5b should also hold under `per_unit = true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)