### PR TITLE
Harden fix_case robustness (#286)

### DIFF
--- a/src/augmentation/fix.jl
+++ b/src/augmentation/fix.jl
@@ -126,7 +126,7 @@ function fix_case(net::Dict{String,Any};
 
     manifest = TransformationManifest(
         string(Dates.now()),
-        AugmentationRecipe(),   # placeholder — FixRecipe is recorded via entries
+        recipe,                 # the actual FixRecipe (manifest.recipe is ::Any)
         entries,
         fb,
         fa,
@@ -138,6 +138,15 @@ end
 # ── Pass helpers ─────────────────────────────────────────────────────────────
 
 # Pass 1: drop everything not reachable from a voltage source
+# Return `base` if free in `existing`, else `base_2`, `base_3`, … — so a
+# generated element id never silently overwrites a pre-existing one.
+function _unique_id(existing, base::AbstractString)::String
+    haskey(existing, base) || return String(base)
+    k = 2
+    while haskey(existing, "$(base)_$k"); k += 1; end
+    "$(base)_$k"
+end
+
 function _fix_largest_component!(net′, entries)
     conn = connectivity_analysis(net′, Finding[])
     conn["is_connected"] && return   # nothing to do
@@ -145,6 +154,18 @@ function _fix_largest_component!(net′, entries)
     source_buses = Set{String}(get(conn, "source_buses", String[]))
     comps = get(conn, "components", Vector{Vector{String}}[])
     isempty(comps) && return
+
+    # With no voltage source, EVERY component is unsourced and the pass below
+    # would delete the entire network — never the intent. Bail with a finding so
+    # a later source/generator augmentation can still act on the intact net.
+    if isempty(source_buses)
+        push!(entries, TransformEntry(
+            :network, "(topology)", "no_source", nothing, nothing,
+            "connectivity_analysis", :standard,
+            "No voltage source in the network — largest-component pruning skipped " *
+            "(dropping every unsourced component would delete the whole network)."))
+        return
+    end
 
     # Which components contain at least one source bus?
     keep_buses = Set{String}()
@@ -286,7 +307,7 @@ function _fix_low_impedance!(net′, entries, threshold_ohm)
         i_max = get(line, "i_max", nothing)
         i_max === nothing && lc isa Dict && (i_max = get(lc, "i_max", nothing))
         i_max !== nothing && (sw["i_max"] = deepcopy(i_max))
-        sw_id = "_sw_$(id)"
+        sw_id = _unique_id(switches, "_sw_$(id)")
         switches[sw_id] = sw
         delete!(lines, id)
 
@@ -448,13 +469,9 @@ function _infer_and_write_i_max!(el, etype, eid, adj, entries)
         push!(sources, "$(ntype)/$(nid)")
     end
 
-    if isempty(bounds)
-        push!(entries, TransformEntry(
-            etype, eid, "i_max", nothing, nothing,
-            "adjacent_current_bound", :low,
-            "no adjacent element with a current bound found"))
-        return
-    end
+    # Nothing was written when no neighbour carries a bound — do not record a
+    # change entry for a no-op (it would over-count changes in the manifest).
+    isempty(bounds) && return
 
     derived = minimum(bounds)
     # i_max is per-conductor in the data model (and the solution checker only
@@ -635,7 +652,7 @@ function _fix_shunt_to_capacitor!(net′, entries)
         any(isnothing, idx) && continue
         maximum(abs.(B2[idx, idx] .- B)) <= 1e-7 * bscale || continue
 
-        new_id = "cap_$(id)"
+        new_id = _unique_id(caps, "cap_$(id)")
         caps[new_id] = cand
         delete!(shunts, id)
         push!(entries, TransformEntry(

--- a/test/fix_tests.jl
+++ b/test/fix_tests.jl
@@ -713,6 +713,52 @@ end
         @test !any(x -> x.code == "W.SPEC.CONFIG_ARITY" && x.component_id == "cap_sh", f)
     end
 
+    @testset "T11: fix_case robustness (#286)" begin
+        # (a) A disconnected network with NO voltage source must not be wiped by
+        # the largest-component pass (every component would look unsourced).
+        net = Dict{String,Any}(
+            "bus" => Dict{String,Any}(
+                "a"=>Dict{String,Any}("terminal_names"=>["1","n"]),
+                "b"=>Dict{String,Any}("terminal_names"=>["1","n"]),
+                "c"=>Dict{String,Any}("terminal_names"=>["1","n"]),
+                "d"=>Dict{String,Any}("terminal_names"=>["1","n"])),
+            "linecode" => Dict{String,Any}("lc"=>Dict{String,Any}("R_series_1_1"=>0.1)),
+            "line" => Dict{String,Any}(
+                "l1"=>Dict{String,Any}("bus_from"=>"a","bus_to"=>"b","linecode"=>"lc","length"=>10.0,
+                    "terminal_map_from"=>["1","n"],"terminal_map_to"=>["1","n"]),
+                "l2"=>Dict{String,Any}("bus_from"=>"c","bus_to"=>"d","linecode"=>"lc","length"=>10.0,
+                    "terminal_map_from"=>["1","n"],"terminal_map_to"=>["1","n"])))
+        net′, mf = fix_case(net; recipe=FixRecipe(apply_simplify_network=false,
+            apply_remove_zero_loads=false, apply_low_impedance_to_switch=false,
+            apply_source_bus_bounds=false))
+        @test length(net′["bus"]) == 4                                # not wiped
+        @test any(e -> occursin("No voltage source", e.note), mf.entries)
+        # The manifest records the actual FixRecipe, not a placeholder recipe.
+        @test mf.recipe isa FixRecipe
+
+        # (b) A generated switch id that collides with an existing element does
+        # not overwrite it — the new switch gets a unique id.
+        net2 = Dict{String,Any}(
+            "bus" => Dict{String,Any}(
+                "src"=>Dict{String,Any}("terminal_names"=>["1","n"],"perfectly_grounded_terminals"=>["n"]),
+                "b1"=>Dict{String,Any}("terminal_names"=>["1","n"],"perfectly_grounded_terminals"=>["n"]),
+                "b2"=>Dict{String,Any}("terminal_names"=>["1","n"],"perfectly_grounded_terminals"=>["n"])),
+            "voltage_source" => Dict{String,Any}("vs"=>Dict{String,Any}("bus"=>"src",
+                "terminal_map"=>["1"],"v_magnitude"=>[230.0],"v_angle"=>[0.0])),
+            "linecode" => Dict{String,Any}("lc0"=>Dict{String,Any}("R_series_1_1"=>1e-10)),
+            "line" => Dict{String,Any}("l1"=>Dict{String,Any}("bus_from"=>"src","bus_to"=>"b1",
+                "linecode"=>"lc0","length"=>1.0,"terminal_map_from"=>["1","n"],"terminal_map_to"=>["1","n"])),
+            "switch" => Dict{String,Any}("_sw_l1"=>Dict{String,Any}("bus_from"=>"b1","bus_to"=>"b2",
+                "open_switch"=>false,"terminal_map_from"=>["1","n"],"terminal_map_to"=>["1","n"])),
+            "load" => Dict{String,Any}("ld"=>Dict{String,Any}("bus"=>"b2","terminal_map"=>["1","n"],
+                "configuration"=>"SINGLE_PHASE","p_nom"=>[1e3],"q_nom"=>[0.0])))
+        n2, _ = fix_case(net2; recipe=FixRecipe(apply_largest_component=false,
+            apply_simplify_network=false, apply_remove_zero_loads=false,
+            apply_source_bus_bounds=false))
+        @test haskey(n2["switch"], "_sw_l1")          # existing switch preserved
+        @test length(n2["switch"]) == 2               # new switch got a unique id
+    end
+
     @testset "T10: Snap placeholder transformer leakage (opt-in)" begin
         # Z_base = 11000²/50000 = 2420 Ω.
         mknet(xf) = Dict{String,Any}(


### PR DESCRIPTION
Closes #286.

- **`_fix_largest_component!` with no voltage source** dropped *every* (unsourced) component, deleting the whole network. Now it bails with a finding, leaving the net intact for a later source/generator augmentation.
- **Generated element ids** (`_sw_<line>`, `cap_<shunt>`) silently overwrote a pre-existing element of the same name. New `_unique_id` appends a suffix on collision.
- **Manifest provenance:** the manifest recorded a placeholder `AugmentationRecipe()` instead of the actual `FixRecipe` (the field is `::Any`, so the real recipe fits).
- **Manifest over-counting:** the adjacent-current-bound pass pushed a "no adjacent bound found" `TransformEntry` into the *change* manifest even though nothing was written. It now just returns.

### Tests
`T11` covers the empty-source wipe (4-bus disconnected net kept, not emptied), the `FixRecipe` provenance, and the id-collision guard (existing `_sw_l1` preserved, new switch gets a unique id). Verified discriminating (pre-fix: 4 failures); existing fix suite still passes.

### Not addressed
The DC network is not swept by the largest-component pass, but DC buses are not part of the AC connectivity graph, so this is an *unpowered-island* situation (already flagged by `W.DOM.DC_BUS_NO_CONVERTER`) rather than a dangling-reference bug. Left for separate DC-topology work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)