### PR TITLE
Backstop line i_max with a to-side variable box (#299)

### DIFF
--- a/ext/BMOPFOpfExt/branch.jl
+++ b/ext/BMOPFOpfExt/branch.jl
@@ -206,6 +206,10 @@ function _add_line_constraints!(model, net, vars, kcl_r, kcl_i;
                 vmax_fr = Union{Float64,Nothing}[
                     _terminal_vmax_to_ground(bus_fr, tmfr[j], grounded, b_fr)
                     for j in 1:n_map]
+                bus_to = get(buses, b_to, Dict{String,Any}())
+                vmax_to = Union{Float64,Nothing}[
+                    _terminal_vmax_to_ground(bus_to, tmto[j], grounded, b_to)
+                    for j in 1:n_map]
                 for k in 1:min(n_map, length(i_max))
                     ilim = Float64(i_max[k])
                     cfr_r = @expression(model, cr_fr[(lid,k)] + ish_fr_r[k])
@@ -217,10 +221,23 @@ function _add_line_constraints!(model, net, vars, kcl_r, kcl_i;
                         @constraint(model, cto_r^2 + cto_i^2 <= ilim^2)
                     end
 
-                    # Series-current variable box (from-side shunt determines it).
-                    ish_bound = _line_shunt_row_bound(G_fr, B_fr, vmax_fr, k, n_map)
-                    ish_bound === nothing && continue
-                    _limit_current_box!(cr_fr[(lid,k)], ci_fr[(lid,k)], ilim + ish_bound)
+                    # Series-current variable boxes. The one series current
+                    # appears at both ends: the from-total is cr_fr + ish_fr and
+                    # the to-total is −cr_fr + ish_to, so a valid outer box on the
+                    # bare series variable is |cr_fr| ≤ ilim + |ish_end| at each
+                    # end. Applying both keeps the tighter (min). These hard
+                    # variable bounds backstop the (soft) SOC cones: at a large
+                    # per-unit base the cone values fall below Ipopt's constraint
+                    # tolerance, so without a to-side box a from-side-only shunt
+                    # would leave the to-end current effectively unconstrained
+                    # (issue #299). With no to-side shunt the to-side box is a
+                    # tight |cr_fr| ≤ ilim.
+                    ish_fr_bound = _line_shunt_row_bound(G_fr, B_fr, vmax_fr, k, n_map)
+                    ish_fr_bound !== nothing &&
+                        _limit_current_box!(cr_fr[(lid,k)], ci_fr[(lid,k)], ilim + ish_fr_bound)
+                    ish_to_bound = _line_shunt_row_bound(G_to, B_to, vmax_to, k, n_map)
+                    ish_to_bound !== nothing &&
+                        _limit_current_box!(cr_fr[(lid,k)], ci_fr[(lid,k)], ilim + ish_to_bound)
                 end
             end
         end

--- a/test/network_limit_tests.jl
+++ b/test/network_limit_tests.jl
@@ -238,10 +238,10 @@
         # added it only when a *to*-side shunt was present, leaving the to-end
         # unbounded here.
         #
-        # NOTE: run in SI (per_unit=false). In the default per-unit path a line's
-        # i_max cone is currently dropped entirely when its linecode carries a
-        # π-shunt (a separate bug, filed alongside this); once that is fixed this
-        # test should also hold under per_unit=true.
+        # Checked in both per-unit and SI mode. (Issue #299: the default per-unit
+        # path used to silently drop a shunt-bearing line's i_max backstop, so
+        # this could only be observed in SI; #299 added a to-side variable box so
+        # the limit now holds in both modes.)
         mknet(ilim) = parse_bmopf("""
         {"bus":{"src":{"terminal_names":["1","2","3","n"],"perfectly_grounded_terminals":["n"]},
                 "b":{"terminal_names":["1","2","3","n"],"perfectly_grounded_terminals":["n"],
@@ -258,20 +258,22 @@
              "model":"constant_power","p_nom":[3000.0,3000.0,3000.0],"q_nom":[4000.0,4000.0,4000.0]}}}
         """; from_string=true)
 
-        # Positive control: a slack limit (25 A > both ends) solves, and the
-        # from-side shunt genuinely makes the to-end the larger of the two.
-        ok = solve_opf(mknet(25.0); per_unit = false)
-        @test ok["termination_status"] in ("LOCALLY_SOLVED", "OPTIMAL")
-        cm_fr = ok["line"]["l"]["1"]["cm_fr"]
-        cm_to = ok["line"]["l"]["1"]["cm_to"]
-        @test cm_to > cm_fr + 1.0                     # ends differ; to-end is larger
-        @test cm_to <= 25.0 * (1 + 5e-3)
+        for pu in (false, true)
+            # Positive control: a slack limit (25 A > both ends) solves, and the
+            # from-side shunt genuinely makes the to-end the larger of the two.
+            ok = solve_opf(mknet(25.0); per_unit = pu)
+            @test ok["termination_status"] in ("LOCALLY_SOLVED", "OPTIMAL")
+            cm_fr = ok["line"]["l"]["1"]["cm_fr"]
+            cm_to = ok["line"]["l"]["1"]["cm_to"]
+            @test cm_to > cm_fr + 1.0                 # ends differ; to-end is larger
+            @test cm_to <= 25.0 * (1 + 5e-3)
 
-        # Binding case: i_max = 19 A sits between |I_fr| (≈17) and |I_to| (≈22).
-        # With the to-side cone the fixed load cannot be met (infeasible); without
-        # it (the bug) the solve succeeds with the to-end ≈22 A over the 19 A cap.
-        lim = solve_opf(mknet(19.0); per_unit = false)
-        @test lim["termination_status"] ∉ ("LOCALLY_SOLVED", "OPTIMAL")
+            # Binding case: i_max = 19 A sits between |I_fr| (≈17) and |I_to| (≈22).
+            # With the to-side backstop the fixed load cannot be met (infeasible);
+            # without it (the bug) the solve succeeds with the to-end ≈22 A over cap.
+            lim = solve_opf(mknet(19.0); per_unit = pu)
+            @test lim["termination_status"] ∉ ("LOCALLY_SOLVED", "OPTIMAL")
+        end
     end
 
     # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #299.

## Root cause
A line's thermal `i_max` cone was silently unenforced in the **default** per-unit mode whenever the linecode carried a π-shunt (`B_from` etc.).

The SOC cones `cr² + ci² ≤ i_max²` turn out to be enforced in practice by the hard **variable box** on the series current, not by the cone itself. At a large per-unit base (default `s_base = 1e6`) a small feeder's currents are ~`1e-3` p.u. and the cone values ~`1e-6`, far below Ipopt's `constr_viol_tol` (`1e-4`), so Ipopt tolerates gross violations of the cone. The box was applied only from the **from**-side, at `i_max + |ish_fr|`:

- **No shunt:** `_line_shunt_row_bound` returns `0`, so the box is a tight `|cr_fr| ≤ i_max` → the limit holds (this is why non-shunt lines were fine).
- **From-side shunt:** the box loosens to `i_max + |ish_fr|` (correct — the series *can* exceed `i_max` when the shunt opposes), and with nothing backing the to-side cone the to-end current escaped the limit entirely.

Confirmed by scaling: with `s_base` matched to the feeder (`1e4`) both shunt/no-shunt cases correctly go infeasible; only the default-base + shunt combination leaked.

## Fix
Also apply a **to-side** box on the series variable at `i_max + |ish_to|`, mirroring the from-side. With no to-side shunt this is a tight `|cr_fr| ≤ i_max`. It is a valid *outer* box — implied by the true magnitude limit `|−cr_fr + ish_to| ≤ i_max`, so it never removes a feasible point — and it backstops the to-side cone in both per-unit and SI mode.

## Verification
- The shunt-bearing `i_max` repro now goes **infeasible** under the default `per_unit=true` (previously solved with the current ~2× over cap), matching `per_unit=false` and the no-shunt case.
- `L-A5b` (the #274 to-side test) now runs in **both** per-unit modes; the binding case is verified discriminating (fails without this box on the `per_unit=true` branch).
- All `network_limit_tests` binding tests still pass (38 pass, 2 pre-existing scaffolds).

## Not addressed
Other limit cones (line `s_max`, transformer coil `i_max`/`s_max`) share the same tolerance sensitivity at large per-unit bases but lack a box backstop. A more general fix (normalizing the cone constraints by their limit so they are O(1)-scaled, or choosing `s_base` from the network's actual power) would cover those too, but is broader and riskier — worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)