### PR TITLE
fix: strip longitude/latitude from bus objects in write_bmopf

### DIFF
--- a/src/io/write_bmopf.jl
+++ b/src/io/write_bmopf.jl
@@ -11,6 +11,11 @@ A `meta` block is always written. Fields are assembled in this priority order
 defaults (`\$schema`, `case_study_generator`, `created`). Caller-supplied values
 are never overwritten by auto-generation.
 
+The input `net` is never mutated. Tool-private state is not serialised verbatim:
+the `"_meta"` key is persisted under `meta.provenance`, and non-spec bus fields
+(see [`_DERIVED_BUS_FIELDS`](@ref)) are stripped so the output satisfies the
+schema's `additionalProperties: false` on bus objects.
+
 # Keyword argument
 - `meta`: a `Dict` of fields to include or override in the written `meta` block.
   All fields are optional; common ones are `title`, `description`, `license`,
@@ -79,18 +84,41 @@ end
 # Internal: drop tool-derived bus fields that are not part of the spec
 # ---------------------------------------------------------------------------
 
-# Fields the tool attaches to buses for internal convenience but which are not
-# in the BMOPF schema (bus objects declare additionalProperties:false). They are
-# derivable from `terminal_names` on read (see `_neutral_terminal`), so dropping
-# them on write keeps the JSON spec-compliant without losing information.
-const _DERIVED_BUS_FIELDS = ("neutral_terminal",)
+"""
+    _DERIVED_BUS_FIELDS
+
+Bus fields the tool attaches in memory that must not be serialised: bus objects
+declare `additionalProperties: false` in the BMOPF schema, so any of these that
+survives a write makes the file schema-invalid and provokes spurious
+`I.SCHEMA.UNKNOWN_FIELDS` findings when it is read back.
+
+They are stripped for the same reason but recovered differently:
+
+- `neutral_terminal` — *derived*. Recomputed from `terminal_names` on read (see
+  `_neutral_terminal`), so dropping it loses nothing.
+- `longitude`, `latitude` — *sideloaded*. Attached by [`sideload_coordinates!`](@ref)
+  from an external Buscoords CSV, and **not** recoverable from anything else in
+  the file. Dropping them is lossy by design: the BMOPF schema has nowhere to put
+  bus coordinates, so they live in memory only and are re-attached from the CSV
+  on each load.
+
+See [`_strip_derived_bus_fields`](@ref), which is the only consumer.
+"""
+const _DERIVED_BUS_FIELDS = ("neutral_terminal", "longitude", "latitude")
 
 """
     _strip_derived_bus_fields(buses) -> Dict{String,Any}
 
-Return a shallow copy of the bus collection with tool-derived, non-spec fields
-(see `_DERIVED_BUS_FIELDS`) removed from each bus object. Does not mutate the
-input; buses that carry none of these fields are passed through unchanged.
+Return a shallow copy of the bus collection with every field in
+[`_DERIVED_BUS_FIELDS`](@ref) removed from each bus object, so the written JSON
+satisfies the schema's `additionalProperties: false` on buses.
+
+Does not mutate the input: the caller's in-memory network keeps its coordinates
+and neutral terminals. Buses carrying none of these fields are passed through by
+reference rather than copied.
+
+Note this is lossy for sideloaded coordinates — see [`_DERIVED_BUS_FIELDS`](@ref)
+for which fields are recoverable on read and which are not.
 """
 function _strip_derived_bus_fields(buses::Dict)::Dict{String,Any}
     out = Dict{String,Any}()

--- a/src/io/write_bmopf.jl
+++ b/src/io/write_bmopf.jl
@@ -13,8 +13,10 @@ are never overwritten by auto-generation.
 
 The input `net` is never mutated. Tool-private state is not serialised verbatim:
 the `"_meta"` key is persisted under `meta.provenance`, and non-spec bus fields
-(see [`_DERIVED_BUS_FIELDS`](@ref)) are stripped so the output satisfies the
-schema's `additionalProperties: false` on bus objects.
+(`neutral_terminal`, plus the `longitude`/`latitude` attached by
+`sideload_coordinates!`) are stripped so the output satisfies the schema's
+`additionalProperties: false` on bus objects. Dropping the coordinates is lossy
+by design: they are not recoverable on read.
 
 # Keyword argument
 - `meta`: a `Dict` of fields to include or override in the written `meta` block.

--- a/test/sideload_coordinates_tests.jl
+++ b/test/sideload_coordinates_tests.jl
@@ -3,6 +3,8 @@
 # Coverage for sideload_coordinates! — merges an OpenDSS-style Buscoords CSV
 # (bus_id,x,y, no header) into a parsed network. No solver required.
 
+using JSON3
+
 @testset "sideload_coordinates!" begin
 
     # write_csv(rows) → path to a temp CSV holding the given text lines.
@@ -58,5 +60,40 @@
         net = parse_bmopf(IEEE13_FIXTURE; from_string=true)
         @test_throws ArgumentError sideload_coordinates!(
             net, joinpath(tempdir(), "definitely_no_such_coords.csv"))
+    end
+
+    @testset "sideloaded coordinates are stripped on write_bmopf" begin
+        net = parse_bmopf(IEEE13_FIXTURE; from_string=true)
+        # Attach synthetic coordinates to all buses
+        for (id, bus) in net["bus"]
+            bus["longitude"] = 153.0 + rand()
+            bus["latitude"]  = -27.0 - rand()
+        end
+        buf = IOBuffer()
+        write_bmopf(net, buf)
+        raw    = String(take!(buf))
+        parsed = JSON3.read(raw, Dict{String,Any})
+        for (_, bus) in parsed["bus"]
+            @test !haskey(bus, "longitude")
+            @test !haskey(bus, "latitude")
+        end
+    end
+
+    @testset "schema_check passes after sideload + write + reload" begin
+        net = parse_bmopf(IEEE13_FIXTURE; from_string=true)
+        for (id, bus) in net["bus"]
+            bus["longitude"] = 153.0
+            bus["latitude"]  = -27.5
+        end
+        buf = IOBuffer()
+        write_bmopf(net, buf)
+        raw      = String(take!(buf))
+        reloaded = parse_bmopf(raw; from_string=true)
+        findings = Finding[]
+        schema_check(reloaded, findings)
+        @test isempty(filter(f -> f.severity == ERROR, findings))
+        # Unstripped coordinates surface as INFO-level I.SCHEMA.UNKNOWN_FIELDS,
+        # never as ERROR, so the assertion has to name that code to have teeth.
+        @test isempty(filter(f -> f.code == "I.SCHEMA.UNKNOWN_FIELDS", findings))
     end
 end


### PR DESCRIPTION
sideload_coordinates! attaches longitude and latitude to bus dicts for in-memory use, but the bus schema declares additionalProperties:false. These fields survived write_bmopf, producing schema-invalid JSON and causing spurious I.SCHEMA.UNKNOWN_FIELDS findings on reload that could mask genuine validation errors (see issue #281).

Add "longitude" and "latitude" to _DERIVED_BUS_FIELDS. The existing _strip_derived_bus_fields machinery handles the rest.

Closes #281 (partial — the first-issue-only schema_check limitation is tracked separately).