### PR TITLE
docs: add tutorial router + 'Trust but verify' and 'Nameplate to mode…

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,6 +14,7 @@ makedocs(
         "Home"                    => "index.md",
         "Getting started"         => [
             "End-to-end tutorial"      => "tutorial_end_to_end.md",
+            "Choose your tutorial"     => "choose_tutorial.md",
             "Positioning & ecosystem"  => "positioning.md",
         ],
         "Data model"              => [
@@ -26,10 +27,12 @@ makedocs(
         "Analysis & diagnostics"  => [
             "Analysis & reports"       => "analysis.md",
             "Finding-code reference"   => "findings.md",
+            "Trust but verify: validating a solve" => "tutorial_trust_but_verify.md",
             "Methodology notes"        => "methodology.md",
         ],
         "Case preparation"        => [
             "Case augmentation"        => "augmentation.md",
+            "From nameplate data to a model" => "tutorial_nameplate.md",
             "Simplification tutorial"  => "tutorial_simplify.md",
             "DER placement tutorial"   => "tutorial_ders.md",
             "VVWO tutorial"            => "tutorial_vvwo.md",

--- a/docs/src/choose_tutorial.md
+++ b/docs/src/choose_tutorial.md
@@ -1,0 +1,47 @@
+# Choose your tutorial
+
+The documentation is organised by *topic* — data model, case preparation, OPF,
+bounds. That is the right shape for reference, but not always for a newcomer who
+knows their **goal** and wants a starting point. This page routes by goal.
+
+If you are brand new, read the [end-to-end tutorial](tutorial_end_to_end.md)
+first — it is the one-sitting overview every path below assumes.
+
+## Route by goal
+
+| I want to… | Start here | Then |
+|---|---|---|
+| **Convert** OpenDSS / nameplate data into a BMOPF case | [From nameplate data to a defensible model](tutorial_nameplate.md) | [Conversion guide](conversion.md), [Case augmentation](augmentation.md) |
+| **Understand four-wire physics** (why terminals, neutrals, matrices) | [Buses & terminals primer](terminals_primer.md) | [Impedance models & OPF decisions](tutorial_impedance_models.md), [Line geometry](tutorial_line_geometry.md) |
+| **Build a benchmark** an optimiser can respect | [Case augmentation](augmentation.md) | [From nameplate data to a defensible model](tutorial_nameplate.md), [DER placement](tutorial_ders.md) |
+| **Diagnose an infeasible case** | [Infeasibility diagnosis](tutorial_infeasibility.md) | [Bounds & feasibility](bounds/index.md), [Trusting the solver](bounds/solver_trust.md) |
+| **Verify a solved OPF** you don't yet trust | [Trust but verify](tutorial_trust_but_verify.md) | [Trusting the solver](bounds/solver_trust.md), [Validating the OPF](validation.md) |
+| **Model a specific device** (STATCOM, MVDC, regulator, PV droop) | [D-STATCOM study](tutorial_statcom.md) | [MVDC](tutorial_mvdc.md), [Tap optimisation](tutorial_tap.md), [VVWO](tutorial_vvwo.md) |
+| **Extend or debug the solver** | [OPF engine: scope & status](dev/opf_engine.md) | [OPF model](opf.md), [Contributing](dev/contributing.md) |
+
+## The judgment spine
+
+Four of the tutorials, read in order, teach the reasoning a defensible study
+needs — not just *how* to call the tools, but *when to trust the answer*:
+
+1. **Assumptions** — [From nameplate data to a defensible model](tutorial_nameplate.md).
+   Incomplete datasheets in; a model out. What can be *derived*, what needs an
+   *assumption*, and what must stay *unknown* — and the difference between
+   standards-derived, standards-inspired, and synthetic values.
+2. **Solve** — [end-to-end tutorial](tutorial_end_to_end.md) and the
+   [OPF model](opf.md). Turn the model into a solved dispatch.
+3. **Verify** — [Trust but verify](tutorial_trust_but_verify.md). Take one solved
+   OPF and independently recompute KCL, voltage bounds, thermal loading, losses,
+   and the objective — learning what a solver's `LOCALLY_SOLVED` status does and
+   does *not* guarantee.
+4. **Consequences** — [Impedance models & OPF decisions](tutorial_impedance_models.md)
+   and [Trusting the solver](bounds/solver_trust.md). How the modelling choices
+   made in step 1 change the answer, and where the remaining traps live.
+
+Read top to bottom you get the missing arc: **model assumptions → solve →
+independent verification → fidelity consequences.**
+
+!!! tip "Prerequisites"
+    The solve/verify tutorials run a real OPF, so they need a Julia environment
+    with `BMOPFTools`, `JuMP` and `Ipopt`. The data-model and conversion pages
+    need only `BMOPFTools`.

--- a/docs/src/tutorial_nameplate.md
+++ b/docs/src/tutorial_nameplate.md
@@ -1,0 +1,141 @@
+# From nameplate data to a defensible network model
+
+*What you can derive, what you must assume, and what has to stay unknown.*
+
+Real network data arrives incomplete. A cable has an impedance but no current
+rating; a bus has a nominal voltage but no operating envelope; a feeder has loads
+but nothing dispatchable to optimise. Turning that into a model an OPF can
+respect means *writing numbers the source never gave you* — and the integrity of
+the study depends on being honest about where each one came from.
+
+BMOPFTools makes that honesty mechanical. Every value a preparation pass writes
+is recorded in a **manifest** with the rule that produced it and a **confidence
+tag**, so the finished case is self-documenting: you can see at a glance which
+numbers are standards-derived, which are heuristic inferences to double-check,
+and which are design choices you own. This tutorial walks one incomplete feeder
+through that process and reads the provenance back out.
+
+*Prerequisites: a Julia environment with `BMOPFTools` — the augmentation passes
+need no solver. See [Case augmentation](augmentation.md) for the reference.*
+
+## 1. An incomplete case
+
+We start from a small LV feeder and, to mimic datasheets that list conductor
+impedances but no ampacities, strip the current ratings. Nothing here is
+invalid — it is just *optimisation-meaningless*: with no voltage bounds nothing
+can be infeasible, and with no ratings nothing can bind.
+
+```@example nameplate
+using BMOPFTools, Printf
+
+raw = parse_bmopf(joinpath(pkgdir(BMOPFTools), "examples", "lv1_14bus.json"))
+for (_, lc) in raw["linecode"]; delete!(lc, "i_max"); end   # datasheets w/o ratings
+
+n_bus_no_bounds = count(b -> !haskey(b, "v_min"), values(raw["bus"]))
+n_lc_no_rating  = count(lc -> !haskey(lc, "i_max"), values(raw["linecode"]))
+(buses_without_bounds = "$n_bus_no_bounds / $(length(raw["bus"]))",
+ linecodes_without_rating = "$n_lc_no_rating / $(length(raw["linecode"]))")
+```
+
+## 2. Fill the gaps — and record where each number came from
+
+[`augment_case`](@ref) fills only what is missing, never overwriting, and returns
+the augmented network together with a [`TransformationManifest`](@ref). It never
+mutates its input.
+
+```@example nameplate
+net, mf = augment_case(raw)
+length(mf.entries)   # one entry per value written (or deliberately skipped)
+```
+
+Each entry carries a `confidence` tag. Grouping the written values by tag sorts
+them onto a spectrum from *fully defensible* to *your call*:
+
+```@example nameplate
+tier(c) = c === :standard             ? "1. standards-derived" :
+          c in (:high, :medium, :low) ? "2. inferred (heuristic estimate)" :
+          c === :heuristic            ? "3. numerical default" :
+          c === :synthetic            ? "4. synthetic (design choice)" :
+                                        String(c)
+
+byt = Dict{String,Int}()
+for e in mf.entries
+    e.new_value === nothing && continue          # skips are recorded too
+    byt[tier(e.confidence)] = get(byt, tier(e.confidence), 0) + 1
+end
+sort(collect(byt))
+```
+
+One representative rule from each kind, so the tags are concrete:
+
+```@example nameplate
+seen = String[]
+for e in mf.entries
+    (e.new_value === nothing || e.rule in seen) && continue
+    push!(seen, e.rule)
+    @printf("[%-9s] %-30s → %s.%s\n", e.confidence, e.rule[1:min(30,end)],
+            e.component_type, e.field)
+end
+```
+
+Reading those tiers back as engineering judgment:
+
+- **Standards-derived** (`:standard`) — the number *is* in a published standard.
+  The voltage envelopes come straight from EN 50160 (`EN50160:2010§3.5`), and the
+  slack generation from the Task Force spec. Trust these.
+- **Inferred, heuristic** (`:high` / `:medium` / `:low`) — the thermal ratings
+  (`heuristic_ampacity_estimate`). The pass reads each conductor's diagonal
+  resistance R₁₁ as a *size fingerprint* and looks up a representative ampacity.
+  This is **not** a standards-conformant rating: R₁₁ is the series resistance
+  (conductor AC resistance **plus** the Carson earth-return term), so it does not
+  identify the conductor's material, class, or installation — see the
+  [thermal pass](augmentation.md#Pass-2-—-Thermal-limits). The confidence
+  (`:high` vs `:medium`) mirrors how trustworthy the *impedance provenance* is
+  (a geometry-`distinct` linecode vs a `near_balanced` one), so a `:medium` tag
+  is a flag to check against your real conductor schedule before publishing.
+- **Numerical default** (`:heuristic`) — loose regularisation floors added for
+  solver conditioning, not physical claims.
+- **Synthetic** (`:synthetic`) — pure design choices. These appear the moment you
+  place dispatchable generation, which is a *scenario*, not a fact:
+
+```@example nameplate
+net_der, der_mf = add_generators(net)
+[(e.rule, e.confidence) for e in der_mf.entries if e.confidence === :synthetic] |> unique
+```
+
+## 3. What must stay unknown
+
+The passes fill what can be *defensibly* defaulted and leave the rest — the
+confidence tag is the tell for what to revisit:
+
+- A conductor's **material and installation** cannot be recovered from R₁₁ alone,
+  so the ampacity is a heuristic estimate, tagged as such and capped at
+  `:medium`/`:high` confidence rather than presented as a standard.
+- Values a datasheet simply omits — a transformer's core-loss branch, a load's
+  true ZIP split — are **not invented**. `augment_case` adds no such field; it
+  fills operating *envelopes*, not missing *physics*.
+- **Where and how large** to place DER is a study input, not a derivable quantity
+  ([`add_generators`](@ref) is explicit about this — every placement is a
+  `:synthetic` entry with a stated strategy, never random).
+
+## 4. Provenance travels with the case
+
+The manifest serialises, so the augmented case and its provenance can ship as a
+pair — `(case.json, case_manifest.json)` — and every default stays auditable
+long after the study:
+
+```@example nameplate
+sort(collect(keys(manifest_to_dict(mf))))
+```
+
+For the human-readable view, `render_manifest(mf)` prints the full diff grouped
+by component. The discipline is the point: a benchmark is only as defensible as
+its least-documented default, and the tag on every number tells the next reader —
+or the reviewer — exactly which ones to trust and which to challenge.
+
+!!! tip "Where to go next"
+    [Case augmentation](augmentation.md) is the full pass-by-pass reference;
+    the [conversion guide](conversion.md) covers getting faithful data *in* from
+    OpenDSS in the first place. Once the model is built and solved, the companion
+    discipline is [Trust but verify](tutorial_trust_but_verify.md) — checking the
+    *solution* as rigorously as you documented the *inputs*.

--- a/docs/src/tutorial_trust_but_verify.md
+++ b/docs/src/tutorial_trust_but_verify.md
@@ -1,0 +1,199 @@
+# Trust but verify: validating one solved OPF
+
+*What a solver's status guarantees — and what it does not.*
+
+A nonlinear OPF solver ends with a verdict like `LOCALLY_SOLVED`. It is tempting
+to read that as "the answer is correct." It is not what the status means. A
+`LOCALLY_SOLVED` status certifies that the solver found a point satisfying the
+first-order optimality (KKT) conditions of **the problem as posed**, to its
+internal tolerances. It says nothing about whether that problem is the one you
+meant, whether the optimum is global, or whether the numbers are physically
+sensible.
+
+The antidote is cheap and worth building once by hand: take a solved case and
+**independently recompute** the physics — Kirchhoff's current law, Ohm's law,
+voltage bounds, thermal loading, losses, and the objective — from the result
+dictionary alone. This tutorial does exactly that on a feeder small enough to
+have a closed-form answer, then shows that the toolkit ships the same checks so
+you do not have to repeat them by hand every time.
+
+*Prerequisites: a Julia environment with `BMOPFTools`, `JuMP` and `Ipopt` — see
+the [end-to-end tutorial](tutorial_end_to_end.md) first.*
+
+## 1. A feeder with a known answer
+
+One single-phase source (1000 V), a resistive line (R = 0.5 Ω), and one
+constant-power load (100 kW) referred to a grounded neutral. For a resistive
+line feeding a constant-power load, Kirchhoff + Ohm give a quadratic in the load
+voltage,
+
+```math
+V^2 - V_s\,V + R\,P = 0,\qquad V = \tfrac{1}{2}\left(V_s + \sqrt{V_s^2 - 4RP}\right)
+```
+
+so we know the operating point before we solve. We also rate the line at
+`i_max = 250 A` so there is a thermal limit to check against.
+
+```@example trustverify
+using BMOPFTools, JuMP, Ipopt
+const OPT = optimizer_with_attributes(Ipopt.Optimizer, "print_level" => 0)
+
+feeder() = parse_bmopf("""
+{"bus":{
+    "src": {"terminal_names":["1","n"],"perfectly_grounded_terminals":["n"]},
+    "load":{"terminal_names":["1","n"],"perfectly_grounded_terminals":["n"],
+            "v_min":[900.0],"v_max":[999.0]}},
+ "voltage_source":{"vs":{"bus":"src","terminal_map":["1"],
+     "v_magnitude":[1000.0],"v_angle":[0.0]}},
+ "linecode":{"lc":{"R_series_1_1":0.5,"X_series_1_1":0.0}},
+ "line":{"l1":{"bus_from":"src","bus_to":"load",
+     "terminal_map_from":["1"],"terminal_map_to":["1"],
+     "linecode":"lc","length":1.0,"i_max":[250.0]}},
+ "load":{"ld":{"bus":"load","terminal_map":["1","n"],"configuration":"SINGLE_PHASE",
+     "p_nom":[100000.0],"q_nom":[0.0]}}}
+"""; from_string=true)
+
+r = solve_opf(feeder(); optimizer = OPT)
+r["termination_status"]
+```
+
+The solver is happy. Now we ignore that and check the physics ourselves.
+
+## 2. Five independent checks
+
+Everything below reads only the result dictionary `r` — no solver internals.
+(See the [result dictionary](results.md) for the full key layout.)
+
+**Check 1 — the voltage matches the closed form.** The solved load-bus
+magnitude should equal the quadratic root to full precision.
+
+```@example trustverify
+Vs, R, P = 1000.0, 0.5, 100000.0
+V_exact  = (Vs + sqrt(Vs^2 - 4R*P)) / 2
+V_solved = r["bus"]["load"]["1"]["vm"]
+(exact = V_exact, solved = V_solved, mismatch = abs(V_exact - V_solved))
+```
+
+**Check 2 — Ohm's law across the line.** Reconstruct the current from the
+terminal voltage drop, `I = |V_from − V_to| / R`, and compare it to the current
+the solver reports on the line (`cm_fr`, the magnitude leaving the from-bus).
+
+```@example trustverify
+Vfr = r["bus"]["src"]["1"]["vr"]  + im*r["bus"]["src"]["1"]["vi"]
+Vto = r["bus"]["load"]["1"]["vr"] + im*r["bus"]["load"]["1"]["vi"]
+I_ohm    = abs(Vfr - Vto) / R
+I_solved = r["line"]["l1"]["1"]["cm_fr"]
+(ohm = I_ohm, solved = I_solved)
+```
+
+**Check 3 — Kirchhoff's current law at the load bus.** The current the line
+delivers into the bus (`cm_to`) must equal what the load draws (`crd`, real here
+because the load is unity-power-factor). KCL is what the OPF enforces per
+terminal; here we confirm it closes.
+
+```@example trustverify
+I_line_in = r["line"]["l1"]["1"]["cm_to"]
+I_load    = r["load"]["ld"]["1"]["crd"]
+(line_into_bus = I_line_in, load_draw = I_load, residual = abs(I_line_in - I_load))
+```
+
+**Check 4 — thermal loading.** The conductor current against its rating. The
+OPF was free to bind this limit; at 42 % it is comfortably slack, which is why
+`i_max` does not appear as an active constraint.
+
+```@example trustverify
+imax = feeder()["line"]["l1"]["i_max"][1]
+loading_percent = I_solved / imax * 100
+```
+
+**Check 5 — losses and the objective.** The line dissipates `I²R`; that must
+equal the reported network loss. And the objective is **zero** — not a bug:
+there is no *costed* generator, so this is a pure feasibility problem (a power
+flow written as an OPF), and its objective has nothing to minimise.
+
+```@example trustverify
+(loss_hand = I_solved^2 * R,
+ loss_reported = r["losses"]["p_loss"],
+ objective = r["objective"])
+```
+
+All five agree. We have now confirmed, without trusting the solver's verdict,
+that the returned point is the physical operating point.
+
+## 3. The toolkit does this for you
+
+Recomputing by hand is the right way to build intuition once; in practice you
+call [`profile_solution`](@ref), which runs the same balance, loss, thermal and
+bound checks and returns a report of `Finding`s.
+
+```@example trustverify
+report = profile_solution(feeder(), r)
+(errors = length(errors(report)), warnings = length(warnings(report)))
+```
+
+The underlying [`solution_check`](@ref) exposes the raw quantities — the
+network-wide power-balance residual and the loss fraction among them:
+
+```@example trustverify
+f = BMOPFTools.Finding[]
+summary = solution_check(feeder(), r, f)
+(codes = [x.code for x in f],
+ power_balance_err = summary["power_balance_err"],
+ loss_fraction = summary["loss_fraction"])
+```
+
+`W.SOL.POWER_BALANCE` fires when generation minus load, shunts and losses fails
+to net to zero; `W.SOL.NEG_LOSS` when a passive branch appears to *source* active
+power; `I.SOL.BINDING_SUMMARY` counts the active and violated limits. These are
+the machine version of the five hand-checks above — see the
+[finding-code reference](findings.md#SOL-—-solution-profiling).
+
+## 4. When the status is green but the answer is not what you want
+
+A clean status does not mean a *good* case. Take the same feeder with a line
+four times more resistive and a slacker voltage floor. The solver still returns
+`LOCALLY_SOLVED` — but the feeder now burns **38 % of the delivered power** in
+the line, which `profile_solution` flags:
+
+```@example trustverify
+badfeeder() = parse_bmopf("""
+{"bus":{"src":{"terminal_names":["1","n"],"perfectly_grounded_terminals":["n"]},
+        "load":{"terminal_names":["1","n"],"perfectly_grounded_terminals":["n"],
+                "v_min":[600.0],"v_max":[1050.0]}},
+ "voltage_source":{"vs":{"bus":"src","terminal_map":["1"],"v_magnitude":[1000.0],"v_angle":[0.0]}},
+ "linecode":{"lc":{"R_series_1_1":2.0,"X_series_1_1":0.0}},
+ "line":{"l1":{"bus_from":"src","bus_to":"load","terminal_map_from":["1"],"terminal_map_to":["1"],
+     "linecode":"lc","length":1.0,"i_max":[250.0]}},
+ "load":{"ld":{"bus":"load","terminal_map":["1","n"],"configuration":"SINGLE_PHASE",
+     "p_nom":[100000.0],"q_nom":[0.0]}}}
+"""; from_string=true)
+
+rbad = solve_opf(badfeeder(); optimizer = OPT)
+fbad = BMOPFTools.Finding[]
+sbad = solution_check(badfeeder(), rbad, fbad)
+(status = rbad["termination_status"],
+ load_voltage = round(rbad["bus"]["load"]["1"]["vm"], digits=1),
+ loss_fraction = round(sbad["loss_fraction"], digits=3),
+ flags = [x.code for x in fbad])
+```
+
+The status is identical to the healthy case; only the independent loss check
+tells them apart. This is the general lesson. A `LOCALLY_SOLVED` verdict
+guarantees, to tolerance, a KKT point of the model you handed the solver. It
+does **not** guarantee that:
+
+- the optimum is **global** — nonconvex OPF can have several local optima, and
+  which one you land on depends on the start point (see
+  [Trusting the solver](bounds/solver_trust.md) for why the physical branch is
+  usually reached here, and the traps that remain);
+- the point is **operationally sensible** — a 38 %-loss or a collapsed-voltage
+  solution can be a perfectly valid KKT point;
+- the **model is the one you meant** — the solver validates the equations you
+  wrote, not your modelling assumptions. That gap is the subject of
+  [From nameplate data to a defensible model](tutorial_nameplate.md).
+
+!!! tip "The habit"
+    After every solve, run `profile_solution` and read the findings — treat a
+    green status plus a clean solution report as the bar, not the status alone.
+    For the engine-level validation (agreement with OpenDSS, projection
+    triangulation, optimality tiers) see [Validating the OPF](validation.md).


### PR DESCRIPTION
…l' tutorials

Adds the goal-based routing page and the two judgment tutorials from the
docs plan, giving the missing arc: assumptions -> solve -> verify ->
consequences.

- choose_tutorial.md: route-by-goal table + the judgment spine.
- tutorial_trust_but_verify.md: independently recompute KCL, Ohm, voltage bounds, thermal loading, losses and objective on a closed-form feeder; show profile_solution/solution_check reproduce the hand-checks; and that a green LOCALLY_SOLVED status does not guarantee a global/sensible/ correctly-modelled answer (38%-loss counterexample).
- tutorial_nameplate.md: fill an incomplete case with augment_case and read the manifest's confidence tags back as standards-derived / inferred-heuristic / synthetic provenance (ties to the thermal-ampacity correction); what must stay unknown.

All @example code verified to run (exit 0); nav + cross-links wired.