### PR TITLE
Infer IBR topology from neutral presence, not terminal count (#283)

### DIFF
--- a/src/BMOPFTools.jl
+++ b/src/BMOPFTools.jl
@@ -239,6 +239,43 @@ function _phase_positions(terminal_map::AbstractVector)::Vector{Int}
 end
 
 """
+    _infer_ibr_topology(terminal_map) -> String
+
+Infer an IBR/STATCOM topology from its terminal map by NEUTRAL PRESENCE and
+phase count (not terminal count alone), matching the `_IBR_ARITY` contract:
+
+  * a neutral terminal present → `SINGLE_PHASE` (2 terminals) or `FOUR_LEG` (≥3);
+  * no neutral                 → `THREE_LEG` (≥3 terminals, a delta / 3-wire
+    connection) or `SINGLE_PHASE` (a phase-to-phase pair).
+
+Counting terminals alone mislabels a 3-wire delta `[a,b,c]` as `FOUR_LEG`.
+"""
+function _infer_ibr_topology(terminal_map::AbstractVector)::String
+    n = length(terminal_map)
+    if _neutral_terminal(terminal_map) !== nothing
+        return n <= 2 ? "SINGLE_PHASE" : "FOUR_LEG"
+    end
+    n >= 3 ? "THREE_LEG" : "SINGLE_PHASE"
+end
+
+"""
+    _ibr_phase_count(topology, terminal_map) -> (n_phase::Int, has_neutral::Bool)
+
+Number of phase currents and whether a neutral conductor is present for an IBR,
+given its `topology` and terminal map. Single source of truth mirrored by the
+OPF stamp (`ext/BMOPFOpfExt/ibr.jl`) and integrity's per-conductor `i_max`
+check: `THREE_LEG` carries one current per terminal with no neutral;
+`SINGLE_PHASE` one phase current (with a return when ≥2 terminals); `FOUR_LEG`
+one per non-neutral phase plus a neutral.
+"""
+function _ibr_phase_count(topology, terminal_map::AbstractVector)::Tuple{Int,Bool}
+    n = length(terminal_map)
+    topology == "THREE_LEG"    && return (n, false)
+    topology == "SINGLE_PHASE" && return (1, n >= 2)
+    return (max(n - 1, 0), true)   # FOUR_LEG (and unknown → default)
+end
+
+"""
     _xfmr_winding_pairs(terminal_map) -> Vector{Tuple{Int,Union{Int,Nothing}}}
 
 Winding terminal pairs `(p, q)` for one side of a single-phase transformer /

--- a/src/augmentation/ibr.jl
+++ b/src/augmentation/ibr.jl
@@ -40,7 +40,10 @@ function _apply_ibr_augmentation!(net′::Dict{String,Any},
     for (inv_id, inv) in ibrs
         inv isa Dict || continue
         tm      = Vector{String}(get(inv, "terminal_map", String[]))
-        n_phase = length(tm) - 1
+        # Phase-current count follows the topology: length(tm) - 1 assumes a
+        # neutral and undercounts a THREE_LEG (delta) IBR by one, truncating the
+        # per-phase p_max/q_max boxes it writes below.
+        n_phase, _ = _ibr_phase_count(get(inv, "topology", "FOUR_LEG"), tm)
         n_phase >= 1 || continue
 
         smax_arr = let s = get(inv, "s_max", nothing)

--- a/src/augmentation/ibr_placement.jl
+++ b/src/augmentation/ibr_placement.jl
@@ -232,10 +232,11 @@ function add_statcom!(net::Dict{String,Any}, bus::AbstractString;
     length(tm) >= 2 ||
         throw(ArgumentError("add_statcom!: bus '$bus' needs ≥2 terminals " *
                             "(got $(length(tm))); pass terminal_map explicitly"))
-    n_phase = length(tm) - 1
-
     topo = topology !== nothing ? uppercase(String(topology)) :
-           (length(tm) <= 2 ? "SINGLE_PHASE" : "FOUR_LEG")
+           _infer_ibr_topology(tm)
+    # Phase-current count follows the topology, not `length(tm) - 1` (which
+    # assumes a neutral): a 3-wire delta STATCOM is THREE_LEG with 3 phases.
+    n_phase, _ = _ibr_phase_count(topo, tm)
 
     smax_vec = s_max isa AbstractVector ? Float64.(collect(s_max)) :
                                           fill(Float64(s_max), n_phase)
@@ -431,8 +432,7 @@ function _resolve_topology(recipe::IBRRecipe, terminal_map::Vector{String})::Str
     if recipe.inverter_topology !== :infer
         return uppercase(string(recipe.inverter_topology))
     end
-    n = length(terminal_map)
-    n <= 2 ? "SINGLE_PHASE" : "FOUR_LEG"
+    _infer_ibr_topology(terminal_map)
 end
 
 # ── Findings ──────────────────────────────────────────────────────────────────

--- a/src/validation/integrity.jl
+++ b/src/validation/integrity.jl
@@ -343,7 +343,11 @@ function integrity_check(net::Dict{String,Any},
     # ibr per-phase filter/cost vectors must match phase count = |terminal_map| - 1
     for (id, inv) in get(net, "ibr", Dict())
         inv isa Dict || continue
-        n_phase = length(get(inv, "terminal_map", String[])) - 1
+        tm_i = Vector{String}(get(inv, "terminal_map", String[]))
+        # Phase count is set by the topology, not length(tm) - 1 (which assumes a
+        # neutral): a THREE_LEG (delta) IBR carries |tm| phase currents, so
+        # correct 3-entry per-phase vectors must NOT be flagged as mismatched.
+        n_phase, has_n = _ibr_phase_count(get(inv, "topology", "FOUR_LEG"), tm_i)
         n_phase < 1 && continue
         for field in ("r_filter", "x_filter", "cost", "s_max")
             v = get(inv, field, nothing)
@@ -352,19 +356,13 @@ function integrity_check(net::Dict{String,Any},
                 push!(findings, Finding(WARNING, "W.INT.DIM_MISMATCH", :integrity,
                     :ibr, id,
                     "IBR '$id': $field has $(length(v)) entries but the " *
-                    "terminal map implies $n_phase phase(s).",
+                    "topology implies $n_phase phase(s).",
                     Dict{String,Any}("field" => field, "n_phase" => n_phase)))
             end
         end
         # i_max is per CONDUCTOR; topology sets phase count and neutral presence.
-        let tm_i = Vector{String}(get(inv, "terminal_map", String[])),
-            topo = get(inv, "topology", "FOUR_LEG")
-            n_ph_i, has_n = topo == "THREE_LEG" ? (length(tm_i), false) :
-                            topo == "SINGLE_PHASE" ? (1, length(tm_i) >= 2) :
-                            (length(tm_i) - 1, true)        # FOUR_LEG
-            n_dim_issues += _check_conductor_imax!(findings, :ibr, "IBR", id,
-                get(inv, "i_max", nothing), n_ph_i, has_n)
-        end
+        n_dim_issues += _check_conductor_imax!(findings, :ibr, "IBR", id,
+            get(inv, "i_max", nothing), n_phase, has_n)
     end
 
     # generator per-phase vectors must match the phase-conductor count, which is

--- a/test/ibr_placement_tests.jl
+++ b/test/ibr_placement_tests.jl
@@ -53,6 +53,21 @@ _inv_1ph_net() = parse_bmopf("""
      "p_nom":[1000.0],"q_nom":[0.0]}}}
 """, from_string=true)
 
+# Delta (3-wire, no neutral) load — topology must infer THREE_LEG, not FOUR_LEG.
+_inv_delta_net() = parse_bmopf("""
+{"bus":{
+    "src":{"terminal_names":["1","2","3","n"],"perfectly_grounded_terminals":["n"]},
+    "b1": {"terminal_names":["1","2","3"]}},
+ "voltage_source":{"vs":{"bus":"src","terminal_map":["1","2","3"],
+     "v_magnitude":[230.0,230.0,230.0],"v_angle":[0.0,-2.0944,2.0944]}},
+ "linecode":{"lc":{"R_series_1_1":0.000396,"R_series_2_2":0.000396,"R_series_3_3":0.000396}},
+ "line":{"l1":{"bus_from":"src","bus_to":"b1",
+     "terminal_map_from":["1","2","3"],"terminal_map_to":["1","2","3"],
+     "linecode":"lc","length":100.0}},
+ "load":{"ld":{"bus":"b1","terminal_map":["1","2","3"],"configuration":"DELTA",
+     "p_nom":[1000.0,1000.0,1000.0],"q_nom":[0.0,0.0,0.0]}}}
+""", from_string=true)
+
 # ── I1: load-following placement writes the nameplate ────────────────────────
 
 @testset "I1: load-following — nameplate" begin
@@ -104,6 +119,38 @@ end
     inv = net′["ibr"]["pv_b1"]
     @test inv["topology"] == "SINGLE_PHASE"        # 2-terminal load
     @test inv["s_max"] ≈ [800.0]                atol=1e-6
+end
+
+# ── I4b: topology inference — delta (3-wire) load → THREE_LEG (#283) ──────────
+@testset "I4b: topology inference (delta, no neutral)" begin
+    net = _inv_delta_net()
+    net′, _ = add_ibrs(net)
+    inv = net′["ibr"]["pv_b1"]
+    @test inv["topology"] == "THREE_LEG"           # 3 terminals, no neutral
+    @test inv["terminal_map"] == ["1","2","3"]
+    @test length(inv["s_max"]) == 3
+
+    # augment_case fills a full 3-entry P/Q box — not truncated to 2 by a
+    # length(tm) - 1 phase count that assumed a neutral.
+    net3, _ = augment_case(net′)
+    inv3 = net3["ibr"]["pv_b1"]
+    @test length(inv3["p_max"]) == 3
+    @test length(inv3["q_max"]) == 3
+
+    # integrity must not flag the (correct) 3-entry vectors as a dimension
+    # mismatch against a bogus 2-phase count.
+    f = Finding[]
+    integrity_check(net3, f)
+    @test !any(x -> x.code == "W.INT.DIM_MISMATCH" && x.component_id == "pv_b1", f)
+end
+
+# ── I4c: add_statcom! on a 3-wire (delta) bus → THREE_LEG (#283) ──────────────
+@testset "I4c: add_statcom! delta bus" begin
+    net = _inv_delta_net()
+    add_statcom!(net, "b1"; s_max = 15_000.0)
+    inv = net["ibr"]["statcom_b1"]
+    @test inv["topology"] == "THREE_LEG"
+    @test length(inv["s_max"]) == 3                # one per phase, no neutral
 end
 
 # ── I5: forced topology overrides inference ──────────────────────────────────


### PR DESCRIPTION
Closes #283.

Four sites inferred an IBR/STATCOM **topology** or **phase count** from the terminal-map length alone — mislabeling a 3-wire delta `[a,b,c]` as `FOUR_LEG`, and using `n_phase = length(tm) - 1` (which assumes a neutral):

- `_resolve_topology` (placement): `n <= 2 ? SINGLE_PHASE : FOUR_LEG`
- `add_statcom!`: same inference, plus `n_phase = length(tm) - 1`
- `augmentation/ibr.jl`: `n_phase = length(tm) - 1` → **truncated the per-phase `p_max`/`q_max` boxes** (2 entries for a 3-phase delta), leaving the third phase bounded only by the `s_max` circle
- integrity `DIM_MISMATCH`: `n_phase = length(tm) - 1` → **falsely flagged** correct 3-entry `s_max`/`cost`/`r_filter` on a `THREE_LEG` IBR

### Fix
Two shared helpers in `BMOPFTools.jl` — the single source of truth, mirroring the OPF stamp (`ext/ibr.jl`) and integrity's per-conductor `i_max` check:
- `_infer_ibr_topology(terminal_map)` — neutral present → `SINGLE_PHASE`/`FOUR_LEG`; no neutral → `THREE_LEG` (≥3) / `SINGLE_PHASE`.
- `_ibr_phase_count(topology, terminal_map)` → `(n_phase, has_neutral)`.

All four sites route through them. The OPF already implements `THREE_LEG` (delta, box bounds), so a placed/inferred delta IBR now **solves end-to-end** (verified: `LOCALLY_SOLVED`, 3 phase results) instead of falling back to a phase-to-ground `FOUR_LEG` stamp with a spurious ground return.

### Tests
Delta-load placement → `THREE_LEG` with a full 3-entry P/Q box and no `DIM_MISMATCH`; `add_statcom!` on a 3-wire bus → `THREE_LEG`. Verified discriminating; existing FOUR_LEG/SINGLE_PHASE placement, statcom, and augmentation tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)