### PR TITLE
Make n_winding transformers visible to analysis/validation loops (#291)

### DIFF
--- a/src/BMOPFTools.jl
+++ b/src/BMOPFTools.jl
@@ -66,6 +66,28 @@ const WINDING_LIST_SUBTYPES = ("n_winding",)
 const GALVANIC_CONTINUOUS_SUBTYPES =
     ("single_phase_autotransformer", "open_delta_regulator")
 
+"""
+    _xfmr_from_to_buses(subtype, t) -> (from::Vector{String}, to::Vector{String})
+
+The "from" and "to" bus references of a transformer, unifying the two-bus and
+winding-list (`n_winding`) shapes so generic downstream / connectivity loops can
+handle both. Two-bus subtypes → `([bus_from], [bus_to])`; `n_winding` →
+winding 1's bus as the from side and every other winding's bus as the to side.
+Absent references drop out (empty vectors).
+"""
+function _xfmr_from_to_buses(subtype, t)::Tuple{Vector{String},Vector{String}}
+    if subtype in WINDING_LIST_SUBTYPES
+        ws = _nw_windings(t)
+        isempty(ws) && return (String[], String[])
+        return (isempty(ws[1].bus) ? String[] : String[ws[1].bus],
+                String[w.bus for w in ws[2:end] if !isempty(w.bus)])
+    end
+    f  = get(t, "bus_from", nothing)
+    tt = get(t, "bus_to",   nothing)
+    (f  isa AbstractString ? String[f]  : String[],
+     tt isa AbstractString ? String[tt] : String[])
+end
+
 # ---------------------------------------------------------------------------
 # Finding — the one struct in the library.
 # Everything network-related stays as Dict{String,Any}; findings are outputs

--- a/src/analysis/connectivity.jl
+++ b/src/analysis/connectivity.jl
@@ -267,9 +267,18 @@ function _check_supply_phase_consistency(net::Dict{String,Any},
         b = get(buses, bid, nothing)
         b isa Dict ? _nphase(get(b, "terminal_names", String[])) : 0
     end
-    function _xfmr_to_nphase(subtype, id)
+    function _xfmr_to_nphase(subtype, id, zone_buses)
         sub = get(xfmr, subtype, nothing); sub isa Dict || return 0
         t = get(sub, id, nothing); t isa Dict || return 0
+        if subtype in WINDING_LIST_SUBTYPES
+            # n_winding has no terminal_map_to; the winding that supplies THIS
+            # zone is the one whose bus falls inside it.
+            np = 0
+            for w in _nw_windings(t)
+                w.bus in zone_buses && (np = max(np, _nphase(w.terminal_map)))
+            end
+            return np
+        end
         _nphase(get(t, "terminal_map_to", String[]))
     end
 
@@ -298,7 +307,7 @@ function _check_supply_phase_consistency(net::Dict{String,Any},
             end
         end
         for (subtype, id) in z.feed
-            supplied = max(supplied, _xfmr_to_nphase(subtype, id))
+            supplied = max(supplied, _xfmr_to_nphase(subtype, id, z.buses))
         end
         supplied == 0 && continue   # no identifiable supply — cannot judge
 

--- a/src/analysis/operational.jl
+++ b/src/analysis/operational.jl
@@ -80,11 +80,12 @@ function operational_analysis(net::Dict{String,Any},
             s_rating = Float64(get(t, "s_rating", 0.0))
             s_rating <= 0 && continue
 
-            # Estimate loading: sum all loads downstream of this transformer
-            t_bus = get(t, "bus_to", nothing)
-            f_bus = get(t, "bus_from", nothing)
-            (t_bus === nothing || f_bus === nothing) && continue
-            s_load = _downstream_load(net, id, f_bus, t_bus)
+            # Estimate loading: sum all loads downstream of this transformer.
+            # Uses from/to buses that also cover the winding-list (n_winding)
+            # shape, which has no bus_from/bus_to and was previously skipped.
+            from_buses, to_buses = _xfmr_from_to_buses(subtype, t)
+            (isempty(from_buses) || isempty(to_buses)) && continue
+            s_load = _downstream_load(net, id, from_buses, to_buses)
             util_pct = round(100.0 * s_load / s_rating, digits=1)
 
             entry = Dict{String,Any}(
@@ -352,14 +353,16 @@ end
 Sum apparent power of all loads electrically downstream of a transformer.
 
 Method: build the bus adjacency from lines, closed switches, and all
-transformers *except* the one under analysis, then BFS from `t_bus`.
+transformers *except* the one under analysis, then BFS from the `to_buses`.
 Every bus reached without crossing the excluded transformer is downstream
 (valid for radial networks; for meshed networks where a parallel path
-exists back to `f_bus`, the result over-counts and the utilisation figure
-should be treated as an upper bound).
+exists back to a `from` bus, the result over-counts and the utilisation figure
+should be treated as an upper bound). `from_buses`/`to_buses` are vectors so the
+winding-list (`n_winding`) shape — winding 1 upstream, all other windings
+downstream — is handled alongside the two-bus shape.
 """
 function _downstream_load(net::Dict{String,Any}, xfmr_id::String,
-                           f_bus::String, t_bus::String)::Float64
+                           from_buses::Vector{String}, to_buses::Vector{String})::Float64
     # Build adjacency excluding the transformer under analysis
     adj = Dict{String,Vector{String}}()
     add!(a, b) = (push!(get!(adj, a, String[]), b);
@@ -380,14 +383,16 @@ function _downstream_load(net::Dict{String,Any}, xfmr_id::String,
         sub isa Dict || continue
         for (oid, ot) in sub
             oid == xfmr_id && continue   # exclude the transformer under analysis
-            f = get(ot, "bus_from", nothing); t = get(ot, "bus_to", nothing)
-            (f isa AbstractString && t isa AbstractString) && add!(f, t)
+            fb, tb = _xfmr_from_to_buses(subtype, ot)
+            for f in fb, t in tb
+                add!(f, t)               # connect every winding pair for traversal
+            end
         end
     end
 
-    # BFS from t_bus
-    downstream = Set{String}([t_bus])
-    queue = String[t_bus]
+    # BFS from all to-side buses
+    downstream = Set{String}(to_buses)
+    queue = copy(to_buses)
     while !isempty(queue)
         b = popfirst!(queue)
         for nb in get(adj, b, String[])
@@ -396,6 +401,8 @@ function _downstream_load(net::Dict{String,Any}, xfmr_id::String,
             push!(queue, nb)
         end
     end
+    # A from (upstream) bus reached via a meshed parallel path is not downstream.
+    setdiff!(downstream, Set(from_buses))
 
     # Sum apparent power of loads at downstream buses
     s = 0.0

--- a/src/augmentation/der_placement.jl
+++ b/src/augmentation/der_placement.jl
@@ -410,9 +410,10 @@ function _xfmr_downstream(net, loads)
         for (id, t) in sub
             t isa Dict || continue
             s_rating = Float64(get(t, "s_rating", 0.0))
-            t_bus = get(t, "bus_to", nothing)
-            (s_rating > 0 && t_bus isa AbstractString) || continue
-            down = _downstream_buses(net, string(id), string(t_bus))
+            s_rating > 0 || continue
+            _, to_buses = _xfmr_from_to_buses(subtype, t)   # covers n_winding
+            isempty(to_buses) && continue
+            down = _downstream_buses(net, string(id), to_buses)
             down_total = sum(Float64[sum(loads[b].p_nom) for b in down if haskey(loads, b)]; init = 0.0)
             for b in down
                 haskey(loads, b) || continue
@@ -425,7 +426,7 @@ function _xfmr_downstream(net, loads)
 end
 
 # Buses electrically downstream of a transformer (mirrors _downstream_load's BFS).
-function _downstream_buses(net, xfmr_id::String, t_bus::String)::Set{String}
+function _downstream_buses(net, xfmr_id::String, to_buses::Vector{String})::Set{String}
     adj = Dict{String,Vector{String}}()
     add!(a, b) = (push!(get!(adj, a, String[]), b); push!(get!(adj, b, String[]), a))
     for (_, l) in get(net, "line", Dict())
@@ -443,11 +444,14 @@ function _downstream_buses(net, xfmr_id::String, t_bus::String)::Set{String}
         sub isa Dict || continue
         for (oid, ot) in sub
             string(oid) == xfmr_id && continue
-            f = get(ot, "bus_from", nothing); t = get(ot, "bus_to", nothing)
-            (f isa AbstractString && t isa AbstractString) && add!(string(f), string(t))
+            # Include n_winding windings so BFS can traverse OTHER transformers.
+            fb, tb = _xfmr_from_to_buses(subtype, ot)
+            for f in fb, t in tb
+                add!(f, t)
+            end
         end
     end
-    seen = Set{String}([t_bus]); q = String[t_bus]
+    seen = Set{String}(to_buses); q = copy(to_buses)
     while !isempty(q)
         b = popfirst!(q)
         for nb in get(adj, b, String[])

--- a/src/augmentation/fix.jl
+++ b/src/augmentation/fix.jl
@@ -185,11 +185,15 @@ function _fix_largest_component!(net′, entries)
             get(el, "bus", nothing) in drop_buses && delete!(d, id)
         end
     end
-    for (_, xfmr_sub) in get(net′, "transformer", Dict())
+    for (subtype, xfmr_sub) in get(net′, "transformer", Dict())
         xfmr_sub isa Dict || continue
         for (id, el) in collect(xfmr_sub)
-            (get(el, "bus_from", nothing) in drop_buses ||
-             get(el, "bus_to",   nothing) in drop_buses) && delete!(xfmr_sub, id)
+            el isa Dict || continue
+            # Use the subtype-aware bus accessor so a winding-list (n_winding)
+            # transformer whose winding bus was dropped is pruned too, rather than
+            # left dangling by a bus_from/bus_to-only check.
+            fb, tb = _xfmr_from_to_buses(subtype, el)
+            (any(in(drop_buses), fb) || any(in(drop_buses), tb)) && delete!(xfmr_sub, id)
         end
     end
 

--- a/src/validation/integrity.jl
+++ b/src/validation/integrity.jl
@@ -126,6 +126,18 @@ function integrity_check(net::Dict{String,Any},
         sub isa Dict || continue
         for (id, c) in sub
             c isa Dict || continue
+            if subtype in WINDING_LIST_SUBTYPES
+                # Winding-list buses/terminal_maps live in windings[]; a fixed
+                # bus_from/bus_to check skips them, so dangling references were
+                # never caught for n_winding.
+                for w in get(c, "windings", Any[])
+                    w isa AbstractDict || continue
+                    b = get(w, "bus", nothing)
+                    b isa AbstractString && check_bus_ref("transformer", id, b) &&
+                        check_tmap("transformer", id, b, get(w, "terminal_map", String[]))
+                end
+                continue
+            end
             f = get(c, "bus_from", nothing); t = get(c, "bus_to", nothing)
             f isa AbstractString && check_bus_ref("transformer", id, f) &&
                 check_tmap("transformer", id, f, get(c, "terminal_map_from", String[]))
@@ -687,6 +699,19 @@ function integrity_check(net::Dict{String,Any},
         sub isa Dict || continue
         for (_, c) in sub
             c isa Dict || continue
+            if subtype in WINDING_LIST_SUBTYPES
+                # Winding terminals wire their buses too; omitting them made
+                # n-winding-fed buses look like they had floating/unused terminals.
+                for w in get(c, "windings", Any[])
+                    w isa AbstractDict || continue
+                    b  = get(w, "bus", nothing)
+                    tm = get(w, "terminal_map", nothing)
+                    b isa AbstractString && tm isa AbstractVector || continue
+                    s = get!(branch_terminals, b, Set{String}())
+                    for t in tm; push!(s, string(t)); end
+                end
+                continue
+            end
             for (bus_field, tm_field) in (("bus_from","terminal_map_from"),
                                            ("bus_to",  "terminal_map_to"))
                 b  = get(c, bus_field, nothing)

--- a/test/nwinding_tests.jl
+++ b/test/nwinding_tests.jl
@@ -131,6 +131,54 @@ end
     @test any(x -> x.code == "W.SPEC.XFMR_TMAP_ARITY", f4)
 end
 
+@testset "n_winding — visible to analysis/validation (#291)" begin
+    _b() = Dict{String,Any}("terminal_names" => ["a","b","c","n"],
+                            "perfectly_grounded_terminals" => ["n"])
+    xf = _nw_xfmr([("hv",115.0,0.3),("mv",24.9,0.4),("lv",4.16,0.4)],
+                  Dict("1_2"=>8.0,"1_3"=>8.0,"2_3"=>6.0); s_rating=30e6)
+    net = Dict{String,Any}(
+        "bus" => Dict{String,Any}("hv"=>_b(),"mv"=>_b(),"lv"=>_b()),
+        "voltage_source" => Dict{String,Any}("s"=>Dict{String,Any}("bus"=>"hv",
+            "terminal_map"=>["a","b","c"],"v_magnitude"=>[66395.0,66395.0,66395.0],
+            "v_angle"=>[0.0,-2.0944,2.0944])),
+        "load" => Dict{String,Any}(
+            "lmv"=>Dict{String,Any}("bus"=>"mv","terminal_map"=>["a","b","c","n"],
+                "configuration"=>"WYE","p_nom"=>[5e6,5e6,5e6],"q_nom"=>[1e6,1e6,1e6]),
+            "llv"=>Dict{String,Any}("bus"=>"lv","terminal_map"=>["a","b","c","n"],
+                "configuration"=>"WYE","p_nom"=>[2e6,2e6,2e6],"q_nom"=>[5e5,5e5,5e5])),
+        "transformer" => Dict{String,Any}("n_winding"=>Dict{String,Any}("t1"=>xf)))
+
+    # operational: the n_winding gets a utilisation entry that counts the load
+    # on its downstream (winding 2 & 3) buses — previously skipped entirely.
+    rep = analyze(net)
+    util = rep.results[:operational]["transformer_utilisation"]
+    e = findfirst(x -> x["id"] == "t1", util)
+    @test e !== nothing
+    @test util[e]["s_load_va"] > 20e6            # ≈ 21.5 MVA downstream
+
+    # integrity: a clean n_winding produces no false floating/unused terminals,
+    # and a dangling winding-bus reference IS caught.
+    f = Finding[]; integrity_check(net, f)
+    @test !any(x -> x.code in ("W.INT.FLOATING_LOAD_TERMINAL",
+                               "W.INT.UNUSED_BUS_TERMINAL"), f)
+    bad = deepcopy(net); bad["transformer"]["n_winding"]["t1"]["windings"][2]["bus"] = "ghost"
+    fb = Finding[]; integrity_check(bad, fb)
+    @test any(x -> x.code == "E.INT.UNKNOWN_BUS", fb)
+
+    # fix: an islanded n_winding (no path to a source) is pruned by the
+    # largest-component pass instead of being left dangling.
+    isl = deepcopy(net)
+    isl["bus"]["i1"] = _b(); isl["bus"]["i2"] = _b()
+    isl["transformer"]["n_winding"]["t2"] =
+        _nw_xfmr([("i1",4.16,0.3),("i2",0.4,0.4)], Dict("1_2"=>5.0); s_rating=1e6)
+    isl2, _ = fix_case(isl; recipe=FixRecipe(apply_simplify_network=false,
+        apply_remove_zero_loads=false, apply_low_impedance_to_switch=false,
+        apply_source_bus_bounds=false))
+    @test !haskey(isl2["bus"], "i1")                             # islanded bus dropped
+    @test !haskey(isl2["transformer"]["n_winding"], "t2")        # dangling xfmr pruned
+    @test haskey(isl2["transformer"]["n_winding"], "t1")         # sourced one kept
+end
+
 @testset "n_winding — reactance sign / realisability (physics)" begin
     _net(d) = Dict{String,Any}("transformer" =>
         Dict{String,Any}("n_winding" => Dict{String,Any}("t1" => d)))


### PR DESCRIPTION
Closes #291.

Several generic transformer loops read `bus_from`/`bus_to` and silently skipped winding-list (`n_winding`) transformers, whose buses live in `windings[].bus`:

- **operational.jl** transformer utilisation — n_winding units got **no utilisation entry** and no `W.OPS.XFMR_OVERLOADED` check; `_downstream_load` also couldn't traverse *other* n_winding transformers.
- **der_placement.jl** `_xfmr_downstream` / `_downstream_buses` — same, so a DER below (or fed through) an n_winding transformer got no rating basis.
- **integrity.jl** referential check — dangling winding `bus`/`terminal_map` references were **never caught** (`E.INT.UNKNOWN_BUS`/`UNKNOWN_TERMINAL` dead for n_winding); `branch_terminals` omitted winding terminals, yielding **false** `W.INT.FLOATING_LOAD_TERMINAL` / `UNUSED_BUS_TERMINAL` at n-winding-fed buses.
- **fix.jl** largest-component prune — an n_winding whose winding bus was dropped was left **dangling**.
- **connectivity.jl** supply-phase check — `_xfmr_to_nphase` read `terminal_map_to` (absent), so `W.PROV.PHASE_COUNT_EXCEEDS_SUPPLY` could never fire for an n-winding-fed zone.

### Fix
Add one shared accessor, `_xfmr_from_to_buses(subtype, t)`, returning the `(from, to)` buses for both the two-bus and winding-list shapes (winding 1 → from, the rest → to). The downstream BFS/adjacency helpers now take bus vectors; the referential, branch-terminal and supply-phase checks branch on `WINDING_LIST_SUBTYPES` to read `windings[]`.

### Tests
A `#291` testset in `nwinding_tests.jl` covers the utilisation entry, absence of false floating/unused terminals, the caught dangling-winding reference, and the islanded-n_winding prune. Verified discriminating (pre-fix: 4 failed + 1 errored across all five behaviors). Existing fix/der-placement/regulator/dc suites still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)