### PR TITLE
Make simplify connectivity helpers see ibr/capacitor/n_winding (#275)

### DIFF
--- a/src/network/simplify.jl
+++ b/src/network/simplify.jl
@@ -48,10 +48,31 @@ function _simlog!(net, operation, code, severity, element_type, element_id, mess
     push!(get!(net, "_simplification_log", Any[]), entry)
 end
 
+# Non-line, non-switch, non-transformer element categories that attach to a
+# single bus via a `"bus"` field. `ibr` and `capacitor` are first-class
+# categories and must be included alongside loads/generators/shunts/sources.
+const _BUS_ATTACHED_COMPONENTS =
+    ("load", "generator", "shunt", "voltage_source", "ibr", "capacitor")
+
+# Every bus a transformer references, across both the two-bus subtypes
+# (`bus_from`/`bus_to`) and the winding-list subtypes (`windings[].bus`). Read
+# only — see `_redirect_bus!` for the mutating winding path.
+function _xfmr_bus_refs(subtype, t)
+    if subtype in WINDING_LIST_SUBTYPES
+        return String[w.bus for w in _nw_windings(t) if !isempty(w.bus)]
+    end
+    bs = String[]
+    for b in (get(t, "bus_from", nothing), get(t, "bus_to", nothing))
+        b isa AbstractString && push!(bs, b)
+    end
+    bs
+end
+
 # Returns (line_count, nonline_count, lines_at) for all buses.
 # line_count[b]    = number of lines referencing bus b
 # nonline_count[b] = number of non-line elements at bus b
-#                    (loads, generators, shunts, voltage_sources, switches, transformers)
+#                    (loads, generators, shunts, voltage_sources, ibrs,
+#                     capacitors, switches, transformers)
 # lines_at[b]      = vector of line ids referencing bus b
 function _bus_connectivity(net)
     buses        = get(net, "bus",  Dict())
@@ -67,7 +88,7 @@ function _bus_connectivity(net)
         end
     end
 
-    for comp in ("load", "generator", "shunt", "voltage_source")
+    for comp in _BUS_ATTACHED_COMPONENTS
         for (_, c) in get(net, comp, Dict())
             b = get(c, "bus", nothing)
             b isa AbstractString && haskey(nonline_count, b) && (nonline_count[b] += 1)
@@ -83,8 +104,8 @@ function _bus_connectivity(net)
         sub = get(xfmr, subtype, nothing)
         sub isa Dict || continue
         for (_, t) in sub
-            for b in (get(t, "bus_from", nothing), get(t, "bus_to", nothing))
-                b isa AbstractString && haskey(nonline_count, b) && (nonline_count[b] += 1)
+            for b in _xfmr_bus_refs(subtype, t)
+                haskey(nonline_count, b) && (nonline_count[b] += 1)
             end
         end
     end
@@ -98,7 +119,7 @@ function _bus_has_connections(net, bus_id)
         (get(l, "bus_from", nothing) == bus_id ||
          get(l, "bus_to",   nothing) == bus_id) && return true
     end
-    for comp in ("load", "generator", "shunt", "voltage_source")
+    for comp in _BUS_ATTACHED_COMPONENTS
         for (_, c) in get(net, comp, Dict())
             get(c, "bus", nothing) == bus_id && return true
         end
@@ -112,8 +133,7 @@ function _bus_has_connections(net, bus_id)
         sub = get(xfmr, subtype, nothing)
         sub isa Dict || continue
         for (_, t) in sub
-            (get(t, "bus_from", nothing) == bus_id ||
-             get(t, "bus_to",   nothing) == bus_id) && return true
+            bus_id in _xfmr_bus_refs(subtype, t) && return true
         end
     end
     false
@@ -125,7 +145,7 @@ function _redirect_bus!(net, old_bus, new_bus)
         get(l, "bus_from", nothing) == old_bus && (l["bus_from"] = new_bus)
         get(l, "bus_to",   nothing) == old_bus && (l["bus_to"]   = new_bus)
     end
-    for comp in ("load", "generator", "shunt", "voltage_source")
+    for comp in _BUS_ATTACHED_COMPONENTS
         for (_, c) in get(net, comp, Dict())
             get(c, "bus", nothing) == old_bus && (c["bus"] = new_bus)
         end
@@ -139,8 +159,17 @@ function _redirect_bus!(net, old_bus, new_bus)
         sub = get(xfmr, subtype, nothing)
         sub isa Dict || continue
         for (_, t) in sub
-            get(t, "bus_from", nothing) == old_bus && (t["bus_from"] = new_bus)
-            get(t, "bus_to",   nothing) == old_bus && (t["bus_to"]   = new_bus)
+            if subtype in WINDING_LIST_SUBTYPES
+                # Winding-list subtypes carry buses inside `windings[].bus`;
+                # mutate the raw dicts (the `_nw_windings` view is a copy).
+                for w in get(t, "windings", Any[])
+                    w isa AbstractDict && get(w, "bus", nothing) == old_bus &&
+                        (w["bus"] = new_bus)
+                end
+            else
+                get(t, "bus_from", nothing) == old_bus && (t["bus_from"] = new_bus)
+                get(t, "bus_to",   nothing) == old_bus && (t["bus_to"]   = new_bus)
+            end
         end
     end
 end

--- a/test/simplify_tests.jl
+++ b/test/simplify_tests.jl
@@ -55,6 +55,38 @@ function _switch(from, to; open=false, tmap=["1","n"])
     )
 end
 
+function _ibr(bus)
+    Dict{String,Any}(
+        "bus"          => bus,
+        "terminal_map" => ["1","n"],
+        "topology"     => "SINGLE_PHASE",
+        "prime_mover"  => "PV",
+        "s_max"        => [5000.0],
+    )
+end
+
+function _capacitor(bus)
+    Dict{String,Any}(
+        "bus"           => bus,
+        "terminal_map"  => ["1","n"],
+        "configuration" => "SINGLE_PHASE",
+        "q_rated"       => [1000.0],
+        "v_nom"         => 230.0,
+    )
+end
+
+# Minimal winding-list (n_winding) transformer spanning the given buses.
+function _nwinding(buses)
+    Dict{String,Any}(
+        "windings" => [Dict{String,Any}(
+            "bus"           => b,
+            "terminal_map"  => ["1","n"],
+            "v_nom"         => 230.0,
+            "configuration" => "WYE") for b in buses],
+        "x_sc" => Dict{String,Any}("1_2" => 0.05),
+    )
+end
+
 _log_codes(net) = [e["code"] for e in get(net, "_simplification_log", [])]
 _log_sevs(net)  = [e["severity"] for e in get(net, "_simplification_log", [])]
 
@@ -735,4 +767,84 @@ end
     @test length(net["line"]) == 2
     @test haskey(net["bus"], "B")
     @test !haskey(net, "_simplification_log")
+end
+
+# ── Component-blindness regressions (#275) ──────────────────────────────────────
+# The connectivity helpers (_bus_connectivity / _bus_has_connections /
+# _redirect_bus!) used to enumerate only load/generator/shunt/voltage_source
+# and two-bus transformers, silently ignoring `ibr`, `capacitor`, and
+# winding-list (`n_winding`) transformers. That let a series merge or dangling
+# prune delete a bus hosting one of those elements (orphaning it), and let a
+# switch collapse absorb a bus without redirecting the element's `bus`.
+
+@testset "merge_series_lines — ibr/capacitor on intermediate bus blocks merge (#275)" begin
+    for (cat, elt) in (("ibr", _ibr("B")), ("capacitor", _capacitor("B")))
+        net = Dict{String,Any}(
+            "bus"      => Dict("A" => _bus(), "B" => _bus(), "C" => _bus()),
+            "linecode" => _lc("lc1"),
+            "line"     => Dict("l1" => _line("A", "B"), "l2" => _line("B", "C")),
+            "load"     => Dict("ld" => _load("C")),
+            cat        => Dict("e1" => elt),
+        )
+        net′ = merge_series_lines(net)
+        @test length(net′["line"]) == 2                 # not merged
+        @test haskey(net′["bus"], "B")                  # intermediate bus kept
+        @test net′[cat]["e1"]["bus"] == "B"             # element still attached
+        @test "NON_LINE_ON_BUS" in _log_codes(net′)
+    end
+end
+
+@testset "remove_dangling_lines — ibr/capacitor at leaf prevents removal (#275)" begin
+    for (cat, elt) in (("ibr", _ibr("B")), ("capacitor", _capacitor("B")))
+        net = Dict{String,Any}(
+            "bus"            => Dict("A" => _bus(), "B" => _bus()),
+            "linecode"       => _lc("lc1"),
+            "line"           => Dict("l1" => _line("A", "B")),
+            "voltage_source" => Dict("vs" => _vsource("A")),
+            cat              => Dict("e1" => elt),
+        )
+        net′ = remove_dangling_lines(net)
+        @test length(net′["line"]) == 1                 # stub not pruned
+        @test haskey(net′["bus"], "B")
+    end
+end
+
+@testset "collapse_closed_switches — ibr/capacitor bus redirected (#275)" begin
+    for (cat, elt) in (("ibr", _ibr("B")), ("capacitor", _capacitor("B")))
+        net = Dict{String,Any}(
+            "bus"            => Dict("A" => _bus(), "B" => _bus()),
+            "switch"         => Dict("sw" => _switch("A", "B"; open=false)),
+            "voltage_source" => Dict("vs" => _vsource("A")),
+            cat              => Dict("e1" => elt),
+        )
+        net′ = collapse_closed_switches(net)
+        @test !haskey(net′["bus"], "B")                 # B absorbed into A
+        @test net′[cat]["e1"]["bus"] == "A"             # element redirected, not orphaned
+    end
+end
+
+@testset "n_winding transformer visible to simplify helpers (#275)" begin
+    # A winding on the intermediate bus B blocks the series merge.
+    net = Dict{String,Any}(
+        "bus"         => Dict("A" => _bus(), "B" => _bus(), "C" => _bus(), "D" => _bus()),
+        "linecode"    => _lc("lc1"),
+        "line"        => Dict("l1" => _line("A", "B"), "l2" => _line("B", "C")),
+        "load"        => Dict("ld" => _load("C")),
+        "transformer" => Dict("n_winding" => Dict("t1" => _nwinding(["B", "D"]))),
+    )
+    net′ = merge_series_lines(net)
+    @test length(net′["line"]) == 2
+    @test haskey(net′["bus"], "B")
+    @test "NON_LINE_ON_BUS" in _log_codes(net′)
+
+    # A switch collapse redirects the winding's bus from B to A.
+    net2 = Dict{String,Any}(
+        "bus"            => Dict("A" => _bus(), "B" => _bus(), "D" => _bus()),
+        "switch"         => Dict("sw" => _switch("A", "B"; open=false)),
+        "voltage_source" => Dict("vs" => _vsource("A")),
+        "transformer"    => Dict("n_winding" => Dict("t1" => _nwinding(["B", "D"]))),
+    )
+    net2′ = collapse_closed_switches(net2)
+    @test !haskey(net2′["bus"], "B")
+    @test net2′["transformer"]["n_winding"]["t1"]["windings"][1]["bus"] == "A"
 end


### PR DESCRIPTION
Closes #275.

The three bus-connectivity helpers that back **every** `simplify_network` pass — `_bus_connectivity`, `_bus_has_connections`, `_redirect_bus!` — enumerated only `load`/`generator`/`shunt`/`voltage_source` plus two-bus transformers. They silently ignored:

- **`ibr` and `capacitor`** — first-class, bus-attached categories (`fix.jl` already enumerates them);
- **`n_winding` transformers** — whose buses live in `windings[].bus`, not `bus_from`/`bus_to` (it's in `TRANSFORMER_SUBTYPES`, so the loops iterated it but read absent keys → contributed nothing).

Consequences: `merge_series_lines` / `remove_dangling_lines` could delete a degree-2 or leaf bus hosting only an IBR/capacitor/n-winding winding, leaving a dangling bus reference; `collapse_closed_switches` absorbed a bus without rewriting those elements' `bus`.

### Fix
- Add `ibr`/`capacitor` to a shared `_BUS_ATTACHED_COMPONENTS` list used by all three helpers.
- Branch the transformer loops on `WINDING_LIST_SUBTYPES` via a new read-only `_xfmr_bus_refs(subtype, t)` helper (returns `windings[].bus` for n_winding, else `bus_from`/`bus_to`). `_redirect_bus!` mutates the raw winding dicts directly, since the `_nw_windings` view is a copy.

All three passes route bus queries through these helpers, so this is the single choke point — no other inline component lists exist in the file.

### Tests
New regressions place an ibr, a capacitor, and an n-winding winding on an intermediate bus (series merge must be **blocked**, `NON_LINE_ON_BUS` logged), at a **leaf** (dangling prune blocked), and on an **absorbed** bus (switch collapse must **redirect** the reference, and the winding's `bus` flips B→A). Verified discriminating against the pre-fix code; all existing simplify tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)