### PR TITLE
State estimation via the staged API: guard test + dev-reference docs

### DIFF
--- a/docs/src/dev/opf_engine.md
+++ b/docs/src/dev/opf_engine.md
@@ -108,6 +108,44 @@ transformer leakage to exact zero (pass 9) — and the
 [zero-voltage / ill-conditioning traps](../bounds/known_traps.md) page catalogues
 what happens when this is gotten wrong.
 
+## Extending the engine without forking it
+
+The "not a model zoo" stance above is only tenable because the engine is
+extensible from *outside*: a downstream package can add devices, swap the
+objective, couple time steps, or pose an entirely different problem — reusing all
+the device physics, per-unit handling, and result extraction — without a new
+constraint landing in `ext/BMOPFOpfExt/`. Three seams, in increasing order of
+reach (full detail under
+[extending the formulation](../opf.md#extending-the-formulation)):
+
+- **`model_hook!(ctx)` / `solution_hook!(ctx, result)`** — add custom variables,
+  constraints, or objective terms to a single solve, then read their solved
+  values. A hook device stamps its current into `ctx.kcl_r`/`ctx.kcl_i` and may
+  register its net injection as `result["custom_injection"]` so the power-balance
+  check in [`profile_solution`](../validation.md) stays honest. This is how a
+  battery, EV charger, or bespoke limit is added **without touching the JSON
+  spec**.
+- **The staged API** ([`build_opf_model`](@ref) → [`enforce_kcl!`](@ref) →
+  [`extract_result`](@ref), with [`generation_cost`](@ref) for the objective) —
+  unfuses build/solve/extract so several snapshots share one JuMP model. This is
+  what makes **inter-temporal** coupling (battery state of charge across a
+  horizon) expressible, which the single-shot [`solve_opf`](@ref) cannot do; see
+  [the staged API](../opf.md#staged-api).
+- **A different problem specification entirely.** Because `build_opf_model` adds
+  operational limits only where the net *declares* them, a bounds-free net yields
+  a pure physics model with free voltages; with `add_objective=false` and a
+  `model_hook!` objective this hosts **state estimation**, parameter estimation,
+  and other model-fitting problems that are not dispatch optimisation. See
+  [Beyond OPF](../opf.md#beyond-opf).
+
+Internally the same seam is the `build!` *recipe* (`build_opf!`, `build_pf!`,
+`build_feasibility!`): a fourth problem type is a fourth recipe over the
+invariant `_build_and_solve` pipeline. Promoting that recipe entry point to a
+public `build_custom_model` is the natural step **if** such a formulation
+graduates from a downstream experiment to accepted practice — the same "fold it
+back in via the spec" path the model-zoo warning describes. Until then, the
+public hooks and staged API let you build it in your own package.
+
 ## Keep it behind the extension boundary
 
 !!! warning "The OPF engine may be carved out into its own package"

--- a/docs/src/opf.md
+++ b/docs/src/opf.md
@@ -1241,7 +1241,7 @@ println(diag["is_feasible"])            # false if network is overloaded
 println(diag["total_infeasibility_A"])  # L2 norm of all slacks (A)
 ```
 
-## Solver control and extending the formulation
+## [Solver control and extending the formulation](@id extending-the-formulation)
 
 All three entry points (`solve_opf`, `solve_pf`, `solve_feasibility_opf`)
 accept:
@@ -1294,7 +1294,7 @@ unwrapping, with the model still live: read `JuMP.value` of the variables a
 counted by `profile_solution`'s power-balance check, so a correct solve no
 longer trips a spurious `W.SOL.POWER_BALANCE`.
 
-### Multi-period and storage: the staged API
+### [Multi-period and storage: the staged API](@id staged-api)
 
 `solve_opf` builds, solves, and extracts one snapshot in a single fused call —
 it cannot express constraints that couple one time step to the next, such as a
@@ -1337,7 +1337,7 @@ Everything a snapshot exposes for coupling — `ctx.model`, `ctx.vars`,
 `ctx.bases`, `ctx.kcl_r`/`ctx.kcl_i` — is the same context object a `model_hook!`
 receives, so custom devices are declared exactly as in the single-snapshot case.
 
-### Beyond OPF: other problem specifications
+### [Beyond OPF: other problem specifications](@id beyond-opf)
 
 The staged API is problem-agnostic — it exposes the network physics, not just
 the dispatch problem. Because `build_opf_model` adds operational limits only

--- a/docs/src/opf.md
+++ b/docs/src/opf.md
@@ -1337,6 +1337,26 @@ Everything a snapshot exposes for coupling — `ctx.model`, `ctx.vars`,
 `ctx.bases`, `ctx.kcl_r`/`ctx.kcl_i` — is the same context object a `model_hook!`
 receives, so custom devices are declared exactly as in the single-snapshot case.
 
+### Beyond OPF: other problem specifications
+
+The staged API is problem-agnostic — it exposes the network physics, not just
+the dispatch problem. Because `build_opf_model` adds operational limits only
+where the net *declares* them (`v_min`/`v_max`/`i_max`), a net that omits them
+yields a pure physics model with the bus voltages left free. Combined with
+`add_objective=false` and a `model_hook!` that supplies its own objective, this
+hosts estimation and fitting problems that are not dispatch optimisation at all.
+
+For example, **weighted-least-squares state estimation** is: build the physics
+of a bounds-free, load-free net (`source` + `line`s), add a free injection
+current at each measured bus via a `model_hook!` (so KCL closes with the
+voltages free to fit the data), and set the objective to the weighted sum of
+squared measurement residuals `∑ wᵢ (zᵢ − hᵢ(state))²` for voltage-magnitude and
+power-injection measurements. The solve returns the state that best explains the
+measurements; with measurement redundancy it filters noise the raw readings
+cannot. The same seam supports parameter estimation and other model-fitting
+formulations — the device physics, per-unit handling, and multi-instance
+coupling are reused unchanged.
+
 ---
 
 ## API reference

--- a/src/BMOPFTools.jl
+++ b/src/BMOPFTools.jl
@@ -1033,17 +1033,45 @@ JuMP.optimize!(model)
 results = [extract_result(c) for c in ctxs]
 ```
 
-See each function's own docstring (in the extension) for the full contract.
+The full per-argument contract for each function is documented on its own entry
+below.
 """
 function build_opf_model end
 export build_opf_model
 
+"""
+    enforce_kcl!(ctx) -> ctx
+
+Enforce Kirchhoff's current law for one snapshot's accumulators (AC nodal balance
++ DC network), after every device constraint and `model_hook!` injection for that
+snapshot has contributed. Second step of the staged API (see
+[`build_opf_model`](@ref)); call once per snapshot `ctx` before `JuMP.optimize!`.
+Implemented in the `BMOPFOpfExt` extension.
+"""
 function enforce_kcl! end
 export enforce_kcl!
 
+"""
+    generation_cost(ctx) -> JuMP.QuadExpr
+
+The snapshot's total active-power generation-cost expression — the quantity
+[`solve_opf`](@ref) minimises — returned WITHOUT setting it on the model. Sum
+these across snapshots (adding any custom terms) and call `JuMP.@objective` once
+for a multi-period solve. Pairs with `build_opf_model(...; add_objective=false)`.
+Implemented in the `BMOPFOpfExt` extension.
+"""
 function generation_cost end
 export generation_cost
 
+"""
+    extract_result(ctx; solution_hook!=nothing) -> Dict{String,Any}
+
+Extract one snapshot's SI result dict from the solved model (call
+`JuMP.optimize!(ctx.model)` first). Mirrors [`solve_opf`](@ref)'s output for that
+snapshot: runs the optional `solution_hook!(ctx, result)`, attaches `opt_profile`,
+and unwraps per-unit back to SI. Final step of the staged API (see
+[`build_opf_model`](@ref)). Implemented in the `BMOPFOpfExt` extension.
+"""
 function extract_result end
 export extract_result
 

--- a/test/opf_tests.jl
+++ b/test/opf_tests.jl
@@ -899,6 +899,109 @@
         end
     end
 
+    @testset "T-STATE-EST: WLS state estimation via the staged API (different problem spec)" begin
+        # The staged API is problem-agnostic: the same device physics underlies a
+        # DIFFERENT problem specification — weighted-least-squares state estimation.
+        # No operational bounds, no fixed loads, a measurement-residual objective.
+        # This guards that build_opf_model(add_objective=false) + model_hook! can
+        # host an estimator (bounds are added only where the net declares them,
+        # so a bounds-free net yields a pure physics model with free voltages).
+
+        # Ground truth from a determined power flow on a 3-bus resistive feeder.
+        truejson = """
+        {"bus":{
+            "src": {"terminal_names":["1","n"],"perfectly_grounded_terminals":["n"]},
+            "bus1":{"terminal_names":["1","n"],"perfectly_grounded_terminals":["n"]},
+            "bus2":{"terminal_names":["1","n"],"perfectly_grounded_terminals":["n"]}},
+         "voltage_source":{"vs":{"bus":"src","terminal_map":["1"],
+             "v_magnitude":[1000.0],"v_angle":[0.0]}},
+         "linecode":{"lc":{"R_series_1_1":0.5}},
+         "line":{
+            "l1":{"bus_from":"src","bus_to":"bus1","terminal_map_from":["1"],"terminal_map_to":["1"],"linecode":"lc","length":1.0},
+            "l2":{"bus_from":"bus1","bus_to":"bus2","terminal_map_from":["1"],"terminal_map_to":["1"],"linecode":"lc","length":1.0}},
+         "load":{
+            "d1":{"bus":"bus1","terminal_map":["1","n"],"configuration":"SINGLE_PHASE","p_nom":[20000.0],"q_nom":[0.0]},
+            "d2":{"bus":"bus2","terminal_map":["1","n"],"configuration":"SINGLE_PHASE","p_nom":[20000.0],"q_nom":[0.0]}}}
+        """
+        pf = solve_pf(parse_bmopf(truejson; from_string=true); per_unit=false)
+        true_vm = Dict(b => hypot(pf["bus"][b]["1"]["vr"], pf["bus"][b]["1"]["vi"])
+                       for b in ("bus1","bus2"))
+        # Constant-power loads draw exactly nominal ⇒ injection = −20 kW, 0 var.
+        true_pinj = Dict("bus1" => -20000.0, "bus2" => -20000.0)
+
+        # Estimator net: physics only — source + lines, NO loads, NO limits.
+        estjson = """
+        {"bus":{
+            "src": {"terminal_names":["1","n"],"perfectly_grounded_terminals":["n"]},
+            "bus1":{"terminal_names":["1","n"],"perfectly_grounded_terminals":["n"]},
+            "bus2":{"terminal_names":["1","n"],"perfectly_grounded_terminals":["n"]}},
+         "voltage_source":{"vs":{"bus":"src","terminal_map":["1"],
+             "v_magnitude":[1000.0],"v_angle":[0.0]}},
+         "linecode":{"lc":{"R_series_1_1":0.5}},
+         "line":{
+            "l1":{"bus_from":"src","bus_to":"bus1","terminal_map_from":["1"],"terminal_map_to":["1"],"linecode":"lc","length":1.0},
+            "l2":{"bus_from":"bus1","bus_to":"bus2","terminal_map_from":["1"],"terminal_map_to":["1"],"linecode":"lc","length":1.0}}}
+        """
+        # meas :: Vector of (kind, bus, value, sigma), kind ∈ (:vm,:pinj,:qinj).
+        function estimate(meas)
+            est_net = parse_bmopf(estjson; from_string=true)
+            buses = unique(b for (_, b, _, _) in meas)
+            function wls!(ctx)
+                m = ctx.model
+                vr = ctx.vars[:vr]; vi = ctx.vars[:vi]
+                cr = Dict{String,Any}(); ci = Dict{String,Any}()
+                for b in buses         # free injection so KCL closes; voltages stay free
+                    cr[b] = JuMP.@variable(m, base_name="cinj_r_$b")
+                    ci[b] = JuMP.@variable(m, base_name="cinj_i_$b")
+                    JuMP.add_to_expression!(ctx.kcl_r[(b,"1")],  cr[b])
+                    JuMP.add_to_expression!(ctx.kcl_i[(b,"1")],  ci[b])
+                    JuMP.add_to_expression!(ctx.kcl_r[(b,"n")], -cr[b])
+                    JuMP.add_to_expression!(ctx.kcl_i[(b,"n")], -ci[b])
+                end
+                obj = zero(JuMP.QuadExpr)
+                for (kind, b, z, σ) in meas
+                    w = 1.0 / σ^2; vrb = vr[(b,"1")]; vib = vi[(b,"1")]
+                    if kind == :vm
+                        r = JuMP.@expression(m, vrb^2 + vib^2 - z^2)
+                        obj += (w / (2z)^2) * r^2
+                    elseif kind == :pinj
+                        obj += w * JuMP.@expression(m, vrb*cr[b] + vib*ci[b] - z)^2
+                    elseif kind == :qinj
+                        obj += w * JuMP.@expression(m, vib*cr[b] - vrb*ci[b] - z)^2
+                    end
+                end
+                JuMP.@objective(m, Min, obj)
+            end
+            ctx = build_opf_model(est_net; per_unit=false, add_objective=false, model_hook! = wls!)
+            enforce_kcl!(ctx)
+            JuMP.optimize!(ctx.model)
+            extract_result(ctx)
+        end
+
+        σv = 2.0; σp = 400.0
+        mk(nz) = vcat([[(:vm, b, true_vm[b] + nz[b][1], σv),
+                        (:pinj, b, true_pinj[b] + nz[b][2], σp),
+                        (:qinj, b, 0.0 + nz[b][3], σp)] for b in ("bus1","bus2")]...)
+
+        # (1) Noiseless measurements ⇒ estimate recovers the true state exactly.
+        zero_nz = Dict(b => (0.0,0.0,0.0) for b in ("bus1","bus2"))
+        res0 = estimate(mk(zero_nz))
+        @test res0["termination_status"] in ("LOCALLY_SOLVED","OPTIMAL")
+        for b in ("bus1","bus2")
+            @test res0["bus"][b]["1"]["vm"] ≈ true_vm[b]  atol=1e-2
+        end
+
+        # (2) Fixed, deterministic perturbation ⇒ estimate stays within a few σ of
+        # truth (graceful degradation; no reliance on an RNG in the suite).
+        pert = Dict("bus1" => ( 1.5, -300.0, 0.0),
+                    "bus2" => (-2.5,  350.0, 0.0))
+        resN = estimate(mk(pert))
+        @test resN["termination_status"] in ("LOCALLY_SOLVED","OPTIMAL")
+        for b in ("bus1","bus2")
+            @test abs(resN["bus"][b]["1"]["vm"] - true_vm[b]) <= 3σv
+        end
+    end
+
     @testset "T-WSTART: warm start honours a/b/c terminal naming" begin
         # Regression: canonical 120° start angles were keyed by the literal
         # names "1"/"2"/"3"; a bus using another convention (not covered by


### PR DESCRIPTION
## What

Proves and documents that the OPF engine's staged public API (`build_opf_model` + `model_hook!`) is **problem-agnostic**: the same device physics hosts a different problem specification — weighted-least-squares (WLS) **state estimation** — with no new engine code.

This is the "prove it first" follow-up to the `solution_hook!` / staged-API work (PR #328). It adds no new engine capability; it locks in and documents one the merged API already enables.

## Why it works today

`build_opf_model` adds operational limits only where the net *declares* them, so a bounds-free, load-free net yields a pure physics model with free bus voltages. A `model_hook!` then adds free injection currents at measured buses (so KCL closes) plus a measurement-residual objective via `add_objective=false`. No recipe seam needs to be exposed for basic SE.

## Changes

- **`test/opf_tests.jl` — `T-STATE-EST`**: builds a WLS estimator on a 3-bus feeder. Noiseless measurements recover the true state exactly; a fixed deterministic perturbation stays within 3σ of truth. Guards that the "bounds only where declared" and free-voltage physics properties the estimator relies on don't regress.
- **`docs/src/dev/opf_engine.md` — "Extending the engine without forking it"**: documents the three extension seams (`model_hook!`/`solution_hook!`, the staged API, and different problem specifications like state estimation), answering the question the page's "not a model zoo" stance raises.
- **`docs/src/opf.md`**: "Beyond OPF" section + explicit `@id` anchors for cross-references.
- **Docstring fix**: `enforce_kcl!`, `generation_cost`, `extract_result` carried docstrings only on their extension methods, which Documenter (`modules=[BMOPFTools]`) doesn't collect — so their `@docs` entries and `@ref`s failed to resolve and the docs build was **already broken on main** since #328. Added docstrings on the src stubs, mirroring `solve_opf`.

## Verification

- Full test suite: **4008 passed, 0 failed** (33 pre-existing broken).
- `julia --project=docs docs/make.jl` builds clean (exit 0) — this branch also fixes the latent docs-build breakage from #328.
- Separately (not committed): over 100 noise draws the fused estimate cut mean voltage RMS error 81% (1.73 V → 0.34 V), beating raw measurements in 94/100 draws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)