### PR TITLE
fix: replace deprecated Dates.UTC with UTC in _build_meta

### DIFF
--- a/src/io/write_bmopf.jl
+++ b/src/io/write_bmopf.jl
@@ -115,6 +115,17 @@ end
 Merge `base` (from `net["meta"]`) and `override` (from the `meta` kwarg),
 then fill in auto-generated defaults for `\$schema`, `case_study_generator`, and `created`
 if those keys are not already present. Never overwrites a value the caller set.
+
+The auto-generated fields are:
+
+- `\$schema` — URI of the BMOPF schema this file claims to conform to.
+- `case_study_generator` — tool name and version stamp.
+- `created` — wall-clock time of the write as an ISO-8601 UTC timestamp
+  (`yyyy-mm-ddTHH:MM:SSZ`). Always UTC, never local time, so stamps from
+  different machines are directly comparable. Note this makes `write_bmopf`
+  non-deterministic: writing the same network twice yields files differing in
+  this field. Pass `meta = Dict("created" => …)` to pin it, e.g. for byte-exact
+  round-trip tests.
 """
 function _build_meta(base::Dict,
                      override::Union{Dict,Nothing})::Dict{String,Any}
@@ -129,6 +140,6 @@ function _build_meta(base::Dict,
         "tool"    => "BMOPFTools.jl",
         "version" => _BMOPFTOOLS_VERSION,
     ))
-    get!(m, "created", Dates.format(now(Dates.UTC), dateformat"yyyy-mm-ddTHH:MM:SSZ"))
+    get!(m, "created", Dates.format(now(UTC), dateformat"yyyy-mm-ddTHH:MM:SSZ"))
     m
 end

--- a/test/write_bmopf_tests.jl
+++ b/test/write_bmopf_tests.jl
@@ -130,6 +130,19 @@ end
         @test meta["case_study_generator"]["tool"] == "BMOPFTools.jl"
     end
 
+    @testset "created field is a valid UTC timestamp" begin
+        buf = IOBuffer()
+        write_bmopf(net, buf)
+        raw    = String(take!(buf))
+        parsed = JSON3.read(raw)
+        created = get(parsed["meta"], "created", nothing)
+        @test !isnothing(created)
+        @test created isa AbstractString
+        # Must parse as a valid DateTime and end with Z (UTC marker)
+        @test endswith(created, "Z")
+        @test !isnothing(tryparse(DateTime, rstrip(created, 'Z')))
+    end
+
     # ── write_result / read_result round-trip ─────────────────────────────────
     @testset "write_result / read_result round-trip" begin
         # A solver-shaped result dict mirroring the network structure.


### PR DESCRIPTION
Dates.UTC was deprecated in Julia 1.10; the correct form is now(UTC) with UTC in scope from `using Dates`. The deprecation warning was visible to end users on every write_bmopf call.

No import changes required; Dates is already loaded in this module.