### PR TITLE
Require terminal-map order/content on merge & switch collapse (#276)

### DIFF
--- a/src/network/simplify.jl
+++ b/src/network/simplify.jl
@@ -301,7 +301,12 @@ function _merge_series_lines!(net)
                 tmap_B_l2  = get(l2, "terminal_map_to",   String[])
             end
 
-            if Set(tmap_B_l1) != Set(tmap_B_l2)
+            # The two segments are in series per conductor only when their maps
+            # at the shared bus agree in ORDER, not merely as sets: terminal maps
+            # are positional (conductor k ↔ entry k), so ["1","n"] vs ["n","1"] is
+            # a phase transposition the merged single line cannot represent. Require
+            # exact equality (the inline-impedance path below does the same).
+            if tmap_B_l1 != tmap_B_l2
                 bus_id in warned_buses && continue
                 push!(warned_buses, bus_id)
                 _simlog!(net, "merge_series_lines", "TERMINAL_MISMATCH", "warning",
@@ -516,16 +521,31 @@ function _collapse_closed_switches!(net)
                 continue
             end
 
-            # Block on terminal-map arity mismatch.
-            tmap_fr = get(sw, "terminal_map_from", String[])
-            tmap_to = get(sw, "terminal_map_to",   String[])
-            if length(tmap_fr) != length(tmap_to)
+            # The collapse fuses b_to into b_fr by terminal-NAME union, so a name
+            # present on BOTH buses becomes one node. That is only correct when the
+            # switch actually connects those terminals straight-through. Two failure
+            # modes pass an arity check but corrupt the topology:
+            #   • cross-phase map (tmap_from ≠ tmap_to element-wise): the switch
+            #     joins e.g. b_fr's "1" to b_to's "2", yet the name-union would
+            #     silently make it an identity ("1"↔"1") connection;
+            #   • partial map: a terminal name shared by both buses but absent from
+            #     the switch map would be fused by name though the switch never
+            #     connected it.
+            # Require an identity map (tmap_from == tmap_to) that covers every
+            # terminal name the two buses share; skip otherwise. (A terminal on
+            # only one bus is harmless — it is carried across, not fused.)
+            tmap_fr = String.(get(sw, "terminal_map_from", String[]))
+            tmap_to = String.(get(sw, "terminal_map_to",   String[]))
+            shared  = intersect(Set(String.(get(bus_f, "terminal_names", String[]))),
+                                Set(String.(get(bus_t, "terminal_names", String[]))))
+            if tmap_fr != tmap_to || !issubset(shared, Set(tmap_fr))
                 _simlog!(net, "collapse_closed_switches", "MERGE_CONFLICT_TERMINALS", "warning",
                     "switch", sid,
-                    "Switch $sid has mismatched terminal-map arities " *
-                    "(from=$(length(tmap_fr)), to=$(length(tmap_to))) — skipped.",
+                    "Switch $sid is not a straight-through identity connection over the " *
+                    "terminals its buses share (cross-phase or partial map) — skipped.",
                     detail=Dict("bus_from" => b_fr, "bus_to" => b_to,
-                                "tmap_from" => tmap_fr, "tmap_to" => tmap_to))
+                                "tmap_from" => tmap_fr, "tmap_to" => tmap_to,
+                                "shared_terminals" => sort(collect(shared))))
                 continue
             end
 

--- a/test/simplify_tests.jl
+++ b/test/simplify_tests.jl
@@ -848,3 +848,80 @@ end
     @test !haskey(net2′["bus"], "B")
     @test net2′["transformer"]["n_winding"]["t1"]["windings"][1]["bus"] == "A"
 end
+
+# ── Terminal-map correctness on merge / collapse (#276) ─────────────────────────
+# Terminal maps are positional. A series merge or switch collapse that ignores
+# their ORDER/CONTENT (only their arity/set) silently turns a phase transposition
+# or a partial connection into a straight-through identity, corrupting topology.
+
+@testset "merge_series_lines — permuted terminal map at shared bus blocked (#276)" begin
+    # l1 and l2 meet at B with a phase transposition (["1","2","n"] vs
+    # ["2","1","n"]) — same set, different order. The linecode path used to
+    # compare only Set(...) and would merge; a single line cannot carry the swap.
+    net = Dict{String,Any}(
+        "bus"      => Dict("A" => _bus(terminals=["1","2","n"]),
+                           "B" => _bus(terminals=["1","2","n"]),
+                           "C" => _bus(terminals=["1","2","n"])),
+        "linecode" => _lc("lc1"),
+        "line"     => Dict(
+            "l1" => _line("A", "B"; tmap=["1","2","n"]),
+            "l2" => Dict("bus_from" => "B", "bus_to" => "C",
+                         "terminal_map_from" => ["2","1","n"],   # permuted at B
+                         "terminal_map_to"   => ["1","2","n"],
+                         "linecode" => "lc1", "length" => 100.0)),
+        "load"     => Dict("ld" => _load("C")),
+    )
+    net′ = merge_series_lines(net)
+    @test length(net′["line"]) == 2                 # not merged
+    @test haskey(net′["bus"], "B")
+    @test "TERMINAL_MISMATCH" in _log_codes(net′)
+end
+
+@testset "collapse_closed_switches — cross-phase switch not collapsed (#276)" begin
+    # The switch joins A.1↔B.2 and A.2↔B.1 (a transposition). Fusing by terminal
+    # name would wrongly identify A.1 with B.1. Same arity, so the old arity-only
+    # gate let it through.
+    net = Dict{String,Any}(
+        "bus"            => Dict("A" => _bus(terminals=["1","2","n"]),
+                                 "B" => _bus(terminals=["1","2","n"])),
+        "switch"         => Dict("sw" => Dict("bus_from" => "A", "bus_to" => "B",
+                             "open_switch" => false,
+                             "terminal_map_from" => ["1","2","n"],
+                             "terminal_map_to"   => ["2","1","n"])),
+        "voltage_source" => Dict("vs" => _vsource("A")),
+    )
+    net′ = collapse_closed_switches(net)
+    @test haskey(net′["bus"], "B")                  # not collapsed
+    @test haskey(net′["switch"], "sw")
+    @test "MERGE_CONFLICT_TERMINALS" in _log_codes(net′)
+end
+
+@testset "collapse_closed_switches — partial switch over a shared terminal blocked (#276)" begin
+    # Both buses carry phase "2", but the switch connects only "1" and "n".
+    # A name-union collapse would fuse A.2 with B.2 though the switch never
+    # joined them.
+    net = Dict{String,Any}(
+        "bus"            => Dict("A" => _bus(terminals=["1","2","n"]),
+                                 "B" => _bus(terminals=["1","2","n"])),
+        "switch"         => Dict("sw" => Dict("bus_from" => "A", "bus_to" => "B",
+                             "open_switch" => false,
+                             "terminal_map_from" => ["1","n"],
+                             "terminal_map_to"   => ["1","n"])),
+        "voltage_source" => Dict("vs" => _vsource("A")),
+    )
+    net′ = collapse_closed_switches(net)
+    @test haskey(net′["bus"], "B")                  # not collapsed
+    @test "MERGE_CONFLICT_TERMINALS" in _log_codes(net′)
+
+    # Positive control: an extra terminal on ONE side only (B has "2", A does
+    # not) is harmless — the switch still collapses and "2" is carried across.
+    net2 = Dict{String,Any}(
+        "bus"            => Dict("A" => _bus(terminals=["1","n"]),
+                                 "B" => _bus(terminals=["1","2","n"])),
+        "switch"         => Dict("sw" => _switch("A", "B"; open=false, tmap=["1","n"])),
+        "voltage_source" => Dict("vs" => _vsource("A")),
+    )
+    net2′ = collapse_closed_switches(net2)
+    @test !haskey(net2′["bus"], "B")                # collapsed
+    @test "2" in net2′["bus"]["A"]["terminal_names"]
+end


### PR DESCRIPTION
Closes #276.

> **Stacked on #303 (#275).** Base is `fix/275-simplify-component-blindness`; review that first. I'll retarget this to `main` once #303 merges.

Terminal maps are positional (conductor `k` ↔ entry `k`), but two `simplify` paths compared only arity or set membership, silently turning a phase transposition or a partial connection into a straight-through identity:

- **`merge_series_lines`** (linecode path) gated on `Set(tmap_B_l1) != Set(tmap_B_l2)`, so `["1","2","n"]` merged with `["2","1","n"]` — a transposition at the shared bus that a single merged line cannot represent. Now requires exact order (matching what the inline-impedance path already did).
- **`collapse_closed_switches`** blocked only on terminal-map **arity** mismatch. A cross-phase switch (`tmap_from != tmap_to`) or a partial switch that leaves a *shared* terminal unconnected would be fused by terminal-name union into an identity connection. Now requires an identity map covering every terminal name the two buses **share**; a terminal on only one bus is harmless and still collapses (carried across, not fused).

### Tests
Permuted-map merge blocked; cross-phase switch skipped; partial-over-shared-terminal switch skipped — plus a positive control that a one-sided extra terminal still collapses. Verified discriminating against the pre-fix code; all existing simplify tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)