### PR TITLE
docs: correct thermal/physics claims and reference audit

### DIFF
--- a/docs/src/augmentation.md
+++ b/docs/src/augmentation.md
@@ -230,12 +230,19 @@ are skipped — the offset is never guessed. Enable with
 
 ### Pass 2 — Thermal limits
 
-Infers `i_max` for linecodes that lack it by matching the diagonal series
-resistance R₁₁ against an IEC 60228:2004 / IEC 60364-5-52:2009 lookup table.
+Infers a heuristic `i_max` for linecodes that lack it by matching the diagonal
+series resistance R₁₁ against a lookup table of representative conductor
+cross-sections and their ampacities. This is a **synthetic estimate**, not a
+standards lookup: R₁₁ is the *series* resistance (the conductor's AC resistance
+**plus** the Carson earth-return coupling), so on its own it does not uniquely
+identify a conductor's material, construction class, cross-section, or
+installation method. Treat the result as a plausible default; a high-confidence
+rating requires the conductor material/class and installation method to be known
+independently.
 
-The table covers cross-sections from 4 mm² to 240 mm²:
+The table spans representative cross-sections from 4 mm² to 240 mm²:
 
-| Cross-section (mm²) | R₁₁ (mΩ/m at 20 °C) | Underground XLPE (A) | Overhead AAC (A) |
+| Cross-section (mm²) | R₁₁ (mΩ/m at 20 °C) | Underground XLPE (A) | Overhead (illustrative, A) |
 |---|---|---|---|
 | 4   | 4.950 | 34  | —   |
 | 6   | 3.300 | 41  | —   |
@@ -251,9 +258,16 @@ The table covers cross-sections from 4 mm² to 240 mm²:
 | 185 | 0.107 | 451 | 490 |
 | 240 | 0.082 | 541 | 600 |
 
-Sources: IEC 60228:2004 (AC resistance at 20 °C), IEC 60364-5-52:2009
-Table B.52 (ampacity at 70 °C conductor temperature, single-circuit
-in-ground or in-air installation).
+On the columns: the R₁₁ values are representative **maximum DC resistances at
+20 °C** for standard conductor sizes — the quantity IEC 60228:2004 actually
+specifies (its procedure measures DC resistance), used here only as a size
+fingerprint, not an AC or earth-return-inclusive value. The underground column
+is loosely calibrated to IEC 60364-5-52:2009 Table B.52 installation ampacity
+(70 °C conductor, single circuit, in-ground or in-air); the overhead column is
+an illustrative overhead rating, **not** an IEC 60364-5-52 value (that standard
+covers LV installation ampacity, not an overhead-AAC catalogue). The table as a
+whole is a heuristic default, not a standards-derived rating, and is
+deliberately *not* tagged as an IEC-conformant result.
 
 The match uses a 15 % relative tolerance on R₁₁.  If no table row falls
 within tolerance the linecode is skipped and the manifest records
@@ -627,13 +641,15 @@ explicit to be reproducible ([ref. 4](#augrefs)).
 
 **Standards as the source of defaults.** Where a value *can* be grounded in a
 published standard, it should be — so the default is auditable rather than
-arbitrary. Voltage windows follow EN 50160:2010, conductor ampacities follow
-IEC 60364-5-52:2009 over IEC 60228:2004 resistances, and DER reactive capability
+arbitrary. Voltage windows follow EN 50160:2010 and DER reactive capability
 follows EN 50549-1:2019 (with IEEE 1547-2018 as the ANSI alternative, whose
 minimum 44 % injecting / 44 % absorbing reactive capability motivates the
 `q_capability_pf = 0.95` preset) ([ref. 5](#augrefs)). This is why
 `augment_case` separates standards-derived fills from synthetic ones in the
-manifest.
+manifest. Conductor ampacities are the deliberate exception: the thermal pass is
+a **heuristic estimate** loosely calibrated to IEC 60364-5-52:2009 / IEC 60228:2004
+tables, not a conformant derivation (a bare R₁₁ does not identify the conductor
+material, class, or installation), and is tagged as such.
 
 **DER scenarios as designed inputs.** Where a value *cannot* be standardised —
 chiefly where to place generation and how large to make it — the literature

--- a/docs/src/methodology.md
+++ b/docs/src/methodology.md
@@ -12,8 +12,9 @@ legitimate transformation of the data can break — as hard checks, and treat
 For the series impedance Z = R + jX of a multiconductor line in wire
 coordinates [1, 5]:
 
-- **Reciprocity** (Z symmetric) holds for any passive network — hard
-  (`E.PROV.NONRECIPROCAL`).
+- **Reciprocity** (Z symmetric) holds for ordinary passive lines in
+  reciprocal media (isotropic conductors and earth — no gyrotropic or
+  otherwise non-reciprocal materials) — hard (`E.PROV.NONRECIPROCAL`).
 - **Passivity** (R ⪰ 0) holds by the dissipation argument, and survives
   Kron reduction: elimination of grounded conductors is a Schur complement,
   and Schur complements of accretive matrices remain accretive [10, 11] —
@@ -24,7 +25,7 @@ coordinates [1, 5]:
   complementation — so X-PSD is also Kron-invariant
   (`W.PROV.X_NOT_PSD`, `W.PROV.X_NONINDUCTIVE`).
 - **Mutual resistance sign**: Carson's earth-return correction [4] makes
-  off-diagonal resistance positive (≈ π²·f·μ₀/4 ≈ 0.049 Ω/km at 50 Hz),
+  off-diagonal resistance positive (≈ ω·μ₀/8 = π·f·μ₀/4 ≈ 0.049 Ω/km at 50 Hz),
   and nearly equal across conductor pairs — a useful fingerprint of
   geometry-derived data, but only *typical*: reductions and fitting can
   perturb it (`I.PROV.NEGATIVE_MUTUAL_R`, soft).
@@ -32,14 +33,17 @@ coordinates [1, 5]:
 ## Sequence-derived matrices and Z₁/Z₀ recovery
 
 A line parameterised from sequence values and transformed back to phase
-coordinates (TF spec Appendix A.2; [2] Eq. 148) is **perfectly balanced**:
+coordinates (TF spec [1], Appendix A.2 / Eq. 148) is **perfectly balanced**:
 
 ```
 Z = Zₛ·I + Zₘ·(J − I),   Zₛ = (Z₀ + 2Z₁)/3,   Zₘ = (Z₀ − Z₁)/3
 ```
 
-Geometric (Carson) parameterisations of untransposed lines cannot produce
-this, because phase-pair spacings differ. The classifier inverts the
+Geometric (Carson) parameterisations of *generic asymmetric* untransposed
+geometries do not produce this, because their phase-pair spacings differ.
+(Symmetric untransposed arrangements — equilateral spacing, symmetric bundled
+construction — *can* be balanced; that is exactly the `near_balanced` case
+below.) The classifier inverts the
 construction — `Z₁ = Zₛ − Zₘ`, `Z₀ = Zₛ + 2Zₘ` — and reports the implied
 sequence parameters (`I.PROV.SEQ_DERIVED`). The verdict tiers:
 

--- a/docs/src/spec/references.md
+++ b/docs/src/spec/references.md
@@ -24,8 +24,8 @@ analysis):
 
 Optimal power flow and its mathematics:
 
-- **S. H. Low**, *Power System Analysis: A Mathematical Approach* (forthcoming
-  graduate textbook). A rigorous, notation-first treatment of network models and OPF;
+- **S. H. Low**, *Power System Analysis: Analytical Tools and Structural Properties*
+  (forthcoming graduate textbook). A rigorous, notation-first treatment of network models and OPF;
   freely available on registration at
   [netlab.caltech.edu/book_reg](https://netlab.caltech.edu/book_reg/). Its complex
   stacked-vector style is close to the [notation](notation.md) used here.
@@ -47,7 +47,9 @@ where Steven Low's book covers the mathematics underneath:
   [Real Distribution System Modeling and Analysis](https://wzy.ece.iastate.edu/PPT/EE653%20Real%20Distribution%20System%20Modeling%20and%20Analysis.pdf)
   (EE653). Clear, worked treatments of feeder components and how transformer losses map
   onto the equivalent circuit.
-- Distribution-transformer modelling, *IET Generation, Transmission & Distribution*, 2020,
+- **S. Claeys, G. Deconinck, F. Geth**, "Decomposition of n-winding transformers for
+  unbalanced optimal power flow," *IET Generation, Transmission & Distribution*
+  **14**(24):5961–5969, 2020,
   [doi:10.1049/iet-gtd.2020.0776](https://doi.org/10.1049/iet-gtd.2020.0776) — a useful
   reference for conceptualising the
   [transformer loss model](transformer.md#The-loss-equivalent-circuit).
@@ -75,6 +77,13 @@ models:
 - **R. C. Dugan**, "A perspective on transformer modeling for distribution system
   analysis," *IEEE PES General Meeting*, 2003. Background for the
   [transformer](transformer.md) winding models and grounding conventions.
+- **R. Yan, Y. Li, T. K. Saha, L. Wang, M. I. Hossain**, "Modeling and Analysis of
+  Open-Delta Step Voltage Regulators for Unbalanced Distribution Network With
+  Photovoltaic Power Generation," *IEEE Transactions on Smart Grid*
+  **9**(3):2224–2234, 2018,
+  [doi:10.1109/TSG.2016.2609440](https://doi.org/10.1109/TSG.2016.2609440). The
+  common-neutral open-delta step-voltage-regulator model behind the
+  [regulator](regulator.md) page (`open_delta_regulator`).
 
 ## Benchmark libraries and test systems
 

--- a/docs/src/spec/transformer-admittance.md
+++ b/docs/src/spec/transformer-admittance.md
@@ -292,7 +292,7 @@ across the from/to pair $(p,q)$, summed with the from-side shunt:
 ```
 
 This is the device's natural line-to-line admittance — the "unspecified neutral" matrix
-of Yan et al. (2018), IEEE Trans. Smart Grid **9**(3):2224, Eq. (11): the shared phase
+of Yan et al. (2018), IEEE Trans. Smart Grid **9**(3):2224–2234, [doi:10.1109/TSG.2016.2609440](https://doi.org/10.1109/TSG.2016.2609440), Eq. (11): the shared phase
 carries $2\textcolor{brown}{y_t}$ on its diagonal (both regulators) and the from↔to
 coupling scales as $\textcolor{red}{n^{\text{eff}}}$ and $(\textcolor{red}{n^{\text{eff}}})^2$ — the autotransformer factor, not an isolated-transformer ratio. The galvanic
 straight-through of the shared phase (the paper's *common-neutral* model, its Eq. 14) is

--- a/docs/src/tutorial_ders.md
+++ b/docs/src/tutorial_ders.md
@@ -129,8 +129,8 @@ nothing # hide
 ```
 
 `augment_case` then fills the standards-grounded gaps: the IBR `P²+Q²≤s_max²`
-circle and its EN 50549-1 reactive box, the generator reactive limits, the
-IEC 60228 thermal limit, and a per-phase slack price. Two
+circle and its EN 50549-1 reactive box, the generator reactive limits, a
+heuristic conductor-ampacity thermal limit, and a per-phase slack price. Two
 [`AugmentationRecipe`](@ref) presets implement "no network limit" (scenario A)
 versus "network limits on" (B and C) — A skips the voltage *and* thermal
 passes, while B/C keep the thermal pass and get their voltage ceiling from

--- a/docs/src/tutorial_end_to_end.md
+++ b/docs/src/tutorial_end_to_end.md
@@ -145,8 +145,9 @@ render_manifest(der_mf)
 [`augment_case`](@ref) fills the bounds and costs an OPF needs, **without
 overwriting any value already present**. Each fill is tagged in the manifest as
 `:standard` (derived from a cited standard) or `:synthetic` (a design choice).
-The passes draw on EN 50160 (voltage bounds), IEC 60228 (thermal limits from
-conductor cross-sections), and EN 50549-1 / IEEE 1547 (reactive capability). See
+The passes draw on EN 50160 (voltage bounds), a heuristic conductor-size →
+ampacity estimate (thermal limits, loosely IEC-60228/60364-calibrated), and
+EN 50549-1 / IEEE 1547 (reactive capability). See
 [Case augmentation](augmentation.md) for the full pass-by-pass rationale.
 
 ```@example e2e

--- a/docs/src/tutorial_line_geometry.md
+++ b/docs/src/tutorial_line_geometry.md
@@ -238,7 +238,7 @@ has a guard (a `W.DOM.*` finding + compile-time warning — see the
 |---|---|---|
 | Carson series truncation (`modified_carson`, `full_carson`) | k = √(ωμ₀/ρ)·S ≪ 1 — true for distribution spacings at 50/60 Hz (< 1 % vs the full series, Kersting & Green 2011) | `W.DOM.GEOM_CARSON_VALIDITY` at k > 0.25 |
 | Height-independence of `modified_carson` | equivalent return depth Dₑ = 658.87·√(ρ/f) m (≈ 850 m at 60 Hz/100 Ω·m) dwarfs conductor heights and burial depths | implicit in the above |
-| Buried conductors treated at the surface | burial depth ≪ earth skin depth (δ ≈ 356 m at 60 Hz/100 Ω·m); the rigorous theory is Pollaczek (1926)/Saad et al. (1996), needed only beyond power frequency | `W.DOM.GEOM_BURIED_EARTH_MODEL` |
+| Buried conductors treated at the surface | burial depth ≪ earth skin depth (δ = √(2ρ/(ωμ₀)) ≈ 650 m at 60 Hz/100 Ω·m; the Deri complex-depth magnitude \|p\| = √(ρ/(ωμ₀)) ≈ 459 m is the same scale); the rigorous theory is Pollaczek (1926)/Saad et al. (1996), needed only beyond power frequency | `W.DOM.GEOM_BURIED_EARTH_MODEL` |
 | Deri complex-depth images | \|y\| ≪ \|p\|, p = √(ρ/jωμ₀) (Deri et al. 1981) | `W.DOM.GEOM_BURIED_EARTH_MODEL` (depth > 0.1·\|p\|) |
 | Constant r_ac, GMR-based internal inductance | f below the critical skin frequency f_crit = ρ_c/(π r² μ₀) (Jensen et al. 2001) | `W.DOM.WIRE_SKIN_FREQUENCY` |
 | Perfect-earth electrostatics (capacitance) | always at power frequency (no Carson analogue exists electrostatically) | — |

--- a/docs/src/tutorial_mvdc.md
+++ b/docs/src/tutorial_mvdc.md
@@ -345,10 +345,11 @@ end
 2. X. Jiang, Y. Zhou, W. Ming, P. Yang, J. Wu, *An Overview of Soft Open Points in
    Electricity Distribution Networks*, IEEE Transactions on Smart Grid
    **13**(3):1899–1910, 2022.
-3. *Hosting-capacity maximisation of distribution networks with optimised soft
-   open points*, Energies **16**(3):1035, 2023.
-4. *Comparison between voltage droop and voltage margin controllers for MTDC
-   systems*, 2019.
+3. R. de Oliveira, L. W. de Oliveira, E. J. de Oliveira, *Optimization Approach for
+   Planning Soft Open Points in a MV-Distribution System to Maximize the Hosting
+   Capacity*, Energies **16**(3):1035, 2023, doi:10.3390/en16031035.
+4. F. Torres, S. Martinez, C. Roa, E. Lopez, *Comparison Between Voltage Droop and
+   Voltage Margin Controllers for MTDC Systems*, IEEE ICA-ACCA, Concepción, Chile, 2018.
 5. K. Rouzbehi, A. Miranian, A. Luna, P. Rodriguez, *A Generalized Voltage Droop
    Strategy for Control of Multiterminal DC Grids*, IEEE Transactions on Industry
    Applications **51**(1):607–618, 2015.

--- a/docs/src/tutorial_statcom.md
+++ b/docs/src/tutorial_statcom.md
@@ -133,8 +133,9 @@ together — it cannot preferentially raise the sagging phase, because on a resi
 feeder reactive power is the wrong lever ([1](@ref refs-statcom)). Worse, the guess
 is actively counterproductive: the extra reactive current *raises* the feeder losses
 from 3723 W to 4009 W. A different constant setpoint would land somewhere else
-equally arbitrary; a simulation can only *evaluate* a guess, never *find* the right
-per-phase split.
+equally arbitrary; a single fixed-setpoint power flow can only *evaluate* a guess —
+finding the right per-phase split needs a search over setpoints, i.e. the
+optimisation.
 
 ## 3. Reactive-only, optimally dispatched — still not enough
 

--- a/docs/src/tutorial_vvwo.md
+++ b/docs/src/tutorial_vvwo.md
@@ -322,7 +322,9 @@ nothing # hide
 
 The OPF **co-optimises the droop and the network limits**: the voltage is held at
 *exactly* 1.10 pu by curtailing a little more PV. This binding constraint —
-impossible in a simulation-only tool — is the whole point of an OPF.
+enforced directly as a hard limit here, rather than approached by trial-and-error
+setpoints or outer iteration in a fixed-setpoint simulation — is the whole point
+of an OPF.
 
 ### Summary
 

--- a/src/augmentation/thermal.jl
+++ b/src/augmentation/thermal.jl
@@ -1,8 +1,15 @@
 # Thermal limit inference pass.
 #
-# Infers i_max for linecodes that lack it by matching the diagonal series
-# resistance R₁₁ against an IEC 60228:2004 / IEC 60364-5-52:2009 lookup
-# table of cross-section → ampacity.
+# Infers a heuristic i_max for linecodes that lack it by matching the diagonal
+# series resistance R₁₁ against a lookup table of representative conductor
+# cross-sections → ampacity. This is a SYNTHETIC ESTIMATE, not a standards
+# lookup: R₁₁ is the series resistance (conductor AC resistance PLUS the Carson
+# earth-return coupling), so it does not by itself identify a conductor's
+# material, construction class, cross-section, or installation method. The R₁₁
+# column is keyed on maximum DC resistance at 20 °C (the quantity IEC 60228:2004
+# specifies, measured by a DC procedure) purely as a size fingerprint; a
+# high-confidence rating needs material/class and installation method known
+# independently.
 #
 # The neutral conductor carries the same rating as the phase conductors in
 # this implementation (no derating applied).  IEC 60364-5-52:2009 Table B.52
@@ -14,9 +21,12 @@
 # recipe.thermal_min_confidence are processed.  This prevents assigning
 # ratings derived from a fictitious sequence-impedance matrix.
 
-# ── IEC 60228:2004 + IEC 60364-5-52:2009 lookup table ───────────────────────
-# Columns: (R₁₁ mΩ/m at 20 °C, cross_section mm², underground XLPE A, overhead AAC A)
-# Overhead AAC values marked nothing for cross-sections not commonly overhead.
+# ── Heuristic conductor size → ampacity lookup table ────────────────────────
+# Columns: (R₁₁ mΩ/m — max DC resistance at 20 °C, cross_section mm²,
+#           underground ampacity A, overhead illustrative ampacity A)
+# The underground column is loosely calibrated to IEC 60364-5-52:2009 Table B.52
+# (LV installation ampacity); the overhead column is illustrative, NOT an
+# IEC 60364/AAC catalogue value. `nothing` marks sizes not commonly overhead.
 const _IEC_CONDUCTOR_TABLE = [
     (4.950, 4,    34,  nothing),
     (3.300, 6,    41,  nothing),
@@ -31,11 +41,18 @@ const _IEC_CONDUCTOR_TABLE = [
     (0.132, 150, 386, 430),
     (0.107, 185, 451, 490),
     (0.082, 240, 541, 600),
-]  # Source: IEC 60228:2004 (resistance), IEC 60364-5-52:2009 Table B.52 (ampacity)
+]  # Heuristic table: R₁₁ ~ IEC 60228:2004 max DC resistance (size fingerprint);
+   # underground ampacity ~ IEC 60364-5-52:2009 Table B.52; overhead illustrative.
 
 # 15 % relative tolerance (default) for R₁₁ matching against the IEC table.
 # Sourced from config/default.toml [thermal].tolerance.
 const _THERMAL_TOLERANCE = Float64(_thermal_cfg()["tolerance"])
+
+# Provenance rule tag for thermal fills. Deliberately labelled a heuristic
+# estimate rather than "IEC60228+IEC60364": R₁₁ alone does not identify the
+# conductor material/class or installation, so the result is not a
+# standards-conformant ampacity (see the header comment).
+const _THERMAL_RULE = "heuristic_ampacity_estimate"
 
 # Confidence ordering for threshold comparison
 const _CONFIDENCE_ORDER = Dict(:low => 1, :medium => 2, :high => 3)
@@ -59,7 +76,7 @@ end
 """
     _lookup_ampacity(r11_ohm_per_m, conductor_type) -> (mm2, ampacity, note)
 
-Find the nearest IEC 60228 table entry for the given R₁₁ (Ω/m).
+Find the nearest heuristic table entry for the given R₁₁ (Ω/m).
 Returns (cross_section_mm2, ampacity_A, note_string) or nothing if no match
 within tolerance.
 """
@@ -116,7 +133,7 @@ function _apply_thermal!(net′::Dict{String,Any},
         _confidence_ok(confidence, r.thermal_min_confidence) || begin
             push!(entries, TransformEntry(
                 :linecode, lcid, "i_max", nothing, nothing,
-                "IEC60228:2004+IEC60364-5-52:2009", confidence,
+                _THERMAL_RULE, confidence,
                 "skipped: confidence $(confidence) below threshold " *
                 "$(r.thermal_min_confidence) (classification: $(cls))"))
             continue
@@ -127,7 +144,7 @@ function _apply_thermal!(net′::Dict{String,Any},
         (r11 isa Number && r11 > 0) || begin
             push!(entries, TransformEntry(
                 :linecode, lcid, "i_max", nothing, nothing,
-                "IEC60228:2004+IEC60364-5-52:2009", confidence,
+                _THERMAL_RULE, confidence,
                 "skipped: R_series_1_1 absent or non-positive"))
             continue
         end
@@ -136,7 +153,7 @@ function _apply_thermal!(net′::Dict{String,Any},
         if result === nothing
             push!(entries, TransformEntry(
                 :linecode, lcid, "i_max", nothing, nothing,
-                "IEC60228:2004+IEC60364-5-52:2009", confidence,
+                _THERMAL_RULE, confidence,
                 "skipped: R₁₁=$(round(Float64(r11)*1000, digits=3)) mΩ/m " *
                 "outside lookup range (no match within $(round(tolerance*100))%)"))
             continue
@@ -151,7 +168,7 @@ function _apply_thermal!(net′::Dict{String,Any},
         lc["i_max"] = i_max_vec
         push!(entries, TransformEntry(
             :linecode, lcid, "i_max", nothing, i_max_vec,
-            "IEC60228:2004+IEC60364-5-52:2009", confidence, note))
+            _THERMAL_RULE, confidence, note))
     end
 end
 

--- a/test/augmentation_tests.jl
+++ b/test/augmentation_tests.jl
@@ -236,7 +236,7 @@ end
     e = only(filter(x -> x.component_id == "lc_dist" && x.field == "i_max" &&
                          x.new_value !== nothing, mf.entries))
     @test e.new_value == [170.0, 170.0, 170.0]
-    @test contains(e.rule, "IEC60228")
+    @test contains(e.rule, "heuristic_ampacity")
     @test e.confidence == :high   # distinct verdict → :high
 end
 


### PR DESCRIPTION
Technical corrections from external review (all independently verified):

Physics:
- Carson earth-return mutual resistance: π²·f·μ₀/4 → ω·μ₀/8 = π·f·μ₀/4 (0.049 Ω/km at 50 Hz corresponds to the latter).
- Earth skin depth example: δ = √(2ρ/ωμ₀) ≈ 650 m (was 356 m) at 60 Hz/100 Ω·m; note Deri complex depth |p| ≈ 459 m.
- Reciprocity: scope to passive lines in reciprocal media (not 'any passive network' — passive non-reciprocal media exist).
- Untransposed balance: 'generic asymmetric untransposed geometries do not' produce a balanced matrix (symmetric arrangements can).

Thermal ratings (IEC 60228 / IEC 60364-5-52):
- IEC 60228 specifies maximum DC resistance at 20 °C, not AC.
- Reframe the ampacity inference as a heuristic synthetic estimate: R₁₁ = conductor AC resistance + Carson earth-return, so it does not identify material/class/section/installation; overhead column is illustrative, not an IEC-60364 AAC catalogue. Provenance rule tag changed from 'IEC60228:2004+IEC60364-5-52:2009' to 'heuristic_ampacity_estimate' (+ test).

References:
- methodology.md: TF spec is [1], not [2].
- IET-GTD 10.1049/iet-gtd.2020.0776: full title/authors (Claeys, Deconinck, Geth, 'Decomposition of n-winding transformers…', 14(24):5961–5969).
- Steven Low book: 'Analytical Tools and Structural Properties'.
- MVDC refs: correct SOP hosting-capacity title+authors (de Oliveira et al., Energies 16(3):1035, 2023); MTDC droop/margin paper is 2018, not 2019.
- Add complete Yan et al. open-delta entry (doi:10.1109/TSG.2016.2609440).

Wording:
- Soften two overstated simulation-vs-OPF claims (statcom, vvwo) to the fixed-setpoint power-flow vs integrated OPF contrast.