### PR TITLE
fix: add trailing newline in write_bmopf compact mode

### DIFF
--- a/src/io/write_bmopf.jl
+++ b/src/io/write_bmopf.jl
@@ -1,5 +1,5 @@
 """
-    write_bmopf(net::Dict{String,Any}, dest; meta=nothing)
+    write_bmopf(net::Dict{String,Any}, dest; meta=nothing, indent=2)
 
 Serialise a BMOPF network dict to JSON.
 
@@ -11,11 +11,17 @@ A `meta` block is always written. Fields are assembled in this priority order
 defaults (`\$schema`, `case_study_generator`, `created`). Caller-supplied values
 are never overwritten by auto-generation.
 
-# Keyword argument
+Output is newline-terminated in both modes, so files round-trip through `diff`
+and shell pipelines without a "\\ No newline at end of file" marker.
+
+# Keyword arguments
 - `meta`: a `Dict` of fields to include or override in the written `meta` block.
   All fields are optional; common ones are `title`, `description`, `license`,
   `authors`, `data_sources`, and `version`. See `docs/src/conventions.md` for the
   full field reference.
+- `indent`: number of spaces for pretty-printing (default `2`). Pass
+  `indent=nothing` for compact single-line output — one line of JSON plus the
+  trailing newline.
 
 # Example
 ```julia
@@ -62,6 +68,7 @@ function write_bmopf(net::Dict{String,Any}, io::IO;
     out["meta"] = out_meta
     if isnothing(indent)
         JSON3.write(io, out)
+        write(io, '\n')
     else
         JSON3.pretty(io, out, JSON3.AlignmentContext(; indent=UInt16(indent)))
     end

--- a/test/write_bmopf_tests.jl
+++ b/test/write_bmopf_tests.jl
@@ -64,8 +64,19 @@ end
         buf = IOBuffer()
         write_bmopf(net, buf; indent=nothing)
         raw = String(take!(buf))
-        # JSON3 compact mode writes no internal newlines.
-        @test count('\n', raw) == 0
+        # JSON3 compact mode writes no internal newlines; only the trailing
+        # terminator newline added after the compact write.
+        @test count('\n', raw) == 1
+        @test endswith(raw, '\n')
+    end
+
+    @testset "compact output ends with newline" begin
+        buf = IOBuffer()
+        write_bmopf(net, buf; indent=nothing)
+        raw = String(take!(buf))
+        @test !occursin('\n', raw[1:end-1])   # single line body
+        @test endswith(raw, '\n')              # terminated by newline
+        @test !isnothing(JSON3.read(raw))      # still valid JSON
     end
 
     @testset "the literal _meta key is never serialised" begin


### PR DESCRIPTION
JSON3.write emits no trailing newline when indent=nothing, producing files that violate POSIX line-ending conventions and break diff output. Add write(io, '\n') after the compact write path.

The pretty-print path is unaffected; JSON3.pretty already appends a newline. Also documents the indent=nothing option in the docstring.