### PR TITLE
docs: newcomer onboarding — installation page, prerequisites, from_dss warnings report

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,30 @@ OpenDSS .dss ──(from_dss / PowerIO.jl)──► BMOPF Dict{String,Any} ◄�
 
 ## Installation
 
-BMOPFTools requires **Julia ≥ 1.10**.  It is not yet in the General registry,
-so install it from this Git URL:
+### Prerequisites
+
+BMOPFTools requires **Julia ≥ 1.10**. If you don't have Julia yet, install it
+with [juliaup](https://github.com/JuliaLang/juliaup), the official version
+manager — on Windows via the
+[Microsoft Store](https://apps.microsoft.com/detail/9NJNWW8PVKMN) (or
+`winget install julia -s msstore`), on macOS/Linux via
+`curl -fsSL https://install.julialang.org | sh` — or grab an installer from
+[julialang.org/downloads](https://julialang.org/downloads/).
+
+A note on the code blocks below: `julia` blocks are **Julia code** — run
+`julia` in your terminal first, then type them at the `julia>` prompt — while
+`sh` blocks go in your system terminal (Command Prompt / PowerShell / bash).
+Completely new to Julia? The
+[Installation & first steps](https://frederikgeth.github.io/BMOPFTools.jl/docs/installation/)
+docs page walks through all of this, and the official
+[Getting Started](https://docs.julialang.org/en/v1/manual/getting-started/)
+guide and [julialang.org/learning](https://julialang.org/learning/) cover the
+language basics.
+
+### Installing the package
+
+BMOPFTools is not yet in the General registry (Julia's default package
+catalogue), so install it from this Git URL:
 
 ```julia
 using Pkg

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,6 +13,7 @@ makedocs(
     pages = [
         "Home"                    => "index.md",
         "Getting started"         => [
+            "Installation & first steps" => "installation.md",
             "End-to-end tutorial"      => "tutorial_end_to_end.md",
             "Choose your tutorial"     => "choose_tutorial.md",
             "Positioning & ecosystem"  => "positioning.md",

--- a/docs/src/choose_tutorial.md
+++ b/docs/src/choose_tutorial.md
@@ -44,4 +44,5 @@ independent verification → fidelity consequences.**
 !!! tip "Prerequisites"
     The solve/verify tutorials run a real OPF, so they need a Julia environment
     with `BMOPFTools`, `JuMP` and `Ipopt`. The data-model and conversion pages
-    need only `BMOPFTools`.
+    need only `BMOPFTools`. [Installation & first steps](installation.md)
+    covers setting all of this up, starting from installing Julia itself.

--- a/docs/src/conversion.md
+++ b/docs/src/conversion.md
@@ -160,6 +160,34 @@ regulator/auto-transformer families — is catalogued under
 [Known limitations](#Known-limitations); most are tracked as upstream PowerIO.jl
 issues.
 
+### [Ingest warnings: the full report](@id ingest-warnings)
+
+`from_dss` is loud about fidelity loss: every piece of OpenDSS information
+that could not be represented in BMOPF is collected during the parse. The
+console `Warning` you see after a call is a **preview only** — it shows the
+first five items plus an `… and N more` count. Nothing is lost, and nothing
+is written to disk: the **complete list travels with the returned network
+dict**, so you can inspect it whenever you like:
+
+```julia
+net = from_dss("Master.dss")
+
+net["_meta"]["powerio_warnings"]      # Vector{String} — every warning, untruncated
+println.(net["_meta"]["powerio_warnings"]);   # print them all, one per line
+net["_meta"]["powerio_source"]        # absolute path of the parsed .dss file
+```
+
+Because the list is ordinary data on the dict, it survives into any
+downstream processing and can be filtered like any vector, e.g.
+`filter(contains("transformer"), net["_meta"]["powerio_warnings"])`.
+
+Note the distinction from the [analysis framework](analysis.md):
+[`analyze`](@ref) validates the *content* of the resulting network (schema,
+completeness, domain rules, …) and does **not** re-surface these ingest
+warnings — `powerio_warnings` is about what the conversion could not carry
+over, `analyze` is about the quality of what arrived. Run both after an
+import.
+
 ### Identifier case-folding
 
 OpenDSS identifiers are case-*insensitive* but case-*preserving*: `SourceBus`,

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -53,8 +53,12 @@ codes, never on message text.
 
 ## Installation
 
-BMOPFTools requires **Julia ≥ 1.10**. It is not yet in the General registry,
-so install it from its Git URL:
+BMOPFTools requires **Julia ≥ 1.10**. New to Julia? The
+[Installation & first steps](installation.md) page covers installing Julia
+itself (via [juliaup](https://github.com/JuliaLang/juliaup)), what the
+`julia>` prompt is and where these commands go, and how to set up for the
+tutorials — start there. The package is not yet in the General registry,
+so install it from its Git URL at the `julia>` prompt:
 
 ```julia
 using Pkg

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -1,0 +1,136 @@
+# Installation & first steps
+
+This page takes you from a bare machine to a Julia session where the
+[end-to-end tutorial](tutorial_end_to_end.md) runs. If you already use Julia
+day-to-day, the [Installing BMOPFTools](@ref installing-bmopftools) section is
+all you need.
+
+## Prerequisites: installing Julia
+
+BMOPFTools is a [Julia](https://julialang.org) package and requires
+**Julia ≥ 1.10**. The recommended way to install Julia on every platform is
+[**juliaup**](https://github.com/JuliaLang/juliaup), the official version
+manager — it installs the current release and keeps it updated:
+
+- **Windows** — install from the
+  [Microsoft Store](https://apps.microsoft.com/detail/9NJNWW8PVKMN), or from a
+  terminal (Command Prompt or PowerShell):
+
+  ```sh
+  winget install julia -s msstore
+  ```
+
+- **macOS / Linux** — in a terminal:
+
+  ```sh
+  curl -fsSL https://install.julialang.org | sh
+  ```
+
+Standalone installers are also available from the
+[official downloads page](https://julialang.org/downloads/). Either route puts
+a `julia` command on your PATH; open a *new* terminal window afterwards so the
+PATH change takes effect.
+
+If Julia itself is new to you, the official
+[Getting Started](https://docs.julialang.org/en/v1/manual/getting-started/)
+manual page and the community
+[“Get started with Julia”](https://julialang.org/learning/) learning hub
+(free tutorials and courses) cover the basics in an hour or two. The
+[Pkg documentation](https://pkgdocs.julialang.org/v1/getting-started/)
+explains the package manager used below.
+
+## The Julia REPL — where the commands go
+
+Typing `julia` in your terminal (or launching Julia from the Start menu)
+opens the **REPL**, Julia's interactive prompt:
+
+```
+julia>
+```
+
+This is where Julia code runs — **not** the Windows Command Prompt,
+PowerShell, or a Unix shell. Throughout this documentation:
+
+- ```` ```julia ```` code blocks (and the executed example blocks in the
+  tutorials) are **Julia code**: type or paste them at the `julia>` prompt,
+  or put them in a `.jl` script.
+- ```` ```sh ```` code blocks are **system terminal commands**: run them in
+  Command Prompt / PowerShell / bash, *not* inside Julia.
+
+One more prompt you will meet: pressing `]` at the `julia>` prompt switches
+the REPL into **package mode** (`pkg>`), Julia's built-in package manager.
+Press backspace to return to `julia>`. Everything package mode does is also
+available as ordinary function calls via `using Pkg` — this documentation
+uses the function form (`Pkg.add(...)`) because it works identically in
+scripts, but `pkg> add ...` and `Pkg.add("...")` are interchangeable.
+
+## [Installing BMOPFTools](@id installing-bmopftools)
+
+BMOPFTools is not yet in Julia's **General registry** (the default catalogue
+`Pkg.add("SomePackage")` searches), so install it from its Git URL. At the
+`julia>` prompt:
+
+```julia
+using Pkg
+Pkg.add(url = "https://github.com/frederikgeth/BMOPFTools.jl")
+```
+
+The first install resolves and compiles the dependency tree, which takes a
+few minutes; later sessions start fast. Then check it loads:
+
+```julia
+using BMOPFTools
+```
+
+Parsing, validation, analysis, reporting, and OpenDSS ingestion
+([`from_dss`](@ref)) now work out of the box.
+
+### Optional: the OPF / power-flow solvers
+
+`solve_opf`, `solve_pf` and `solve_feasibility_opf` live in a **package
+extension**: optional functionality that activates automatically once its
+extra dependencies are installed. The tutorials that solve an OPF need
+**JuMP** (the optimisation modelling layer) and a solver such as **Ipopt**:
+
+```julia
+Pkg.add(["JuMP", "Ipopt"])
+using BMOPFTools, JuMP, Ipopt   # extension activates on load
+```
+
+!!! note "Tracking a moving target"
+    The package is under rapid development, with breaking changes landing
+    directly on `main`. Pin a specific revision when you need reproducibility:
+    `Pkg.add(url = "https://github.com/frederikgeth/BMOPFTools.jl", rev = "<commit-sha>")`.
+
+## Running the tutorials from a clone
+
+Every tutorial can be followed by copy-pasting its code blocks into your own
+REPL after the install above. If you would rather run against the bundled
+test networks and the exact dependency versions the documentation is built
+with, work from a clone of the repository:
+
+```sh
+git clone https://github.com/frederikgeth/BMOPFTools.jl
+cd BMOPFTools.jl
+julia --project=docs
+```
+
+`--project=docs` starts Julia with the `docs/` folder's **environment** — the
+`Project.toml` file there pins the package set (BMOPFTools, JuMP, Ipopt, …).
+The first time, materialise that environment from inside the REPL:
+
+```julia
+using Pkg
+Pkg.develop(path = ".")   # use the cloned BMOPFTools source
+Pkg.instantiate()         # download and install the pinned dependencies
+```
+
+After that, `julia --project=docs` from the repository folder drops you
+straight into a session where every tutorial runs.
+
+## Where to next
+
+- The [end-to-end tutorial](tutorial_end_to_end.md) walks the primary
+  pipeline — OpenDSS in, solved OPF benchmark out — on a real feeder.
+- [Choose your tutorial](choose_tutorial.md) maps the rest of the tutorial
+  library to what you want to do.

--- a/docs/src/tutorial_end_to_end.md
+++ b/docs/src/tutorial_end_to_end.md
@@ -24,7 +24,9 @@ neutral reactors.
     A Julia session with BMOPFTools plus **JuMP** and **Ipopt** for the solve
     step: `using Pkg; Pkg.add(["JuMP", "Ipopt"])` in your own environment. If
     you are working from a clone of the repository, the docs environment
-    already has everything: `julia --project=docs`.
+    already has everything: `julia --project=docs`. First time with Julia, or
+    unsure what any of that means? Start with
+    [Installation & first steps](installation.md).
 
 !!! note "Two deep-dive tutorials branch off this one"
     Once the pipeline makes sense, [DER placement](tutorial_ders.md) explores the
@@ -55,8 +57,10 @@ println(rpad("transformer", 16), ": ", sum(length(v) for v in values(xfmr) if v 
 
 `from_dss` is loud about fidelity: the `Warning` it prints above lists every
 piece of OpenDSS information that has no BMOPF representation and was dropped
-(here mostly cosmetic fields such as linecode `units`); the full list stays
-inspectable at `net["_meta"]["powerio_warnings"]`.
+(here mostly cosmetic fields such as linecode `units`). The console preview is
+capped at five items — the full, untruncated list stays inspectable at
+`net["_meta"]["powerio_warnings"]` (see
+[Ingest warnings](@ref ingest-warnings)).
 
 ## 2. Analyze & diagnose
 


### PR DESCRIPTION
## Motivation

Feedback from a first-time user (never used Julia, on Windows):
1. Couldn't find the full `from_dss` validation/warning report — the console shows only a few warnings.
2. Needed help just to get Julia installed — asked for a Prerequisites section.
3. Took a while to realise the documented commands are Julia REPL input, not Windows Command Prompt commands.

## Changes

- **New docs page `installation.md`** (first entry in the *Getting started* nav group): installing Julia via juliaup (Windows/macOS/Linux), what the `julia>` and `pkg>` prompts are, a legend for `julia` vs `sh` code fences, links to official Julia learning resources, installing BMOPFTools + the JuMP/Ipopt extension, and the `git clone` + `julia --project=docs` + `instantiate` setup for running tutorials locally.
- **README**: new *Prerequisites* subsection (juliaup, downloads link, REPL-vs-terminal legend, learning links) ahead of the install snippet.
- **`conversion.md`**: new *Ingest warnings: the full report* section — documents that the console `Warning` is a 5-item preview and the complete untruncated list lives on `net["_meta"]["powerio_warnings"]` (plus `powerio_source`), with a `println.` one-liner and a note that `analyze()` does *not* re-surface ingest warnings.
- **`index.md`**, **`tutorial_end_to_end.md`**, **`choose_tutorial.md`**: installation/prerequisites text now links the new page; the end-to-end tutorial's warnings paragraph cross-references the new ingest-warnings section.

No code changes — the full warning list was already stored on the returned dict ([from_dss.jl](src/io/from_dss.jl)); this only makes it discoverable.

## Verification

Full local docs build (`julia --project=docs docs/make.jl`) passes — all `@example` blocks execute, cross-references resolve; only pre-existing size warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)