### PR TITLE
Extend ingest walkers to n_winding windings, capacitors, earth-5 (#280)

### DIFF
--- a/src/io/from_dss.jl
+++ b/src/io/from_dss.jl
@@ -220,11 +220,18 @@ function _canonicalize_identifiers!(net::Dict{String,Any})
         foldref!(c, "bus_from"); foldref!(c, "bus_to")
     end
     if xfmr isa Dict
-        for (_, sub) in xfmr
+        for (subtype, sub) in xfmr
             sub isa Dict || continue
             for (_, c) in sub
                 c isa Dict || continue
                 foldref!(c, "bus_from"); foldref!(c, "bus_to")
+                # Winding-list (n_winding) transformers reference their buses via
+                # windings[i].bus, which the bus_from/bus_to fold does not reach.
+                if subtype in WINDING_LIST_SUBTYPES
+                    for w in get(c, "windings", Any[])
+                        w isa AbstractDict && foldref!(w, "bus")
+                    end
+                end
             end
         end
     end
@@ -278,7 +285,12 @@ function _remap_opendss_terminals!(net::Dict{String,Any})
         let g = get(bus, "perfectly_grounded_terminals", nothing)
             g isa Vector &&
                 (bus["perfectly_grounded_terminals"] =
-                     unique(t == "4" ? "n" : string(t) for t in g))
+                     unique(t == "4" ? "n" : string(t)
+                            for t in g if string(t) != "5"))
+            # "5" is the earth terminal: it is routed to the neutral and recorded
+            # under _meta (grounded THROUGH the neutral, not solidly), so it must
+            # be dropped here rather than left as a dangling reference to a
+            # terminal that "5"→"n" removed from terminal_names.
         end
         rename_maps[bus_id] = rmap
         "5" in str_names && push!(earth_routed, bus_id)

--- a/src/io/parse_bmopf.jl
+++ b/src/io/parse_bmopf.jl
@@ -146,7 +146,7 @@ function each_terminal_array(f, net::Dict{String,Any})
         end
     end
     for comp_type in ("bus", "line", "load", "generator", "voltage_source",
-                      "shunt", "switch", "ibr")
+                      "shunt", "switch", "ibr", "capacitor")
         components = get(net, comp_type, nothing)
         components isa Dict || continue
         foreach(visit, values(components))
@@ -156,7 +156,15 @@ function each_terminal_array(f, net::Dict{String,Any})
         for subtype in TRANSFORMER_SUBTYPES
             sub = get(xfmr, subtype, nothing)
             sub isa Dict || continue
-            foreach(visit, values(sub))
+            for t in values(sub)
+                visit(t)
+                # Winding-list (n_winding) transformers carry terminal maps inside
+                # windings[i], which the top-level visit does not reach.
+                if subtype in WINDING_LIST_SUBTYPES && t isa Dict
+                    ws = get(t, "windings", nothing)
+                    ws isa AbstractVector && foreach(visit, ws)
+                end
+            end
         end
     end
     nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2042,6 +2042,42 @@ const IEEE13_FIXTURE = """
         integrity_check(net4, f4)            # no MethodError
         provenance_analysis(net4, Finding[]) # no MethodError
         @test !any(x -> x.code == "E.INT.UNKNOWN_TERMINAL", f4)
+
+        # (#280) capacitor terminal_map and n_winding windings[].terminal_map are
+        # coerced too — the ingest walker previously skipped both categories.
+        raw5 = """
+        {"bus": {"b": {"terminal_names": [1,2,3,4]}},
+         "capacitor": {"c": {"bus": "b", "terminal_map": [1,2,3,4],
+            "configuration": "WYE", "q_rated": [1000.0,1000.0,1000.0], "v_nom": 230.0}},
+         "transformer": {"n_winding": {"t": {"s_rating": 1000000.0, "x_sc": {"1_2": 0.05},
+            "windings": [{"bus": "b", "terminal_map": [1,2,3,4], "v_nom": 230.0, "configuration": "WYE"},
+                         {"bus": "b", "terminal_map": [1,2,3,4], "v_nom": 115.0, "configuration": "WYE"}]}}}}
+        """
+        net5 = parse_bmopf(raw5; from_string=true)
+        @test net5["capacitor"]["c"]["terminal_map"] == ["1","2","3","n"]
+        @test net5["transformer"]["n_winding"]["t"]["windings"][1]["terminal_map"] == ["1","2","3","n"]
+    end
+
+    @testset "from_dss ingest walkers — n_winding + earth-5 (#280)" begin
+        # n_winding winding bus references are case-folded like every other id.
+        net = Dict{String,Any}(
+            "bus" => Dict{String,Any}("HV"=>Dict{String,Any}("terminal_names"=>["a"]),
+                                      "LV"=>Dict{String,Any}("terminal_names"=>["a"])),
+            "transformer" => Dict{String,Any}("n_winding"=>Dict{String,Any}("T1"=>Dict{String,Any}(
+                "windings"=>[Dict{String,Any}("bus"=>"HV"), Dict{String,Any}("bus"=>"LV")]))))
+        BMOPFTools._canonicalize_identifiers!(net)
+        wbus = [w["bus"] for w in net["transformer"]["n_winding"]["t1"]["windings"]]
+        @test wbus == ["hv", "lv"]
+
+        # The OpenDSS earth terminal "5" is routed to the neutral in terminal_names
+        # and DROPPED from perfectly_grounded_terminals (no dangling reference to a
+        # terminal "5"→"n" removed).
+        net2 = Dict{String,Any}("bus"=>Dict{String,Any}("b"=>Dict{String,Any}(
+            "terminal_names"=>["1","2","3","5"], "perfectly_grounded_terminals"=>["5"])))
+        BMOPFTools._remap_opendss_terminals!(net2)
+        b = net2["bus"]["b"]
+        @test !("5" in b["terminal_names"]) && ("n" in b["terminal_names"])
+        @test isempty(get(b, "perfectly_grounded_terminals", String[]))
     end
 
     @testset "Terminal-name conventions" begin


### PR DESCRIPTION
Closes #280.

Three ingest walkers skipped shapes they should cover:

- **`parse_bmopf`'s `each_terminal_array`** omitted `capacitor` and, for `n_winding` transformers, the terminal maps inside `windings[]`. Integer terminals there (e.g. `[1,2,3,4]`) were left un-coerced, breaking exact string matching downstream. Now adds `capacitor` to the component list and visits each winding dict.
- **`from_dss`'s `_canonicalize_identifiers!`** case-folded `bus_from`/`bus_to` but not the per-winding `windings[].bus`, so a mixed-case winding bus reference dangled. Now folds winding bus refs for `WINDING_LIST_SUBTYPES`.
- **`from_dss`'s `_remap_opendss_terminals!`** folded `terminal_names` `"5"→"n"` but left `"5"` in `perfectly_grounded_terminals` (only `"4"` was handled), a dangling reference. Now drops `"5"` — the earth terminal is routed to the neutral and recorded in `_meta`, not turned into a solid ground (matching the author's stated intent).

### Tests
Capacitor + n_winding terminal coercion (`[1,2,3,4] → ["1","2","3","n"]`), the from_dss winding-bus case-fold, and the earth-`"5"` drop. Verified discriminating; parse/relabel suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)