### PR TITLE
Fix DER/IBR placement determinism and sizing (#284, #285)

### DIFF
--- a/src/augmentation/der_placement.jl
+++ b/src/augmentation/der_placement.jl
@@ -179,7 +179,9 @@ function _apply_der_placement!(net′::Dict{String,Any},
             (lvl === nothing || !(lvl in recipe.voltage_levels)) && continue
         end
         agg = loads[bus]
-        sum(agg.p_nom) < recipe.min_local_load_va && continue
+        # min_local_load_va is a VA threshold — compare against apparent power
+        # |S| = √(ΣP² + ΣQ²), not active power alone.
+        hypot(sum(agg.p_nom), sum(agg.q_nom)) < recipe.min_local_load_va && continue
         # overwrite guard
         if !recipe.overwrite_existing && _bus_has_generator(net′, bus)
             continue
@@ -269,7 +271,10 @@ function _basis_total(recipe::GeneratorRecipe, bus::String, agg, xfmr)
     elseif recipe.size_basis == :fraction_of_downstream_load
         info = get(xfmr.bus_info, bus, nothing)
         info === nothing && return local_total, "p_max = $(recipe.der_p_fraction) × local load (no downstream context)"
-        return local_total, "p_max = $(recipe.der_p_fraction) × downstream-load share at bus"
+        # Size from the load DOWNSTREAM of the feeding transformer, not the local
+        # bus load (which was returned before, making this identical to
+        # :fraction_of_local_load).
+        return info.down_total, "p_max = $(recipe.der_p_fraction) × downstream load $(round(info.down_total)) VA"
     else
         error("unknown GeneratorRecipe.size_basis = $(recipe.size_basis)")
     end
@@ -283,9 +288,13 @@ function _size_der(recipe::GeneratorRecipe, p_nom::Vector{Float64},
     total = recipe.size_basis == :fixed_tiers ?
         get(recipe.fixed_tier_w, level, 0.0) :
         recipe.der_p_fraction * basis_total
-    s = sum(p_nom)
-    weights = s > 0 ? p_nom ./ s : fill(1.0 / n, n)
-    total .* weights
+    # Distribute by per-phase load MAGNITUDE and keep the result non-negative:
+    # a phase with negative p_nom (embedded generation) or a negative basis must
+    # not produce a negative p_max (an inverted/unphysical bound).
+    w  = abs.(p_nom)
+    sw = sum(w)
+    weights = sw > 0 ? w ./ sw : fill(1.0 / n, n)
+    abs(total) .* weights
 end
 
 # ── Cost ─────────────────────────────────────────────────────────────────────
@@ -377,7 +386,12 @@ end
 # p_nom summed elementwise over loads with matching phase count.
 function _collect_load_aggregates(net)::Dict{String,NamedTuple}
     out = Dict{String,NamedTuple}()
-    for (_, l) in get(net, "load", Dict())
+    # Iterate loads in a deterministic (sorted-id) order so the phasing and
+    # configuration a multi-load bus inherits from its "first" load is stable
+    # rather than dependent on Dict iteration order.
+    loaddict = get(net, "load", Dict())
+    for lid in sort!(collect(keys(loaddict)))
+        l = loaddict[lid]
         l isa Dict || continue
         bus = string(get(l, "bus", ""))
         isempty(bus) && continue
@@ -385,15 +399,18 @@ function _collect_load_aggregates(net)::Dict{String,NamedTuple}
         cfg = string(get(l, "configuration", "WYE"))
         pn  = Float64.(get(l, "p_nom", Float64[]))
         isempty(pn) && continue
+        qn  = Float64.(get(l, "q_nom", Float64[]))
+        length(qn) == length(pn) || (qn = zeros(length(pn)))
         if haskey(out, bus)
             prev = out[bus]
             if length(prev.p_nom) == length(pn)
                 out[bus] = (terminal_map = prev.terminal_map,
                             configuration = prev.configuration,
-                            p_nom = prev.p_nom .+ pn)
+                            p_nom = prev.p_nom .+ pn,
+                            q_nom = prev.q_nom .+ qn)
             end
         else
-            out[bus] = (terminal_map = tm, configuration = cfg, p_nom = pn)
+            out[bus] = (terminal_map = tm, configuration = cfg, p_nom = pn, q_nom = qn)
         end
     end
     out
@@ -402,8 +419,9 @@ end
 # Map each downstream load bus to its feeding transformer's rating and the
 # transformer's total downstream load, for transformer-rating-based sizing.
 function _xfmr_downstream(net, loads)
-    bus_info = Dict{String,NamedTuple}()
+    # Collect each rated transformer's downstream set once.
     xfmr = get(net, "transformer", Dict())
+    entries = Tuple{String,Float64,Set{String},Float64}[]
     for subtype in TRANSFORMER_SUBTYPES
         sub = get(xfmr, subtype, nothing)
         sub isa Dict || continue
@@ -415,11 +433,20 @@ function _xfmr_downstream(net, loads)
             isempty(to_buses) && continue
             down = _downstream_buses(net, string(id), to_buses)
             down_total = sum(Float64[sum(loads[b].p_nom) for b in down if haskey(loads, b)]; init = 0.0)
-            for b in down
-                haskey(loads, b) || continue
-                haskey(bus_info, b) && continue   # nearest transformer wins
-                bus_info[b] = (xfmr_id = string(id), s_rating = s_rating, down_total = down_total)
-            end
+            push!(entries, (string(id), s_rating, down, down_total))
+        end
+    end
+    # "Nearest transformer wins": the one whose downstream set is SMALLEST among
+    # those containing the bus (a more-downstream unit's set is a subset). Sort by
+    # (set size, id) so the assignment is deterministic — the previous first-claim
+    # over Dict iteration order was not.
+    sort!(entries, by = e -> (length(e[3]), e[1]))
+    bus_info = Dict{String,NamedTuple}()
+    for (id, s_rating, down, down_total) in entries
+        for b in down
+            haskey(loads, b) || continue
+            haskey(bus_info, b) && continue
+            bus_info[b] = (xfmr_id = id, s_rating = s_rating, down_total = down_total)
         end
     end
     (bus_info = bus_info,)

--- a/src/augmentation/ibr.jl
+++ b/src/augmentation/ibr.jl
@@ -118,8 +118,18 @@ function _apply_ibr_augmentation!(net′::Dict{String,Any},
         # ── P bounds ─────────────────────────────────────────────────────────
         if !haskey(inv, "p_max")
             p_avail = get(inv, "p_avail", nothing)
+            has_smax = length(smax_arr) >= n_phase && sum(@view smax_arr[1:n_phase]) > 0
             p_max_vec = if p_avail isa Number
-                fill(Float64(p_avail) / n_phase, n_phase)
+                if has_smax
+                    # Split p_avail PROPORTIONALLY to each phase's s_max so no
+                    # phase's p_max exceeds its own apparent-power rating. An equal
+                    # ÷n_phase split puts p_max[k] > s_max[k] on a lightly loaded
+                    # phase when s_max mirrors an unbalanced load shape.
+                    sm = smax_arr[1:n_phase]
+                    Float64(p_avail) .* (sm ./ sum(sm))
+                else
+                    fill(Float64(p_avail) / n_phase, n_phase)
+                end
             elseif length(smax_arr) >= n_phase
                 smax_arr[1:n_phase]
             else
@@ -127,8 +137,9 @@ function _apply_ibr_augmentation!(net′::Dict{String,Any},
             end
             if p_max_vec !== nothing
                 inv["p_max"] = p_max_vec
-                src = p_avail !== nothing ? "p_avail ÷ $(n_phase) phase(s)" :
-                                            "s_max per phase"
+                src = p_avail !== nothing ?
+                    (has_smax ? "p_avail split ∝ per-phase s_max" : "p_avail ÷ $(n_phase) phase(s)") :
+                    "s_max per phase"
                 push!(entries, TransformEntry(
                     :ibr, inv_id, "p_max", nothing, p_max_vec,
                     "ibr_p_bound", :standard,

--- a/src/augmentation/ibr_placement.jl
+++ b/src/augmentation/ibr_placement.jl
@@ -294,7 +294,9 @@ function _apply_ibr_placement!(net′::Dict{String,Any},
             (lvl === nothing || !(lvl in recipe.voltage_levels)) && continue
         end
         agg = loads[bus]
-        sum(agg.p_nom) < recipe.min_local_load_va && continue
+        # min_local_load_va is a VA threshold — compare against apparent power
+        # |S| = √(ΣP² + ΣQ²), not active power alone.
+        hypot(sum(agg.p_nom), sum(agg.q_nom)) < recipe.min_local_load_va && continue
         if !recipe.overwrite_existing && _bus_has_ibr(net′, bus)
             continue
         end
@@ -388,7 +390,10 @@ function _ibr_basis_total(recipe::IBRRecipe, bus::String, agg, xfmr)
     elseif recipe.size_basis == :fraction_of_downstream_load
         info = get(xfmr.bus_info, bus, nothing)
         info === nothing && return local_total, "s_max = $(recipe.s_fraction) × local load (no downstream context)"
-        return local_total, "s_max = $(recipe.s_fraction) × downstream-load share at bus"
+        # Size from the load DOWNSTREAM of the feeding transformer, not the local
+        # bus load (which was returned before, making this identical to
+        # :fraction_of_local_load).
+        return info.down_total, "s_max = $(recipe.s_fraction) × downstream load $(round(info.down_total)) VA"
     else
         error("unknown IBRRecipe.size_basis = $(recipe.size_basis)")
     end
@@ -402,9 +407,13 @@ function _size_ibr(recipe::IBRRecipe, p_nom::Vector{Float64},
     total = recipe.size_basis == :fixed_tiers ?
         get(recipe.fixed_tier_va, level, 0.0) :
         recipe.s_fraction * basis_total
-    s = sum(p_nom)
-    weights = s > 0 ? p_nom ./ s : fill(1.0 / n, n)
-    total .* weights
+    # Distribute by per-phase load MAGNITUDE and keep the result non-negative:
+    # a phase with negative p_nom (embedded generation) or a negative basis must
+    # not produce a negative s_max (a schema-invalid, inverted rating).
+    w  = abs.(p_nom)
+    sw = sum(w)
+    weights = sw > 0 ? w ./ sw : fill(1.0 / n, n)
+    abs(total) .* weights
 end
 
 # Per-phase linear dispatch cost, mirroring _cost_der (der_placement.jl). Kept

--- a/test/ibr_placement_tests.jl
+++ b/test/ibr_placement_tests.jl
@@ -302,3 +302,89 @@ end
     @test !haskey(b, "p_dc_min")
     @test !haskey(b, "p_dc_max")
 end
+
+# ── I16: DER/IBR sizing determinism & math (#284, #285) ──────────────────────
+# A feeder src → tx(30 kVA) → mv → line → lv, with load on mv (3 kVA) and lv (6 kVA).
+_inv_xfmr_net() = Dict{String,Any}(
+  "bus"=>Dict{String,Any}(
+    "src"=>Dict{String,Any}("terminal_names"=>["1","2","3","n"],"perfectly_grounded_terminals"=>["n"]),
+    "mv"=>Dict{String,Any}("terminal_names"=>["1","2","3","n"],"perfectly_grounded_terminals"=>["n"]),
+    "lv"=>Dict{String,Any}("terminal_names"=>["1","2","3","n"],"perfectly_grounded_terminals"=>["n"])),
+  "voltage_source"=>Dict{String,Any}("vs"=>Dict{String,Any}("bus"=>"src","terminal_map"=>["1","2","3"],
+     "v_magnitude"=>[6350.0,6350.0,6350.0],"v_angle"=>[0.0,-2.0944,2.0944])),
+  "transformer"=>Dict{String,Any}("single_phase"=>Dict{String,Any}("tx"=>Dict{String,Any}(
+     "bus_from"=>"src","bus_to"=>"mv","terminal_map_from"=>["1","2","3"],"terminal_map_to"=>["1","2","3"],
+     "s_rating"=>30000.0,"v_nom_from"=>11000.0,"v_nom_to"=>400.0,
+     "r_series_from"=>1.0,"r_series_to"=>0.01,"x_series_from"=>5.0,"x_series_to"=>0.05))),
+  "linecode"=>Dict{String,Any}("lc"=>Dict{String,Any}("R_series_1_1"=>0.1,"R_series_2_2"=>0.1,"R_series_3_3"=>0.1)),
+  "line"=>Dict{String,Any}("l"=>Dict{String,Any}("bus_from"=>"mv","bus_to"=>"lv","linecode"=>"lc","length"=>50.0,
+     "terminal_map_from"=>["1","2","3"],"terminal_map_to"=>["1","2","3"])),
+  "load"=>Dict{String,Any}(
+    "lmv"=>Dict{String,Any}("bus"=>"mv","terminal_map"=>["1","2","3","n"],"configuration"=>"WYE","p_nom"=>[1000.0,1000.0,1000.0],"q_nom"=>[0.0,0.0,0.0]),
+    "llv"=>Dict{String,Any}("bus"=>"lv","terminal_map"=>["1","2","3","n"],"configuration"=>"WYE","p_nom"=>[2000.0,2000.0,2000.0],"q_nom"=>[0.0,0.0,0.0])))
+
+@testset "I16a: :fraction_of_downstream_load sizes from downstream, not local (#285)" begin
+    net = _inv_xfmr_net()
+    nd, _ = add_ibrs(net; recipe = IBRRecipe(size_basis = :fraction_of_downstream_load,
+                                             s_fraction = 1.0, strategy = :load_following))
+    nl, _ = add_ibrs(net; recipe = IBRRecipe(size_basis = :fraction_of_local_load,
+                                             s_fraction = 1.0, strategy = :load_following))
+    # mv sees the whole downstream load (mv + lv = 9 kVA), not just its local 3 kVA.
+    @test sum(nd["ibr"]["pv_mv"]["s_max"]) > sum(nl["ibr"]["pv_mv"]["s_max"]) + 1.0
+    @test sum(nd["ibr"]["pv_mv"]["s_max"]) ≈ 9000.0 rtol = 1e-6
+end
+
+@testset "I16b: negative local load never yields a negative rating (#285)" begin
+    net = _inv_xfmr_net()
+    net["load"]["llv"]["p_nom"] = [-2000.0, -2000.0, -2000.0]   # embedded generation
+    nn, _ = add_ibrs(net; recipe = IBRRecipe(size_basis = :fraction_of_local_load,
+                                             s_fraction = 1.0, strategy = :load_following))
+    @test all(nn["ibr"]["pv_lv"]["s_max"] .>= 0.0)
+    @test sum(nn["ibr"]["pv_lv"]["s_max"]) ≈ 6000.0 rtol = 1e-6   # sized by magnitude
+end
+
+@testset "I16c: min_local_load_va is an apparent-power threshold (#285)" begin
+    net = _inv_xfmr_net()
+    # Small active, large reactive: |S| ≈ 6 kVA ≫ 1 kVA, but ΣP = 300 W < 1 kVA.
+    net["load"]["llv"]["p_nom"] = [100.0, 100.0, 100.0]
+    net["load"]["llv"]["q_nom"] = [2000.0, 2000.0, 2000.0]
+    nq, _ = add_ibrs(net; recipe = IBRRecipe(size_basis = :fraction_of_local_load,
+                       s_fraction = 1.0, strategy = :load_following, min_local_load_va = 1000.0))
+    @test haskey(nq["ibr"], "pv_lv")   # not skipped: |S| clears the VA threshold
+end
+
+@testset "I16d: p_avail split ∝ s_max keeps p_max ≤ s_max per phase (#285)" begin
+    net = _inv_xfmr_net()
+    net["load"]["llv"]["p_nom"] = [3000.0, 1000.0, 500.0]   # unbalanced
+    np, _  = add_ibrs(net; recipe = IBRRecipe(size_basis = :fraction_of_local_load,
+                                              s_fraction = 1.0, strategy = :load_following))
+    npa, _ = augment_case(np)
+    inv = npa["ibr"]["pv_lv"]
+    @test all(inv["p_max"] .<= inv["s_max"] .+ 1e-6)   # equal split would violate this
+end
+
+@testset "I16e: nearest transformer wins deterministically (#284)" begin
+    # src → t1(HV/MV) → mv → t2(MV/LV) → lv. Bus lv is downstream of BOTH; the
+    # NEARER (smaller downstream set) transformer t2 must own it, every run.
+    net = _inv_xfmr_net()
+    net["bus"]["lv2"] = Dict{String,Any}("terminal_names"=>["1","2","3","n"],"perfectly_grounded_terminals"=>["n"])
+    net["transformer"]["single_phase"]["t2"] = Dict{String,Any}(
+        "bus_from"=>"lv","bus_to"=>"lv2","terminal_map_from"=>["1","2","3"],"terminal_map_to"=>["1","2","3"],
+        "s_rating"=>10000.0,"v_nom_from"=>400.0,"v_nom_to"=>230.0,
+        "r_series_from"=>0.1,"r_series_to"=>0.01,"x_series_from"=>0.5,"x_series_to"=>0.05)
+    net["load"]["llv2"] = Dict{String,Any}("bus"=>"lv2","terminal_map"=>["1","2","3","n"],
+        "configuration"=>"WYE","p_nom"=>[500.0,500.0,500.0],"q_nom"=>[0.0,0.0,0.0])
+    ids = String[]
+    sized = Float64[]
+    for _ in 1:5
+        nd, _ = add_ibrs(net; recipe = IBRRecipe(size_basis = :fraction_of_transformer_rating,
+                                                 s_fraction = 0.5, strategy = :load_following))
+        push!(sized, sum(nd["ibr"]["pv_lv2"]["s_max"]))
+    end
+    # lv2's basis must be the NEAREST transformer t2 (10 kVA, load-share 1) →
+    # s_max = 0.5 × 10 kVA = 5 kVA, deterministically. The far transformer t1
+    # (30 kVA, small share) would give ~2.1 kVA; which one won used to depend on
+    # Dict iteration order.
+    @test length(unique(round.(sized; digits = 3))) == 1
+    @test sized[1] ≈ 5000.0 rtol = 1e-3
+end


### PR DESCRIPTION
Closes #284. Closes #285.

### Determinism (#284)
- **`_xfmr_downstream`** assigned each bus to the *first-iterated* transformer over Dict order, not the "nearest" (its comment claimed). Now sorts transformers by `(downstream-set size, id)`, so the nearest (smallest set containing the bus) wins deterministically.
- **`_collect_load_aggregates`** let Dict iteration order decide which load fixed a multi-load bus's phasing/configuration. Now iterates loads in sorted-id order.

### Sizing (#285)
- **`:fraction_of_downstream_load`** returned the *local* load (making it identical to `:fraction_of_local_load`) and ignored the computed `down_total`. Now sizes from the transformer's downstream load.
- **`_size_der`/`_size_ibr`** distributed by the *signed* `p_nom`, so a negative per-phase load (embedded generation) or a negative basis produced a **negative** `p_max`/`s_max`. Now distribute by load **magnitude** and keep the result non-negative.
- **`p_avail`** was split *equally* across phases while `s_max` mirrored an unbalanced load, so `p_max[k]` could exceed `s_max[k]`. Now split `p_avail` **proportionally to per-phase `s_max`**, so `p_max[k] ≤ s_max[k]`.
- **`min_local_load_va`** (a VA-named threshold) compared active power only; now compares apparent power `|S| = √(ΣP² + ΣQ²)` (`q_nom` threaded through the aggregate).

### Tests
Testset `I16` (a–e): downstream basis > local, negative-load never negative-rated, `min_local_load_va` clears on a reactive-only bus, `p_avail` split keeps `p_max ≤ s_max`, and the nearest transformer wins deterministically (`≈ 5 kVA`, not the far transformer's `~2.1 kVA`). Verified discriminating; existing der/ibr/augmentation suites still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)