### PR TITLE
Count element-level i_max/s_max in thermal completeness (#288)

### DIFF
--- a/src/analysis/provenance/data_quality.jl
+++ b/src/analysis/provenance/data_quality.jl
@@ -169,22 +169,33 @@ function _check_i_max_completeness(net::Dict{String,Any},
                                     findings::Vector{Finding})::Dict{String,Any}
     linecodes  = get(net, "linecode", Dict())
 
-    # Lines: i_max lives on the linecode, indexed by conductor position.
+    # Lines: a thermal limit may sit on the LINE (i_max / s_max, which override
+    # the linecode) or on the LINECODE (i_max / s_max), matching the OPF's
+    # precedence. The branch is only unprotected when none of the four is present.
+    # Element-level effective value: the line's field if set, else the linecode's.
+    _eff(line, lc, key) = begin
+        v = get(line, key, nothing)
+        v !== nothing ? v : (lc === nothing ? nothing : get(lc, key, nothing))
+    end
     incomplete_lines = String[]
     absent_lines     = String[]
     for (lid, line) in get(net, "line", Dict())
-        lcid = get(line, "linecode", nothing)
-        lc   = lcid === nothing ? nothing : get(linecodes, lcid, nothing)
-        i_max = lc === nothing ? nothing : get(lc, "i_max", nothing)
-        if i_max === nothing
+        lcid  = get(line, "linecode", nothing)
+        lc    = lcid === nothing ? nothing : get(linecodes, lcid, nothing)
+        i_max = _eff(line, lc, "i_max")
+        s_max = _eff(line, lc, "s_max")
+        if i_max === nothing && s_max === nothing
             push!(absent_lines, lid)   # no thermal limit anywhere on this branch
             continue
         end
 
+        # Per-conductor completeness applies to the effective i_max (a scalar
+        # applies to every conductor); an s_max-only branch is limited by its
+        # apparent-power cap and is not flagged here.
         n_fr = length(get(line, "terminal_map_from", String[]))
         n_to = length(get(line, "terminal_map_to",   String[]))
         n_c  = min(n_fr, n_to)
-        length(i_max) < n_c && push!(incomplete_lines, lid)
+        i_max isa AbstractVector && length(i_max) < n_c && push!(incomplete_lines, lid)
     end
     if !isempty(incomplete_lines)
         push!(findings, Finding(WARNING, "W.PROV.I_MAX_INCOMPLETE",
@@ -197,19 +208,20 @@ function _check_i_max_completeness(net::Dict{String,Any},
     if !isempty(absent_lines)
         push!(findings, Finding(WARNING, "W.PROV.I_MAX_ABSENT",
             :provenance, :line, nothing,
-            "$(length(absent_lines)) line(s) have no `i_max` on their linecode " *
-            "(or no linecode at all) — their series current is left entirely " *
-            "unconstrained in the OPF, so no thermal limit is enforced on the branch.",
+            "$(length(absent_lines)) line(s) have no `i_max` or `s_max` on the line " *
+            "or its linecode (or no linecode at all) — their series current is left " *
+            "entirely unconstrained in the OPF, so no thermal limit is enforced on the branch.",
             Dict{String,Any}("lines" => absent_lines)))
     end
 
-    # Switches: i_max is on the switch element itself.
+    # Switches: i_max / s_max are on the switch element itself.
     incomplete_switches = String[]
     absent_switches     = String[]
     for (sid, sw) in get(net, "switch", Dict())
         sw isa Dict || continue
         i_max = get(sw, "i_max", nothing)
-        if i_max === nothing
+        s_max = get(sw, "s_max", nothing)
+        if i_max === nothing && s_max === nothing
             # An open switch carries zero current by construction, so a missing
             # limit only leaves a *closed* switch unprotected.
             get(sw, "open_switch", false) || push!(absent_switches, sid)
@@ -219,7 +231,7 @@ function _check_i_max_completeness(net::Dict{String,Any},
         n_fr = length(get(sw, "terminal_map_from", String[]))
         n_to = length(get(sw, "terminal_map_to",   String[]))
         n_c  = min(n_fr, n_to)
-        length(i_max) < n_c && push!(incomplete_switches, sid)
+        i_max isa AbstractVector && length(i_max) < n_c && push!(incomplete_switches, sid)
     end
     if !isempty(incomplete_switches)
         push!(findings, Finding(WARNING, "W.PROV.I_MAX_INCOMPLETE_SWITCH",
@@ -231,9 +243,9 @@ function _check_i_max_completeness(net::Dict{String,Any},
     if !isempty(absent_switches)
         push!(findings, Finding(WARNING, "W.PROV.I_MAX_ABSENT_SWITCH",
             :provenance, :switch, nothing,
-            "$(length(absent_switches)) closed switch(es) have no `i_max` — their " *
-            "current is left entirely unconstrained in the OPF, so no thermal limit " *
-            "is enforced on the branch.",
+            "$(length(absent_switches)) closed switch(es) have no `i_max` or `s_max` " *
+            "— their current is left entirely unconstrained in the OPF, so no thermal " *
+            "limit is enforced on the branch.",
             Dict{String,Any}("switches" => absent_switches)))
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1373,6 +1373,37 @@ const IEEE13_FIXTURE = """
         @test any(x -> x.code == "W.DOM.ANGLE_UNITS", f7)
         @test any(x -> x.code == "I.DOM.NEGATIVE_LOAD", f7)
 
+        # i_max completeness (#288): an element-level i_max OR any s_max (line or
+        # linecode) counts as a thermal limit — a branch is only "absent" when
+        # NONE of them is present. Previously only the linecode's i_max was read,
+        # so a line-level override or an s_max-only branch was a false positive.
+        _absent(n) = (fa = Finding[]; provenance_analysis(n, fa);
+                      Set(x.code for x in fa
+                          if x.code in ("W.PROV.I_MAX_ABSENT", "W.PROV.I_MAX_ABSENT_SWITCH")))
+        _mkln(le, sce) = Dict{String,Any}(
+            "bus" => Dict{String,Any}(
+                "a" => Dict{String,Any}("terminal_names" => ["1","2","3","n"]),
+                "b" => Dict{String,Any}("terminal_names" => ["1","2","3","n"])),
+            "linecode" => Dict{String,Any}("lc" => merge(Dict{String,Any}("R_series_1_1"=>0.1), sce)),
+            "line" => Dict{String,Any}("l" => merge(Dict{String,Any}(
+                "bus_from"=>"a", "bus_to"=>"b", "linecode"=>"lc",
+                "terminal_map_from"=>["1","2","3","n"], "terminal_map_to"=>["1","2","3","n"]), le)))
+        # line-level i_max only (no linecode i_max) → NOT absent
+        @test isempty(_absent(_mkln(Dict{String,Any}("i_max"=>[100.0,100.0,100.0,100.0]),
+                                    Dict{String,Any}())))
+        # s_max only → NOT absent
+        @test isempty(_absent(_mkln(Dict{String,Any}("s_max"=>[5e4,5e4,5e4,5e4]),
+                                    Dict{String,Any}())))
+        # no limit anywhere → absent
+        @test "W.PROV.I_MAX_ABSENT" in _absent(_mkln(Dict{String,Any}(), Dict{String,Any}()))
+        # closed switch with only s_max → NOT absent
+        swnet = _mkln(Dict{String,Any}(), Dict{String,Any}("i_max"=>[100.0,100.0,100.0,100.0]))
+        swnet["switch"] = Dict{String,Any}("sw" => Dict{String,Any}(
+            "bus_from"=>"a", "bus_to"=>"b", "open_switch"=>false,
+            "terminal_map_from"=>["1","2","3","n"], "terminal_map_to"=>["1","2","3","n"],
+            "s_max"=>[5e4,5e4,5e4,5e4]))
+        @test "W.PROV.I_MAX_ABSENT_SWITCH" ∉ _absent(swnet)
+
         # combined thermal limits (i_max + s_max) on a line → redundancy warning
         net_dual = deepcopy(base)
         net_dual["line"]["l650632"]["i_max"] = [600.0, 600.0, 600.0]


### PR DESCRIPTION
Closes #288.

`_check_i_max_completeness` read only the **linecode's** `i_max` for lines, and only `i_max` (not `s_max`) for switches. So it emitted false `W.PROV.I_MAX_ABSENT` / `W.PROV.I_MAX_ABSENT_SWITCH` findings on branches the OPF actually limits:
- a **line-level `i_max`** override (which the OPF prefers over the linecode), or
- an **`s_max`** apparent-power cap (on the line or linecode).

This directly contradicted `operational.jl`'s own limit check, which considers all four sources.

### Fix
Read the *effective* limit set — the line's `i_max`/`s_max` if present, else the linecode's — and flag a branch as unprotected only when **none** is present. The per-conductor "incomplete" check now uses the effective `i_max` (a scalar applies to every conductor; an `s_max`-only branch is limited by its apparent-power cap and isn't flagged there). Switches gain the same `s_max` awareness.

### Tests
A line-level `i_max`, an `s_max`-only line, and an `s_max`-only closed switch are no longer false positives; a truly unlimited branch still reports absent. Verified against the check; provenance-using suites (augmentation, regulator) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)