### PR TITLE
Re-land #276 + #277 lost from main by stacked-branch deletion

### DIFF
--- a/src/network/simplify.jl
+++ b/src/network/simplify.jl
@@ -21,15 +21,17 @@
 #   TERMINAL_MISMATCH         warning merge_series_lines     terminal maps at shared bus differ — not merged
 #   SWITCH_IN_CHAIN           warning merge_series_lines     switch blocks a same-linecode chain (likely user error)
 #   NON_LINE_ON_BUS           info    merge_series_lines     load/shunt/etc. blocks merge at intermediate bus
-#   GROUNDED_BUS              warning merge_series_lines     intermediate bus has grounded terminals — merge would drop the ground
+#   GROUNDED_BUS              warning merge_series_lines /    bus has grounded terminals — merge/prune would drop the ground
+#                                     remove_dangling_lines
+#   PARALLEL_LINES            info    merge_series_lines     two lines form a parallel pair (A—B—A), not a series chain
 #   LINE_REMOVED              info    remove_dangling_lines  stub line and leaf bus removed
 #   SHUNT_DROPPED             warning remove_dangling_lines  pruned stub carried shunt-to-earth — feasible set may change
 #   SWITCH_REMOVED            info    remove_open_switches   open switch element deleted
 #   ISOLATED_BUS              warning remove_open_switches   bus has no connections after switch removal
 #   SWITCH_COLLAPSED          info    collapse_closed_switches bus pair merged via closed switch
-#   SWITCH_LIMIT_DROPPED      warning collapse_closed_switches collapsed switch carried an i_max — cut vanishes, limit lost
-#   BOUND_DROPPED             warning collapse_closed_switches a merged phase had no voltage bound on either side
-#   MERGE_CONFLICT_TERMINALS  warning collapse_closed_switches terminal-map arity mismatch — not collapsed
+#   SWITCH_LIMIT_DROPPED      warning collapse_closed_switches collapsed switch carried an i_max/s_max — cut vanishes, limit lost
+#   BOUND_DROPPED             warning collapse_closed_switches a merged bound could not be carried across the collapse
+#   MERGE_CONFLICT_TERMINALS  warning collapse_closed_switches terminal-map cross-phase/partial mismatch — not collapsed
 #   MERGE_CONFLICT_SOURCE     warning collapse_closed_switches both buses have voltage sources — not collapsed
 
 # ── Internal helpers ───────────────────────────────────────────────────────────
@@ -301,6 +303,22 @@ function _merge_series_lines!(net)
                 tmap_B_l2  = get(l2, "terminal_map_to",   String[])
             end
 
+            # Two lines forming a 2-cycle A—B—A (both connect the same pair of
+            # buses) share BOTH endpoints, so the non-shared ends resolve to the
+            # same bus. Merging them would fabricate a self-loop line
+            # (bus_from == bus_to) — exactly the E.CONN.SELF_LOOP data error.
+            # Skip; parallel lines are not a series pair.
+            if A == C
+                bus_id in warned_buses && continue
+                push!(warned_buses, bus_id)
+                _simlog!(net, "merge_series_lines", "PARALLEL_LINES", "info",
+                    "bus", bus_id,
+                    "Lines $l1_id and $l2_id both connect buses $A and $bus_id " *
+                    "(a parallel pair, not a series chain) — not merged.",
+                    detail=Dict("line_1" => l1_id, "line_2" => l2_id, "bus" => A))
+                continue
+            end
+
             # The two segments are in series per conductor only when their maps
             # at the shared bus agree in ORDER, not merely as sets: terminal maps
             # are positional (conductor k ↔ entry k), so ["1","n"] vs ["n","1"] is
@@ -386,8 +404,17 @@ function _merge_series_lines!(net)
                 e1 = o1 !== nothing ? o1 : (lc1_d isa Dict ? get(lc1_d, key, nothing) : nothing)
                 e2 = o2 !== nothing ? o2 : (lc2_d isa Dict ? get(lc2_d, key, nothing) : nothing)
                 if e1 isa AbstractVector && e2 isa AbstractVector
-                    n = min(length(e1), length(e2))
-                    merged_lim = [min(Float64(e1[k]), Float64(e2[k])) for k in 1:n]
+                    # Per conductor: the tighter limit where both segments rate
+                    # it, else the one that does. Truncating to the shorter vector
+                    # would silently drop a trailing conductor's rating (e.g. one
+                    # segment rates phases+neutral, the other phases only — the
+                    # neutral limit must survive).
+                    n = max(length(e1), length(e2))
+                    merged_lim = [begin
+                        v1 = k <= length(e1) ? Float64(e1[k]) : nothing
+                        v2 = k <= length(e2) ? Float64(e2[k]) : nothing
+                        v1 === nothing ? v2 : (v2 === nothing ? v1 : min(v1, v2))
+                    end for k in 1:n]
                     had_override ? (l1[key] = merged_lim) : delete!(l1, key)
                 elseif e1 isa AbstractVector
                     l1[key] = deepcopy(e1)
@@ -412,6 +439,7 @@ function _merge_series_lines!(net)
 end
 
 function _remove_dangling_lines!(net)
+    warned_grounded = Set{String}()
     changed = true
     while changed
         changed = false
@@ -421,6 +449,22 @@ function _remove_dangling_lines!(net)
         for bus_id in keys(get(net, "bus", Dict()))
             get(line_count, bus_id, 0) == 1 || continue
             get(nonline_count, bus_id, 0) == 0 || continue
+
+            # A grounded leaf bus is tied to earth; pruning it silently drops a
+            # ground (a return path / neutral reference), changing the electrics.
+            # Keep it, matching merge_series_lines' treatment of grounded buses.
+            bus_obj = get(get(net, "bus", Dict()), bus_id, Dict())
+            if !isempty(get(bus_obj, "perfectly_grounded_terminals", String[]))
+                if bus_id ∉ warned_grounded
+                    push!(warned_grounded, bus_id)
+                    _simlog!(net, "remove_dangling_lines", "GROUNDED_BUS", "warning",
+                        "bus", bus_id,
+                        "Dangling leaf bus $bus_id has grounded terminals — not pruned; " *
+                        "removing it would drop a ground (return path / neutral reference).",
+                        detail=Dict("bus" => bus_id))
+                end
+                continue
+            end
 
             lid  = only(get(lines_at, bus_id, String[]))
             line = lines[lid]
@@ -576,11 +620,14 @@ function _collapse_closed_switches!(net)
             # Tighter voltage bounds, aligned by phase-terminal NAME (max of
             # the lower bounds, min of the upper bounds where both buses bound
             # the same phase). A blind element-wise combine would pair
-            # different phases whenever the orderings differ.
+            # different phases whenever the orderings differ. Covers the
+            # per-phase and phase-to-neutral arrays; scalar and phase-pair
+            # bounds are combined below.
             merged_phases = _phases(bus_f)
             _by_name(phs, vals) = Dict(phs[i] => Float64(vals[i])
                                        for i in 1:min(length(phs), length(vals)))
-            for (field, op) in (("v_min", max), ("v_max", min))
+            for (field, op) in (("v_min", max), ("v_max", min),
+                                ("vpn_min", max), ("vpn_max", min))
                 vf = get(bus_f, field, nothing)
                 vt = get(bus_t, field, nothing)
                 (vf === nothing && vt === nothing) && continue
@@ -615,22 +662,64 @@ function _collapse_closed_switches!(net)
                 end
             end
 
-            # A closed switch with an enforced current limit is flow-limited in
-            # the OPF just like a line. Collapsing fuses its two buses into one
-            # node, so the cut the rating constrained no longer exists and the
-            # limit cannot be projected onto any surviving branch — it is simply
-            # lost. Flag it (the collapse still proceeds); keep `closed_switches
-            # = false` to retain a rated switch as an explicit branch.
-            i_max_sw = get(sw, "i_max", nothing)
-            if i_max_sw isa AbstractVector && any(x -> x isa Number && !iszero(x), i_max_sw)
+            # Scalar feasible-set bounds (sequence magnitudes, neutral voltage,
+            # angle-difference limits): the merged node keeps the tighter of the
+            # two — max for lower bounds, min for upper. Previously only v_min/
+            # v_max survived, so an absorbed bus's tighter scalar bound was lost.
+            for (field, op) in (("vpos_min", max), ("vpos_max", min),
+                                ("vneg_max", min), ("vzero_max", min),
+                                ("vn_max",   min),
+                                ("va_diff_min", max), ("va_diff_max", min))
+                vf = get(bus_f, field, nothing); vt = get(bus_t, field, nothing)
+                if vf isa Number && vt isa Number
+                    bus_f[field] = op(Float64(vf), Float64(vt))
+                elseif vt isa Number
+                    bus_f[field] = Float64(vt)
+                end
+                # vf-only: already on bus_f, nothing to do.
+            end
+
+            # Phase-pair bounds (vpp_*) are indexed by phase PAIR, not phase
+            # name, so they can only be combined element-wise when both buses
+            # enumerate the same phases in the same order. Otherwise the pairing
+            # is ambiguous; keep the survivor's and record the absorbed bus's
+            # loss rather than mis-pair.
+            same_phase_order = ph_f == ph_t
+            for (field, op) in (("vpp_min", max), ("vpp_max", min))
+                vf = get(bus_f, field, nothing); vt = get(bus_t, field, nothing)
+                (vt isa AbstractVector) || continue          # nothing to fold in
+                if vf isa AbstractVector && same_phase_order &&
+                   length(vf) == length(vt)
+                    bus_f[field] = [op(Float64(vf[k]), Float64(vt[k])) for k in eachindex(vf)]
+                elseif vf === nothing && same_phase_order
+                    bus_f[field] = deepcopy(vt)
+                else
+                    _simlog!(net, "collapse_closed_switches", "BOUND_DROPPED",
+                        "warning", "bus", b_fr,
+                        "Merged bus $b_fr: absorbed bus $b_to's `$field` could not " *
+                        "be combined (differing phase order or length) and was dropped.",
+                        detail=Dict("field" => field, "bus_absorbed" => b_to))
+                end
+            end
+
+            # A closed switch with an enforced current OR apparent-power limit is
+            # flow-limited in the OPF just like a line. Collapsing fuses its two
+            # buses into one node, so the cut the rating constrained no longer
+            # exists and the limit cannot be projected onto any surviving branch —
+            # it is simply lost. Flag it (the collapse still proceeds); keep
+            # `closed_switches = false` to retain a rated switch as an explicit
+            # branch.
+            for lim_key in ("i_max", "s_max")
+                lim = get(sw, lim_key, nothing)
+                (lim isa AbstractVector && any(x -> x isa Number && !iszero(x), lim)) || continue
                 _simlog!(net, "collapse_closed_switches", "SWITCH_LIMIT_DROPPED", "warning",
                     "switch", sid,
-                    "Collapsing switch $sid drops its current limit $(i_max_sw): merging " *
+                    "Collapsing switch $sid drops its $lim_key $(lim): merging " *
                     "buses $b_fr and $b_to fuses them into one node, so the cut the rating " *
                     "constrained no longer exists and the limit cannot be projected onto a " *
                     "surviving branch — the feasible set may change. Keep " *
                     "`closed_switches = false` to retain the switch as an explicit branch.",
-                    detail=Dict("bus_from" => b_fr, "bus_to" => b_to, "i_max" => i_max_sw))
+                    detail=Dict("bus_from" => b_fr, "bus_to" => b_to, lim_key => lim))
             end
 
             _redirect_bus!(net, b_to, b_fr)

--- a/src/network/simplify.jl
+++ b/src/network/simplify.jl
@@ -301,7 +301,12 @@ function _merge_series_lines!(net)
                 tmap_B_l2  = get(l2, "terminal_map_to",   String[])
             end
 
-            if Set(tmap_B_l1) != Set(tmap_B_l2)
+            # The two segments are in series per conductor only when their maps
+            # at the shared bus agree in ORDER, not merely as sets: terminal maps
+            # are positional (conductor k ↔ entry k), so ["1","n"] vs ["n","1"] is
+            # a phase transposition the merged single line cannot represent. Require
+            # exact equality (the inline-impedance path below does the same).
+            if tmap_B_l1 != tmap_B_l2
                 bus_id in warned_buses && continue
                 push!(warned_buses, bus_id)
                 _simlog!(net, "merge_series_lines", "TERMINAL_MISMATCH", "warning",
@@ -516,16 +521,31 @@ function _collapse_closed_switches!(net)
                 continue
             end
 
-            # Block on terminal-map arity mismatch.
-            tmap_fr = get(sw, "terminal_map_from", String[])
-            tmap_to = get(sw, "terminal_map_to",   String[])
-            if length(tmap_fr) != length(tmap_to)
+            # The collapse fuses b_to into b_fr by terminal-NAME union, so a name
+            # present on BOTH buses becomes one node. That is only correct when the
+            # switch actually connects those terminals straight-through. Two failure
+            # modes pass an arity check but corrupt the topology:
+            #   • cross-phase map (tmap_from ≠ tmap_to element-wise): the switch
+            #     joins e.g. b_fr's "1" to b_to's "2", yet the name-union would
+            #     silently make it an identity ("1"↔"1") connection;
+            #   • partial map: a terminal name shared by both buses but absent from
+            #     the switch map would be fused by name though the switch never
+            #     connected it.
+            # Require an identity map (tmap_from == tmap_to) that covers every
+            # terminal name the two buses share; skip otherwise. (A terminal on
+            # only one bus is harmless — it is carried across, not fused.)
+            tmap_fr = String.(get(sw, "terminal_map_from", String[]))
+            tmap_to = String.(get(sw, "terminal_map_to",   String[]))
+            shared  = intersect(Set(String.(get(bus_f, "terminal_names", String[]))),
+                                Set(String.(get(bus_t, "terminal_names", String[]))))
+            if tmap_fr != tmap_to || !issubset(shared, Set(tmap_fr))
                 _simlog!(net, "collapse_closed_switches", "MERGE_CONFLICT_TERMINALS", "warning",
                     "switch", sid,
-                    "Switch $sid has mismatched terminal-map arities " *
-                    "(from=$(length(tmap_fr)), to=$(length(tmap_to))) — skipped.",
+                    "Switch $sid is not a straight-through identity connection over the " *
+                    "terminals its buses share (cross-phase or partial map) — skipped.",
                     detail=Dict("bus_from" => b_fr, "bus_to" => b_to,
-                                "tmap_from" => tmap_fr, "tmap_to" => tmap_to))
+                                "tmap_from" => tmap_fr, "tmap_to" => tmap_to,
+                                "shared_terminals" => sort(collect(shared))))
                 continue
             end
 

--- a/test/fix_tests.jl
+++ b/test/fix_tests.jl
@@ -227,10 +227,12 @@ end
 
     @testset "T2: Simplify — dangling line removed" begin
         net = _fix_lv_net()
-        # Add a stub line with no load at its far end
+        # Add a stub line with no load at its far end. The stub bus is left
+        # ungrounded: remove_dangling_lines deliberately keeps a grounded leaf
+        # (removing it would drop a ground — see simplify_tests.jl #277), so a
+        # grounded stub would not be pruned.
         net["bus"]["stub"] = Dict{String,Any}(
             "terminal_names" => ["1","2","3","n"],
-            "perfectly_grounded_terminals" => ["n"],
         )
         net["line"]["lstub"] = Dict{String,Any}(
             "bus_from" => "b2", "bus_to" => "stub",

--- a/test/simplify_tests.jl
+++ b/test/simplify_tests.jl
@@ -925,3 +925,80 @@ end
     @test !haskey(net2′["bus"], "B")                # collapsed
     @test "2" in net2′["bus"]["A"]["terminal_names"]
 end
+
+# ── Rating / bound preservation on merge & collapse (#277) ──────────────────────
+
+@testset "merge_series_lines — trailing (neutral) rating preserved (#277)" begin
+    # One segment rates phases+neutral (4 entries), the other phases only (3).
+    # Truncating to the shorter vector dropped the neutral limit; the merge must
+    # keep every conductor's rating (tighter where both rate it).
+    net = Dict{String,Any}(
+        "bus"      => Dict("A" => _bus(terminals=["1","2","3","n"]),
+                           "B" => _bus(terminals=["1","2","3","n"]),
+                           "C" => _bus(terminals=["1","2","3","n"])),
+        "linecode" => _lc("lc1"),
+        "line"     => Dict(
+            "l1" => _line("A", "B"; tmap=["1","2","3","n"]),
+            "l2" => _line("B", "C"; tmap=["1","2","3","n"])),
+        "load"     => Dict("ld" => _load("C")),
+    )
+    net["line"]["l1"]["i_max"] = [100.0, 100.0, 100.0, 50.0]   # incl. neutral
+    net["line"]["l2"]["i_max"] = [120.0, 120.0, 120.0]         # phases only
+    l = only(values(merge_series_lines(net)["line"]))
+    @test l["i_max"] == [100.0, 100.0, 100.0, 50.0]            # neutral survives
+end
+
+@testset "collapse_closed_switches — s_max drop flagged (#277)" begin
+    net = Dict{String,Any}(
+        "bus"            => Dict("A" => _bus(), "B" => _bus()),
+        "switch"         => Dict("sw" => _switch("A", "B"; open=false)),
+        "load"           => Dict("ld" => _load("B")),
+        "voltage_source" => Dict("vs" => _vsource("A")),
+    )
+    net["switch"]["sw"]["s_max"] = [5000.0, 5000.0]
+    net′ = collapse_closed_switches(net)
+    @test !haskey(net′["bus"], "B")                            # still collapsed
+    entry = only(e for e in net′["_simplification_log"] if e["code"] == "SWITCH_LIMIT_DROPPED")
+    @test entry["detail"]["s_max"] == [5000.0, 5000.0]
+end
+
+@testset "collapse_closed_switches — scalar & vpn bounds combined, not dropped (#277)" begin
+    net = Dict{String,Any}(
+        "bus" => Dict(
+            "A" => Dict("terminal_names" => ["1","n"], "vpn_max" => [250.0], "vneg_max" => 10.0),
+            "B" => Dict("terminal_names" => ["1","n"], "vpn_max" => [245.0], "vneg_max" => 8.0)),
+        "switch" => Dict("sw" => _switch("A", "B"; open=false)),
+    )
+    A = collapse_closed_switches(net)["bus"]["A"]
+    @test A["vpn_max"]  ≈ [245.0]   # min of 250, 245 (per-phase, name-aligned)
+    @test A["vneg_max"] ≈ 8.0       # min of 10, 8 (absorbed bus's tighter scalar kept)
+end
+
+@testset "merge_series_lines — parallel pair not merged into self-loop (#277)" begin
+    # l1 (A→B) and l2 (B→A) both connect A and B: their non-shared ends both
+    # resolve to A, so a naive merge would fabricate a self-loop A→A.
+    net = Dict{String,Any}(
+        "bus"            => Dict("A" => _bus(), "B" => _bus()),
+        "linecode"       => _lc("lc1"),
+        "line"           => Dict("l1" => _line("A", "B"), "l2" => _line("B", "A")),
+        "load"           => Dict("ld" => _load("A")),
+        "voltage_source" => Dict("vs" => _vsource("A")),
+    )
+    net′ = merge_series_lines(net)
+    @test length(net′["line"]) == 2                            # not merged
+    @test !any(l -> l["bus_from"] == l["bus_to"], values(net′["line"]))  # no self-loop
+    @test "PARALLEL_LINES" in _log_codes(net′)
+end
+
+@testset "remove_dangling_lines — grounded leaf not pruned (#277)" begin
+    net = Dict{String,Any}(
+        "bus"            => Dict("A" => _bus(), "B" => _bus(grounded=["n"])),
+        "linecode"       => _lc("lc1"),
+        "line"           => Dict("l1" => _line("A", "B")),
+        "voltage_source" => Dict("vs" => _vsource("A")),
+    )
+    net′ = remove_dangling_lines(net)
+    @test haskey(net′["line"], "l1")                          # ground kept
+    @test haskey(net′["bus"], "B")
+    @test "GROUNDED_BUS" in _log_codes(net′)
+end

--- a/test/simplify_tests.jl
+++ b/test/simplify_tests.jl
@@ -848,3 +848,80 @@ end
     @test !haskey(net2′["bus"], "B")
     @test net2′["transformer"]["n_winding"]["t1"]["windings"][1]["bus"] == "A"
 end
+
+# ── Terminal-map correctness on merge / collapse (#276) ─────────────────────────
+# Terminal maps are positional. A series merge or switch collapse that ignores
+# their ORDER/CONTENT (only their arity/set) silently turns a phase transposition
+# or a partial connection into a straight-through identity, corrupting topology.
+
+@testset "merge_series_lines — permuted terminal map at shared bus blocked (#276)" begin
+    # l1 and l2 meet at B with a phase transposition (["1","2","n"] vs
+    # ["2","1","n"]) — same set, different order. The linecode path used to
+    # compare only Set(...) and would merge; a single line cannot carry the swap.
+    net = Dict{String,Any}(
+        "bus"      => Dict("A" => _bus(terminals=["1","2","n"]),
+                           "B" => _bus(terminals=["1","2","n"]),
+                           "C" => _bus(terminals=["1","2","n"])),
+        "linecode" => _lc("lc1"),
+        "line"     => Dict(
+            "l1" => _line("A", "B"; tmap=["1","2","n"]),
+            "l2" => Dict("bus_from" => "B", "bus_to" => "C",
+                         "terminal_map_from" => ["2","1","n"],   # permuted at B
+                         "terminal_map_to"   => ["1","2","n"],
+                         "linecode" => "lc1", "length" => 100.0)),
+        "load"     => Dict("ld" => _load("C")),
+    )
+    net′ = merge_series_lines(net)
+    @test length(net′["line"]) == 2                 # not merged
+    @test haskey(net′["bus"], "B")
+    @test "TERMINAL_MISMATCH" in _log_codes(net′)
+end
+
+@testset "collapse_closed_switches — cross-phase switch not collapsed (#276)" begin
+    # The switch joins A.1↔B.2 and A.2↔B.1 (a transposition). Fusing by terminal
+    # name would wrongly identify A.1 with B.1. Same arity, so the old arity-only
+    # gate let it through.
+    net = Dict{String,Any}(
+        "bus"            => Dict("A" => _bus(terminals=["1","2","n"]),
+                                 "B" => _bus(terminals=["1","2","n"])),
+        "switch"         => Dict("sw" => Dict("bus_from" => "A", "bus_to" => "B",
+                             "open_switch" => false,
+                             "terminal_map_from" => ["1","2","n"],
+                             "terminal_map_to"   => ["2","1","n"])),
+        "voltage_source" => Dict("vs" => _vsource("A")),
+    )
+    net′ = collapse_closed_switches(net)
+    @test haskey(net′["bus"], "B")                  # not collapsed
+    @test haskey(net′["switch"], "sw")
+    @test "MERGE_CONFLICT_TERMINALS" in _log_codes(net′)
+end
+
+@testset "collapse_closed_switches — partial switch over a shared terminal blocked (#276)" begin
+    # Both buses carry phase "2", but the switch connects only "1" and "n".
+    # A name-union collapse would fuse A.2 with B.2 though the switch never
+    # joined them.
+    net = Dict{String,Any}(
+        "bus"            => Dict("A" => _bus(terminals=["1","2","n"]),
+                                 "B" => _bus(terminals=["1","2","n"])),
+        "switch"         => Dict("sw" => Dict("bus_from" => "A", "bus_to" => "B",
+                             "open_switch" => false,
+                             "terminal_map_from" => ["1","n"],
+                             "terminal_map_to"   => ["1","n"])),
+        "voltage_source" => Dict("vs" => _vsource("A")),
+    )
+    net′ = collapse_closed_switches(net)
+    @test haskey(net′["bus"], "B")                  # not collapsed
+    @test "MERGE_CONFLICT_TERMINALS" in _log_codes(net′)
+
+    # Positive control: an extra terminal on ONE side only (B has "2", A does
+    # not) is harmless — the switch still collapses and "2" is carried across.
+    net2 = Dict{String,Any}(
+        "bus"            => Dict("A" => _bus(terminals=["1","n"]),
+                                 "B" => _bus(terminals=["1","2","n"])),
+        "switch"         => Dict("sw" => _switch("A", "B"; open=false, tmap=["1","n"])),
+        "voltage_source" => Dict("vs" => _vsource("A")),
+    )
+    net2′ = collapse_closed_switches(net2)
+    @test !haskey(net2′["bus"], "B")                # collapsed
+    @test "2" in net2′["bus"]["A"]["terminal_names"]
+end


### PR DESCRIPTION
#304 (#276) and #305 (#277) were **stacked** PRs whose bases were the previous PRs' branches (`fix/275-…`, `fix/276-…`). Those base branches were deleted when the lower PR merged, so #304/#305 merged into now-gone branches and their code never reached `main` — only #303 (#275) did. This re-lands the two lost changes on top of `main`.

Both commits cherry-picked cleanly onto main's #275 squash; `simplify_tests.jl` and `fix_tests.jl` pass.

### #276 — terminal-map order/content on merge & switch collapse
Merge compared only `Set(...)` (permuted maps merged); switch collapse checked only arity (cross-phase / partial switches fused as identity). Now merge requires exact order and collapse requires an identity map covering shared terminals.

### #277 — preserve ratings & feasible-set bounds
Rating merge truncated to the shorter vector (dropped neutral rating); switch collapse flagged only `i_max` (not `s_max`); bus collapse combined only `v_min`/`v_max` (dropped `vpn_*`, sequence/neutral/angle scalars, `vpp_*`); parallel pairs fused into self-loops; grounded leaves pruned (dropping a ground). All fixed, with the `fix_tests` T2 fixture updated for grounded-leaf preservation.

See #304 and #305 for full detail and per-change regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)