### PR TITLE
schema: address PR #16 review (v0.1.0, ASCII, meta renames, extras ha…

### DIFF
--- a/docs/src/conventions.md
+++ b/docs/src/conventions.md
@@ -595,13 +595,13 @@ error) so callers can add project-specific keys freely.
 | `modified` | String | ISO 8601 datetime of most recent edit. Not auto-filled; set explicitly when updating a file. |
 | `license` | String | SPDX identifier (e.g. `"CC-BY-4.0"`) or full URI. |
 | `authors` | Array of objects | List of contributors; each object may have `name`, `email`, `orcid`. |
-| `sources` | Array of objects | Origin datasets; each object may have `name`, `url`, `format`, `doi`, `version`. |
-| `generator` | Object | Tool provenance: `{"tool": "BMOPFTools.jl", "version": "x.y.z"}`. Auto-filled by `write_bmopf`. |
+| `data_sources` | Array of objects | Origin datasets; each object may have `name`, `url`, `format`, `doi`, `version`. |
+| `case_study_generator` | Object | Tool provenance: `{"tool": "BMOPFTools.jl", "version": "x.y.z"}`. Auto-filled by `write_bmopf`. |
 
 **Auto-generation on write.** [`write_bmopf`](@ref) always emits a `meta`
 block.  It merges fields in priority order: the `meta` keyword argument
 → `net["meta"]` → auto-generated defaults.  Auto-generation fills three
-fields if they are absent: `$schema`, `generator`, and `created`.
+fields if they are absent: `$schema`, `case_study_generator`, and `created`.
 Caller-supplied values are never overwritten.
 
 **On parse.** [`parse_bmopf`](@ref) and [`from_dss`](@ref)
@@ -620,7 +620,7 @@ write_bmopf(net, "lv_feeder1.json";
         "license"     => "https://creativecommons.org/licenses/by/4.0/",
         "authors"     => [Dict("name" => "Frederik Geth",
                                "orcid" => "0000-0001-9534-2265")],
-        "sources"     => [Dict("name" => "ENWL dataset",
+        "data_sources" => [Dict("name" => "ENWL dataset",
                                "format" => "OpenDSS",
                                "url"    => "https://www.enwl.co.uk/")],
     ))

--- a/docs/src/spec/bus.md
+++ b/docs/src/spec/bus.md
@@ -17,7 +17,9 @@ A bus is an entry of the top-level `bus` object, keyed by its string ID $i$.
 | `vn_max` | number | V | | Neutral-to-ground magnitude cap |
 | `vpn_min`, `vpn_max` | number[] | V | | Phase-to-neutral magnitude bounds, one per phase |
 | `vpp_min`, `vpp_max` | number[] | V | | Phase-to-phase magnitude bounds, one per phase pair |
-| `vsym_min`, `vsym_max` | number[] | V | | Symmetrical-component magnitude bounds |
+| `vpos_min`, `vpos_max` | number | V | | Positive-sequence magnitude bounds (three-phase buses) |
+| `vneg_max` | number | V | | Negative-sequence magnitude cap (lower bound is always 0) |
+| `vzero_max` | number | V | | Zero-sequence magnitude cap (lower bound is always 0) |
 
 All bound fields are optional: an absent bound means the corresponding limit is not
 enforced.
@@ -31,7 +33,8 @@ enforced.
 | `vn_max` | $\textcolor{red}{U^{\max}_{i,n}}$ | scalar, neutral to ground |
 | `vpn_min`, `vpn_max` | $\textcolor{red}{\mathbf{U}^{Y,\min}_i},\ \textcolor{red}{\mathbf{U}^{Y,\max}_i}$ | per phase, to neutral |
 | `vpp_min`, `vpp_max` | $\textcolor{red}{\mathbf{U}^{\Delta,\min}_i},\ \textcolor{red}{\mathbf{U}^{\Delta,\max}_i}$ | per phase pair |
-| `vsym_min`, `vsym_max` | $\textcolor{red}{\mathbf{U}^{\text{sym},\min}_i},\ \textcolor{red}{\mathbf{U}^{\text{sym},\max}_i}$ | sequence magnitudes |
+| `vpos_min`, `vpos_max` | $\textcolor{red}{U^{1,\min}_i},\ \textcolor{red}{U^{1,\max}_i}$ | positive-sequence magnitude |
+| `vneg_max`, `vzero_max` | $\textcolor{red}{U^{2,\max}_i},\ \textcolor{red}{U^{0,\max}_i}$ | negative-/zero-sequence caps (lower bound 0) |
 
 ## 3. Variables
 
@@ -207,13 +210,11 @@ centred deviation stays within $\pm\pi/2$).
 
 ### Reconciliation notes (data model)
 
-!!! warning "Symmetrical-component fields disagree"
-    The schema exposes one array pair `vsym_min`/`vsym_max`
-    ($\textcolor{red}{\mathbf{U}^{\text{sym}}_i}$, ordered 0/+/−), matching the Task
-    Force PDF. The OPF code instead reads **four separate scalar fields**
-    `vpos_min`, `vpos_max`, `vneg_max`, `vzero_max`. These three representations
-    disagree and must be reconciled before this bound round-trips from schema to
-    solver.
+!!! note "Symmetrical-component fields (reconciled)"
+    The schema and the OPF solver now agree: sequence bounds are the **four scalar
+    fields** `vpos_min`, `vpos_max`, `vneg_max`, `vzero_max`. Only the positive
+    sequence carries a lower bound; the negative- and zero-sequence lower bounds are
+    always 0. This replaces the earlier single array pair `vsym_min`/`vsym_max`.
 
 !!! warning "Angle-difference fields absent from the schema"
     The intra-bus angle bound uses fields `va_diff_min`, `va_diff_max` and the

--- a/docs/src/spec/metadata.md
+++ b/docs/src/spec/metadata.md
@@ -18,17 +18,17 @@ constraints. Symbols are defined in [Notation](notation.md).
 | `license` | string | SPDX identifier (e.g. `CC-BY-4.0`) or an `https://` URI to the licence |
 | `frequency` | number (Hz) | Nominal system frequency — **check-only** (validated against `line_geometry`/linecode derivation frequency; never rescales) |
 | `authors` | object[] | Ordered authors — see below |
-| `sources` | object[] | Upstream data references — see below |
-| `generator` | object | Tool that wrote the file — see below |
+| `data_sources` | object[] | Upstream data references — see below |
+| `case_study_generator` | object | Tool that wrote the file — see below |
 | `provenance` | object | Free-form conversion/audit notes written by tooling |
 
 **`authors[]`**: `name`, `email`, `orcid` (bare hyphenated form `XXXX-XXXX-XXXX-XXXX`,
 without the `https://orcid.org/` prefix).
 
-**`sources[]`**: `name`, `url` (dereferenceable `https://`), `format` (e.g. `OpenDSS`,
+**`data_sources[]`**: `name`, `url` (dereferenceable `https://`), `format` (e.g. `OpenDSS`,
 `PMD-JSON`, `MATPOWER`), `doi`, `version`.
 
-**`generator`**: `tool`, `version`.
+**`case_study_generator`**: `tool`, `version`.
 
 ## Conformance notes
 
@@ -57,10 +57,10 @@ without the `https://orcid.org/` prefix).
     "authors": [
       { "name": "A. Researcher", "email": "a@example.org", "orcid": "0000-0001-9534-2265" }
     ],
-    "sources": [
+    "data_sources": [
       { "name": "ENWL LVNS dataset", "url": "https://www.enwl.co.uk/lvns", "format": "OpenDSS" }
     ],
-    "generator": { "tool": "BMOPFTools.jl", "version": "0.1.0" }
+    "case_study_generator": { "tool": "BMOPFTools.jl", "version": "0.1.0" }
   },
   "bus": { "...": {} },
   "line": { "...": {} }

--- a/src/io/write_bmopf.jl
+++ b/src/io/write_bmopf.jl
@@ -8,13 +8,13 @@ Serialise a BMOPF network dict to JSON.
 
 A `meta` block is always written. Fields are assembled in this priority order
 (highest wins): the `meta` keyword argument → `net["meta"]` → auto-generated
-defaults (`\$schema`, `generator`, `created`). Caller-supplied values are never
-overwritten by auto-generation.
+defaults (`\$schema`, `case_study_generator`, `created`). Caller-supplied values
+are never overwritten by auto-generation.
 
 # Keyword argument
 - `meta`: a `Dict` of fields to include or override in the written `meta` block.
   All fields are optional; common ones are `title`, `description`, `license`,
-  `authors`, `sources`, and `version`. See `docs/src/conventions.md` for the
+  `authors`, `data_sources`, and `version`. See `docs/src/conventions.md` for the
   full field reference.
 
 # Example
@@ -24,7 +24,7 @@ write_bmopf(net, "output.json";
         "title"   => "LV network 1, Feeder 1",
         "license" => "https://creativecommons.org/licenses/by/4.0/",
         "authors" => [Dict("name" => "Frederik Geth", "orcid" => "0000-0001-9534-2265")],
-        "sources" => [Dict("name" => "ENWL dataset", "format" => "OpenDSS",
+        "data_sources" => [Dict("name" => "ENWL dataset", "format" => "OpenDSS",
                            "url"  => "https://www.enwl.co.uk/…")]
     ))
 ```
@@ -113,7 +113,7 @@ end
     _build_meta(base, override) -> Dict{String,Any}
 
 Merge `base` (from `net["meta"]`) and `override` (from the `meta` kwarg),
-then fill in auto-generated defaults for `\$schema`, `generator`, and `created`
+then fill in auto-generated defaults for `\$schema`, `case_study_generator`, and `created`
 if those keys are not already present. Never overwrites a value the caller set.
 """
 function _build_meta(base::Dict,
@@ -125,7 +125,7 @@ function _build_meta(base::Dict,
     end
 
     get!(m, "\$schema", _BMOPF_SCHEMA_URI)
-    get!(m, "generator", Dict{String,Any}(
+    get!(m, "case_study_generator", Dict{String,Any}(
         "tool"    => "BMOPFTools.jl",
         "version" => _BMOPFTOOLS_VERSION,
     ))

--- a/src/validation/schema.jl
+++ b/src/validation/schema.jl
@@ -383,7 +383,7 @@ end
 const _META_KNOWN_FIELDS = Set([
     "\$schema", "version", "title", "description",
     "created", "modified", "license", "frequency",
-    "authors", "sources", "generator", "provenance",
+    "authors", "data_sources", "case_study_generator", "provenance",
 ])
 const _META_AUTHOR_FIELDS  = Set(["name", "email", "orcid"])
 const _META_SOURCE_FIELDS  = Set(["name", "url", "format", "doi", "version"])
@@ -442,28 +442,28 @@ function _check_meta(meta::Dict, findings::Vector{Finding})
         end
     end
 
-    sources = get(meta, "sources", nothing)
+    sources = get(meta, "data_sources", nothing)
     if sources isa Vector
         for (i, src) in enumerate(sources)
             src isa Dict || continue
             bad = [k for k in keys(src) if !(k in _META_SOURCE_FIELDS)]
             isempty(bad) || push!(findings, Finding(INFO, "I.SCHEMA.UNKNOWN_FIELDS",
                 :schema, :network, nothing,
-                "meta.sources[$i] has unknown field(s): $(join(sort(bad), ", "))."))
+                "meta.data_sources[$i] has unknown field(s): $(join(sort(bad), ", "))."))
             url = get(src, "url", nothing)
             if url isa String && !occursin(_URI_RE, url)
                 push!(findings, Finding(WARNING, "W.SCHEMA.META_SOURCE_URL", :schema,
                     :network, nothing,
-                    "meta.sources[$i].url does not look like a URI: \"$url\"."))
+                    "meta.data_sources[$i].url does not look like a URI: \"$url\"."))
             end
         end
     end
 
-    gen = get(meta, "generator", nothing)
+    gen = get(meta, "case_study_generator", nothing)
     if gen isa Dict
         bad = [k for k in keys(gen) if !(k in _META_GEN_FIELDS)]
         isempty(bad) || push!(findings, Finding(INFO, "I.SCHEMA.UNKNOWN_FIELDS",
             :schema, :network, nothing,
-            "meta.generator has unknown field(s): $(join(sort(bad), ", "))."))
+            "meta.case_study_generator has unknown field(s): $(join(sort(bad), ", "))."))
     end
 end

--- a/src/validation/schemas/draft_bmopf_schema.json
+++ b/src/validation/schemas/draft_bmopf_schema.json
@@ -140,19 +140,21 @@
                         },
                         "description": "Maximum phase-phase voltage magnitude [V]"
                     },
-                    "vsym_min": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/$defs/nonnegative_number"
-                        },
-                        "description": "Minimum symmetric component voltage values [V]"
+                    "vpos_min": {
+                        "$ref": "#/$defs/nonnegative_number",
+                        "description": "Minimum positive-sequence voltage magnitude [V] (three-phase buses)"
                     },
-                    "vsym_max": {
-                        "type": "array",
-                        "items": {
-                            "$ref": "#/$defs/nonnegative_number"
-                        },
-                        "description": "Maximum symmetric component voltage values [V]"
+                    "vpos_max": {
+                        "$ref": "#/$defs/nonnegative_number",
+                        "description": "Maximum positive-sequence voltage magnitude [V] (three-phase buses)"
+                    },
+                    "vneg_max": {
+                        "$ref": "#/$defs/nonnegative_number",
+                        "description": "Maximum negative-sequence voltage magnitude [V] (three-phase buses); the lower bound is always 0"
+                    },
+                    "vzero_max": {
+                        "$ref": "#/$defs/nonnegative_number",
+                        "description": "Maximum zero-sequence voltage magnitude [V] (three-phase buses); the lower bound is always 0"
                     },
                     "time_series": {
                         "type": "object",

--- a/src/validation/schemas/draft_bmopf_schema.json
+++ b/src/validation/schemas/draft_bmopf_schema.json
@@ -1,7 +1,8 @@
 {
     "$schema":"https://json-schema.org/draft/2020-12/schema",
     "$id":"https://github.com/frederikgeth/OpenDSSToPMDJSON",
-    "title":"**Draft** BMOPF OPF test case schema",
+    "title":"BMOPF OPF test case schema",
+    "version": "0.1.0",
     "type": "object",
     "additionalProperties": false,
     "properties": {
@@ -23,7 +24,7 @@
                 "frequency":   {
                     "type": "number",
                     "exclusiveMinimum": 0,
-                    "description": "Nominal system frequency [Hz]. Check-only: line_geometry.frequency and linecode derivation.frequency are validated against it (W.DOM.FREQUENCY_MISMATCH); it never defaults or rescales anything"
+                    "description": "Nominal system frequency [Hz]. line_geometry.frequency and linecode derivation.frequency are checked for consistency against it; it never defaults or rescales anything"
                 },
                 "authors": {
                     "type": "array",
@@ -37,8 +38,9 @@
                         "additionalProperties": false
                     }
                 },
-                "sources": {
+                "data_sources": {
                     "type": "array",
+                    "description": "Upstream data sources this case was derived from (renamed from 'sources' to avoid ambiguity with voltage/current sources)",
                     "items": {
                         "type": "object",
                         "properties": {
@@ -51,8 +53,9 @@
                         "additionalProperties": false
                     }
                 },
-                "generator": {
+                "case_study_generator": {
                     "type": "object",
+                    "description": "The tool that generated this case file (renamed from 'generator' to avoid ambiguity with the network generator component)",
                     "properties": {
                         "tool":    { "type": "string" },
                         "version": { "type": "string" }
@@ -61,10 +64,14 @@
                 },
                 "provenance": {
                     "type": "object",
-                    "description": "Free-form conversion/audit provenance written by tooling (e.g. BMOPFTools' fidelity-loss inventory, migration notes, earth-terminal routing). Round-trips to the in-memory _meta block."
+                    "description": "Free-form conversion/audit provenance written by tooling (e.g. a fidelity-loss inventory, migration notes, or earth-terminal routing)."
                 }
             },
             "additionalProperties": false
+        },
+        "extras": {
+            "type": "object",
+            "description": "Free-form escape hatch for case-level fields not (yet) covered by the schema. The rest of the document stays strict (additionalProperties:false); consumers that need to attach custom fields (e.g. mapping to an external struct) put them here rather than at the top level."
         },
         "bus": {
             "type": "object",
@@ -92,14 +99,14 @@
                         "items": {
                             "$ref": "#/$defs/nonnegative_number"
                         },
-                        "description": "Minimum per-phase voltage magnitude(s) at bus, phase-to-ground, one entry per phase terminal [V]"
+                        "description": "Minimum per-terminal voltage magnitude(s) at bus, phase-to-ground, one entry per bus terminal [V]"
                     },
                     "v_max": {
                         "type": "array",
                         "items": {
                             "$ref": "#/$defs/nonnegative_number"
                         },
-                        "description": "Maximum per-phase voltage magnitude(s) at bus, phase-to-ground, one entry per phase terminal [V]"
+                        "description": "Maximum per-terminal voltage magnitude(s) at bus, phase-to-ground, one entry per bus terminal [V]"
                     },
                     "vn_max": {
                         "$ref": "#/$defs/nonnegative_number",
@@ -202,7 +209,7 @@
                 "patternProperties": {
                     "^R_series_\\d+_\\d+$": {
                         "type": "number",
-                        "description": "Element of the TOTAL series resistance matrix of this line section [Ohm]. Units by location: linecode matrices are per metre, line matrices are absolute — never scaled by length"
+                        "description": "Element of the TOTAL series resistance matrix of this line section [Ohm]. Units by location: linecode matrices are per metre, line matrices are absolute - never scaled by length"
                     },
                     "^X_series_\\d+_\\d+$": {
                         "type": "number",
@@ -324,8 +331,7 @@
                     "bus": { "$ref": "#/$defs/bus_type" },
                     "terminal_map": { "$ref": "#/$defs/terminal_map_type" },
                     "configuration": {
-                        "$ref": "#/$defs/configuration_type",
-                        "description": "WYE (phase-to-neutral), SINGLE_PHASE (two terminals), or DELTA (phase-to-phase)"
+                        "$ref": "#/$defs/configuration_type"
                     },
                     "q_rated": {
                         "type": "array",
@@ -371,7 +377,9 @@
                         "$ref": "#/$defs/terminal_map_type"
                     },
                     "model": {
-                        "$ref": "#/$defs/load_model_type"
+                        "type": "string",
+                        "description": "Voltage dependence of the load: constant_power (default), constant_current (P proportional to |V|), constant_impedance (P proportional to |V|^2), zip (polynomial in |V|), or exponential (power law in |V|)",
+                        "enum": ["constant_power", "constant_current", "constant_impedance", "zip", "exponential"]
                     },
                     "v_nom": {
                         "type": "array",
@@ -463,14 +471,14 @@
                     },
                     "s_max": {
                         "type": "array",
-                        "description": "Optional per-phase apparent-power rating [VA]; one entry per phase conductor (length = terminal_map - 1). Stamps the apparent-power circle pg²+qg² ≤ s_max²",
+                        "description": "Optional per-phase apparent-power rating [VA]; one entry per phase conductor (length = terminal_map - 1). Stamps the apparent-power circle pg^2 + qg^2 <= s_max^2",
                         "items": {
                             "$ref": "#/$defs/nonnegative_number"
                         }
                     },
                     "i_max": {
                         "type": "array",
-                        "description": "Optional per-conductor current-magnitude limit [A]. WYE: one entry per phase plus a recommended final entry for the neutral return conductor (length = phases or phases+1; a phases-only vector leaves the neutral unrated and warns, since the neutral may carry more than the phases under unbalance). SINGLE_PHASE: length 1 or 2 (phase and return are the same current — a length-1 vector is standardised to 2). DELTA: exactly one entry per conductor. Stamps crg²+cig² ≤ i_max² on each phase current and (Σ crg)²+(Σ cig)² ≤ i_max_neutral² on the neutral return when the extra entry is present",
+                        "description": "Optional per-conductor current-magnitude limit [A]. WYE: one entry per phase, plus a recommended final entry for the neutral return conductor (length = phases or phases+1; a phases-only vector leaves the neutral unrated and warns, since the neutral may carry more than the phases under unbalance). SINGLE_PHASE: length 1 or 2 (phase and return share a current; a length-1 vector is standardised to 2). Stamps crg^2 + cig^2 <= i_max^2 on each phase current, and (sum crg)^2 + (sum cig)^2 <= i_max_neutral^2 on the neutral return when the extra entry is present. DELTA generators are future work (see the math spec for the array rules).",
                         "items": {
                             "$ref": "#/$defs/nonnegative_number"
                         }
@@ -506,7 +514,7 @@
         },
         "ibr": {
             "type": "object",
-            "description": "Inverter-based resources (IBR): PV arrays, battery storage, or generic sources interfaced to the AC network through an inverter/converter",
+            "description": "Inverter-based resources (IBR): PV arrays, battery storage, or generic sources interfaced to the AC network through an inverter/converter. Optional extension: scope for the July release is under Task Force review.",
             "additionalProperties": {
                 "type": "object",
                 "additionalProperties": false,
@@ -532,7 +540,7 @@
                     },
                     "i_max": {
                         "type": "array",
-                        "description": "Optional per-conductor converter current-magnitude limit [A]. FOUR_LEG: one entry per phase plus a recommended final entry for the neutral conductor (length = phases or phases+1; a phases-only vector leaves the neutral unrated and warns, as it may carry more than the phases under unbalance compensation). SINGLE_PHASE: length 1 or 2 (phase and return are the same current — length-1 is standardised to 2). THREE_LEG: one entry per conductor (no neutral). When present, reactive capability rolls off ~linearly with voltage instead of staying flat at s_max; the neutral entry bounds Σ phase currents",
+                        "description": "Optional per-conductor converter current-magnitude limit [A]. FOUR_LEG: one entry per phase plus a recommended final entry for the neutral conductor (length = phases or phases+1; a phases-only vector leaves the neutral unrated and warns, as it may carry more than the phases under unbalance compensation). SINGLE_PHASE: length 1 or 2 (phase and return are the same current - length-1 is standardised to 2). THREE_LEG: one entry per conductor (no neutral). When present, reactive capability rolls off ~linearly with voltage instead of staying flat at s_max; the neutral entry bounds the sum of phase currents",
                         "items": {
                             "$ref": "#/$defs/nonnegative_number"
                         }
@@ -565,7 +573,7 @@
                     },
                     "dc_bus": {
                         "type": "string",
-                        "description": "Optional reference to a dc_bus id. When present, the converter's DC port injects into that shared DC node (participating in its DC KCL) instead of an isolated private DC link — this is how converter stations / back-to-back SOPs / MVDC ties are formed (several IBRs sharing one dc_bus). When absent, dc_link_coupled retains its isolated-link meaning (p_dc_min/p_dc_max bound)."
+                        "description": "Optional reference to a dc_bus id. When present, the converter's DC port injects into that shared DC node (participating in its DC KCL) instead of an isolated private DC link - this is how converter stations / back-to-back SOPs / MVDC ties are formed (several IBRs sharing one dc_bus). When absent, dc_link_coupled retains its isolated-link meaning (p_dc_min/p_dc_max bound)."
                     },
                     "dc_terminal_map": {
                         "$ref": "#/$defs/terminal_map_type",
@@ -836,7 +844,7 @@
         },
         "wire_data": {
             "type": "object",
-            "description": "Reusable conductor/cable type library (geometry-free construction data). Referenced by line_geometry conductors. All quantities SI: Ohm/m, m, A, degC",
+            "description": "Reusable conductor/cable type library (geometry-free construction data). Referenced by line_geometry conductors. All quantities SI: Ohm/m, m, A, degC. Community extension (with line_geometry): geometry-to-impedance derivation is outside the core Task Force scope for the July release.",
             "additionalProperties": {
                 "type": "object",
                 "additionalProperties": false,
@@ -936,7 +944,7 @@
         },
         "line_geometry": {
             "type": "object",
-            "description": "Reusable line/cable cross-section assemblies: wire_data types placed at coordinates, each mapped to a circuit terminal. Compiled into linecodes by compile_linecode. Every conductor maps to a terminal - the compiled matrix is the full primitive matrix (no Kron elimination pathway; grounding lives on bus perfectly_grounded_terminals)",
+            "description": "Reusable line/cable cross-section assemblies: wire_data types placed at coordinates, each mapped to a circuit terminal. Compiled into linecodes by compile_linecode. Every conductor maps to a terminal - the compiled matrix is the full primitive matrix (no Kron elimination pathway; grounding lives on bus perfectly_grounded_terminals). Community extension (with wire_data): geometry-to-impedance derivation is outside the core Task Force scope for the July release.",
             "additionalProperties": {
                 "type": "object",
                 "additionalProperties": false,
@@ -1068,7 +1076,7 @@
         },
         "dc_bus": {
             "type": "object",
-            "description": "Collection of DC buses (nodes of an MVDC/LVDC network). DC voltage is a signed magnitude relative to earth — no angle. A 1- or 2-terminal dc_bus is a monopole, a 3-terminal dc_bus is a bipole (positive pole, negative pole, metallic return).",
+            "description": "Collection of DC buses (nodes of an MVDC/LVDC network). DC voltage is a signed magnitude relative to earth - no angle. A 1- or 2-terminal dc_bus is a monopole, a 3-terminal dc_bus is a bipole (positive pole, negative pole, metallic return). DC extension (all dc_* objects): under Task Force review for the July release.",
             "additionalProperties": {
                 "type": "object",
                 "additionalProperties": false,
@@ -1213,7 +1221,7 @@
         },
         "time_series": {
             "type": "object",
-            "description": "Named time-series profiles. Components reference a profile via their own time_series map (parameter name -> profile id); get_snapshot multiplies the static parameter by values[t_index].",
+            "description": "Named time-series profiles. Components reference a profile via their own time_series map (parameter name -> profile id); get_snapshot multiplies the static parameter by values[t_index]. Optional extension: time-series support is under review for the July release.",
             "additionalProperties": {
                 "type": "object",
                 "properties": {
@@ -1264,11 +1272,6 @@
             "description": "Element configuration, as WYE, DELTA, or SINGLE_PHASE",
             "enum": ["WYE", "DELTA", "SINGLE_PHASE"]
         },
-        "load_model_type": {
-            "type": "string",
-            "description": "Voltage dependence of the load: constant_power (default), constant_current (P∝|V|), constant_impedance (P∝|V|²), zip (polynomial in |V|), or exponential (power law in |V|)",
-            "enum": ["constant_power", "constant_current", "constant_impedance", "zip", "exponential"]
-        },
         "inverter_topology_type": {
             "type": "string",
             "description": "Inverter topology: SINGLE_PHASE (2 terminals), THREE_LEG (3 terminals, no neutral current), FOUR_LEG (4 terminals, neutral current available)",
@@ -1276,7 +1279,7 @@
         },
         "prime_mover_type": {
             "type": "string",
-            "description": "Energy source behind the inverter: PV (non-negative, resource-limited active power), BATTERY (bidirectional), GENERIC, or STATCOM (no active source — pure reactive shunt compensator; DSTATCOM is the distribution-system alias)",
+            "description": "Energy source behind the inverter: PV (non-negative, resource-limited active power), BATTERY (bidirectional), GENERIC, or STATCOM (no active source - pure reactive shunt compensator; DSTATCOM is the distribution-system alias)",
             "enum": ["PV", "BATTERY", "GENERIC", "STATCOM", "DSTATCOM"]
         },
         "dc_pole_type": {
@@ -1481,7 +1484,7 @@
                     },
                     "tap_min": {
                         "$ref": "#/$defs/nonnegative_number",
-                        "description": "Lower bound on the continuous tap multiplier. With tap_min < tap_max the tap is a free OPF variable; otherwise it is fixed at 'tap'."
+                        "description": "Lower bound on the continuous tap multiplier. With tap_min < tap_max the tap is a free OPF variable; otherwise it is fixed at 'tap'. Note: this is a continuous relaxation; discrete tap step sizes are future work."
                     },
                     "tap_max": {
                         "$ref": "#/$defs/nonnegative_number",
@@ -1609,7 +1612,7 @@
                     },
                     "tap_min": {
                         "$ref": "#/$defs/nonnegative_number",
-                        "description": "Lower bound on the continuous tap multiplier. With tap_min < tap_max the tap is a free OPF variable; otherwise it is fixed at 'tap'."
+                        "description": "Lower bound on the continuous tap multiplier. With tap_min < tap_max the tap is a free OPF variable; otherwise it is fixed at 'tap'. Note: this is a continuous relaxation; discrete tap step sizes are future work."
                     },
                     "tap_max": {
                         "$ref": "#/$defs/nonnegative_number",

--- a/test/data/LV/lv1_14bus_timeseries.json
+++ b/test/data/LV/lv1_14bus_timeseries.json
@@ -588,7 +588,7 @@
   "meta": {
     "$schema": "https://raw.githubusercontent.com/frederikgeth/bmopf-report/main/schema/bmopf.json",
     "created": "2026-07-06T06:10:21Z",
-    "generator": {
+    "case_study_generator": {
       "version": "0.6.2",
       "tool": "powerio"
     },

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -287,7 +287,7 @@ const IEEE13_FIXTURE = """
                 "authors" => [Dict("name" => "Test Author",
                                    "email" => "test@example.com",
                                    "orcid" => "0000-0001-2345-6789")],
-                "sources" => [Dict("name" => "IEEE 13-bus", "format" => "OpenDSS",
+                "data_sources" => [Dict("name" => "IEEE 13-bus", "format" => "OpenDSS",
                                    "doi"  => "10.1109/TPWRS.2012.2209630")],
             ))
             String(take!(buf))
@@ -295,9 +295,9 @@ const IEEE13_FIXTURE = """
         m2 = parse_bmopf(json_caller; from_string=true)["meta"]
         @test m2["title"] == "IEEE 13-bus mini"
         @test m2["authors"][1]["orcid"] == "0000-0001-2345-6789"
-        @test m2["sources"][1]["doi"] == "10.1109/TPWRS.2012.2209630"
+        @test m2["data_sources"][1]["doi"] == "10.1109/TPWRS.2012.2209630"
         @test haskey(m2, "\$schema")      # auto-filled
-        @test haskey(m2, "generator")     # auto-filled
+        @test haskey(m2, "case_study_generator")     # auto-filled
 
         # existing created is preserved across write → parse → write
         net4 = parse_bmopf(json_auto; from_string=true)
@@ -312,7 +312,7 @@ const IEEE13_FIXTURE = """
                 "title"   => "t",
                 "license" => "https://example.com/license",
                 "authors" => [Dict("name" => "A", "orcid" => "0000-0001-2345-6789")],
-                "sources" => [Dict("name" => "S", "url" => "https://example.com/data")],
+                "data_sources" => [Dict("name" => "S", "url" => "https://example.com/data")],
             ))
             parse_bmopf(String(take!(buf)); from_string=true)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -273,8 +273,8 @@ const IEEE13_FIXTURE = """
         m = parse_bmopf(json_auto; from_string=true)["meta"]
         @test m["\$schema"] == BMOPFTools._BMOPF_SCHEMA_URI
         @test haskey(m, "created")
-        @test m["generator"]["tool"] == "BMOPFTools.jl"
-        @test !isempty(m["generator"]["version"])
+        @test m["case_study_generator"]["tool"] == "BMOPFTools.jl"
+        @test !isempty(m["case_study_generator"]["version"])
 
         # _meta (tool-private) is not serialised
         @test !occursin("\"_meta\"", json_auto)

--- a/test/write_bmopf_tests.jl
+++ b/test/write_bmopf_tests.jl
@@ -125,9 +125,9 @@ end
         parsed = JSON3.read(raw)
         meta   = parsed["meta"]
         @test haskey(meta, "\$schema")
-        @test haskey(meta, "generator")
+        @test haskey(meta, "case_study_generator")
         @test haskey(meta, "created")
-        @test meta["generator"]["tool"] == "BMOPFTools.jl"
+        @test meta["case_study_generator"]["tool"] == "BMOPFTools.jl"
     end
 
     # ── write_result / read_result round-trip ─────────────────────────────────


### PR DESCRIPTION
…tch)

Sort out the bmopf-report PR #16 review feedback in the source-of-truth schema and carry the changes through tooling, tests and docs.

- version: drop "Draft" from the title, add "version": "0.1.0"
- add a free-form top-level "extras" escape hatch; keep additionalProperties false everywhere else
- purge non-ASCII from descriptions (proportional to / ^2 / <= / sum / -)
- v_min/v_max wording -> "per bus terminal"
- dedup configuration_type description on capacitor; inline load.model and drop the single-use load_model_type $def
- decouple provenance/frequency descriptions from tool/check-code internals
- rename meta.sources -> data_sources, meta.generator -> case_study_generator (writer, semantic validator, tests, docs, fixture)
- annotate IBR / dc_* / line_geometry+wire_data / time_series / continuous tap / delta generators as optional/extension/future-work

Sync with https://github.com/frederikgeth/bmopf-report/pull/16