### PR TITLE
refactor: add COMPONENT_COLLECTIONS registry to prevent iteration-lis…

### DIFF
--- a/src/BMOPFTools.jl
+++ b/src/BMOPFTools.jl
@@ -38,6 +38,72 @@ const _BMOPF_SCHEMA_URI =
 # Package version, read once at load time from the Project.toml.
 const _BMOPFTOOLS_VERSION = string(pkgversion(BMOPFTools))
 
+"""
+    COMPONENT_COLLECTIONS
+
+Canonical tuple of top-level component collections — the keys of `net` that hold
+a string-keyed dict of named component instances placed in the network
+(`net["load"]["ld1"]`, `net["dc_bus"]["d1"]`, …).
+
+This is the single source of truth for any function that must iterate every
+component type. Generic loops should use it (as
+`BMOPFTools.COMPONENT_COLLECTIONS`; it is module-internal, like
+`TRANSFORMER_SUBTYPES`) rather than repeating the tuple inline, so a new
+component type flows through IO, validation and analysis for free. Current
+consumers: `each_terminal_array`, `_any_component_has_ts_ref` and `get_snapshot`
+— which each used to keep their own inline list, and had already drifted apart.
+
+**Adding a component type:** add its schema key here. Nothing else needs to
+change. `test/registry_tests.jl` fails CI if a schema key is neither registered
+here nor listed as a known non-component, and also if this tuple names a type the
+schema no longer defines.
+
+Deliberately *not* component collections:
+
+| key | why |
+|:--|:--|
+| `transformer` | subtype-dispatched via `TRANSFORMER_SUBTYPES`; `net["transformer"]` is keyed by subtype, not by instance |
+| `linecode`, `wire_data`, `line_geometry` | shared catalogs referenced *by* components; they define no terminals of their own |
+| `time_series` | data store keyed by series id |
+| `name`, `meta`, `extras`, `terminal_conventions` | scalars and document metadata |
+
+See also `TS_COMPONENT_COLLECTIONS` for the time-series-capable subset.
+"""
+const COMPONENT_COLLECTIONS = (
+    "bus", "line", "load", "generator", "voltage_source",
+    "shunt", "switch", "ibr", "capacitor", "control_profile",
+    "dc_bus", "dc_branch", "dc_grounding", "dc_load", "dc_source",
+)
+
+"""
+    TS_COMPONENT_COLLECTIONS
+
+Subset of `COMPONENT_COLLECTIONS` whose instances may carry a
+`"time_series"` sub-dict that `get_snapshot` can actually materialise. Consumed
+by `_any_component_has_ts_ref` (which decides whether a network counts as a
+time-series network) and by `get_snapshot` (which resolves the references).
+
+Currently this is every component collection except `control_profile`.
+
+!!! note "Why control_profile is excluded"
+    A control profile's scalable quantities (`volt_var.breakpoints`, `q_limits`,
+    …) are nested *inside* control-law sub-objects, but `_resolve_component_ts!`
+    only scales top-level numeric or vector params on a component. A
+    `time_series` reference on a control profile therefore has no top-level value
+    to scale, and resolving it would throw rather than materialise a snapshot.
+
+    Including `control_profile` here is the natural fix once the resolver grows
+    nested-path support (e.g. a `"volt_var.breakpoints"` key); until then it is
+    held out deliberately, and a control-profile time-series reference is ignored
+    exactly as it was before the registry existed.
+
+`transformer` is absent for a different reason: it is not in
+`COMPONENT_COLLECTIONS` at all. Its time-series references *are* resolved,
+by a dedicated subtype-aware pass in `get_snapshot` and `_any_component_has_ts_ref`.
+"""
+const TS_COMPONENT_COLLECTIONS =
+    Tuple(c for c in COMPONENT_COLLECTIONS if c != "control_profile")
+
 # Canonical list of transformer subtype keys under `net["transformer"][subtype]`.
 # Generic loops that iterate every subtype should use this constant (visible to
 # the OPF extension as `BMOPFTools.TRANSFORMER_SUBTYPES`) rather than repeating

--- a/src/io/parse_bmopf.jl
+++ b/src/io/parse_bmopf.jl
@@ -153,7 +153,26 @@ function _normalize_terminals!(net::Dict{String,Any}, aliases::Dict)
     (n, mode)
 end
 
-# apply f to every terminal-bearing array in the network dict
+"""
+    each_terminal_array(f, net::Dict{String,Any})
+
+Apply `f` to every terminal-bearing array in the network, in place. An array
+qualifies if its key is one of `_TERMINAL_ARRAY_KEYS` (`terminal_names`,
+`perfectly_grounded_terminals`, `terminal_map`, `terminal_map_from`,
+`terminal_map_to`) on any component instance.
+
+Coverage is driven by `COMPONENT_COLLECTIONS`, plus a dedicated pass over the
+transformer subtypes in `TRANSFORMER_SUBTYPES` (whose instances live one level
+deeper, under `net["transformer"][subtype][id]`). Components that carry none of
+those keys are visited and skipped, so registering a new component type costs
+nothing here.
+
+This is the canonical iteration helper for terminal normalisation at ingest —
+the spec requires terminal identifiers to be strings, and callers use this to
+coerce integer terminals that arrive from looser sources.
+
+`f` receives the array itself and may mutate it element-wise.
+"""
 function each_terminal_array(f, net::Dict{String,Any})
     visit(comp) = begin
         comp isa Dict || return
@@ -162,8 +181,7 @@ function each_terminal_array(f, net::Dict{String,Any})
             v isa AbstractVector && f(v)
         end
     end
-    for comp_type in ("bus", "line", "load", "generator", "voltage_source",
-                      "shunt", "switch", "ibr", "capacitor")
+    for comp_type in COMPONENT_COLLECTIONS
         components = get(net, comp_type, nothing)
         components isa Dict || continue
         foreach(visit, values(components))
@@ -221,9 +239,22 @@ function is_timeseries(net::Dict{String,Any})::Bool
     ts isa Dict && !isempty(ts) && _any_component_has_ts_ref(net)
 end
 
+"""
+    _any_component_has_ts_ref(net::Dict{String,Any}) -> Bool
+
+`true` if any component instance carries a non-empty `"time_series"` sub-dict,
+i.e. references a root-level series. Used by `is_timeseries` to decide whether a
+network is a time-series network at all; a root `"time_series"` collection that
+nothing references is treated as a snapshot network (PMD convention).
+
+Scans `TS_COMPONENT_COLLECTIONS`, then the transformer subtypes separately —
+`net["transformer"]` is keyed by subtype rather than by instance, so a flat scan
+of it would inspect the subtype dicts and never see an instance's references.
+
+Returns on the first reference found; it answers "any?", not "how many?".
+"""
 function _any_component_has_ts_ref(net::Dict{String,Any})::Bool
-    for key in ("bus", "line", "load", "generator", "voltage_source",
-                "shunt", "switch", "ibr", "transformer")
+    for key in TS_COMPONENT_COLLECTIONS
         components = get(net, key, nothing)
         components isa Dict || continue
         for (_, comp) in components
@@ -265,6 +296,13 @@ also removed from the result.
 
 For a network without time series, returns a deep copy unchanged.
 
+References are resolved on every collection in `TS_COMPONENT_COLLECTIONS`, and
+on transformers via their subtype keys. `control_profile` is the one component
+type deliberately *not* resolved — its scalable values are nested inside
+control-law sub-objects, which the resolver cannot reach; see
+`TS_COMPONENT_COLLECTIONS`. A time-series reference on a control profile is
+therefore left untouched rather than materialised.
+
 PMD convention: time series values are **scaling factors** applied
 multiplicatively to the static parameter value:
 
@@ -279,8 +317,7 @@ function get_snapshot(net::Dict{String,Any}, t_index::Int)::Dict{String,Any}
 
     ts_root = snap["time_series"]
 
-    for key in ("bus", "line", "load", "generator", "voltage_source",
-                "shunt", "switch", "ibr")
+    for key in TS_COMPONENT_COLLECTIONS
         components = get(snap, key, nothing)
         components isa Dict || continue
         for (cid, comp) in components

--- a/test/registry_tests.jl
+++ b/test/registry_tests.jl
@@ -1,0 +1,88 @@
+# registry_tests.jl
+#
+# Completeness guard for COMPONENT_COLLECTIONS.
+#
+# COMPONENT_COLLECTIONS is the single source of truth for "every top-level
+# component collection", consumed by each_terminal_array, _any_component_has_ts_ref
+# and get_snapshot. Historically each of those kept its own inline tuple and the
+# three drifted apart from one another and from the schema.
+#
+# This testset makes that drift impossible to introduce silently: every top-level
+# property in the bundled JSON Schema must be classified as EITHER a component
+# collection (it lives in COMPONENT_COLLECTIONS) OR an explicitly-known
+# non-component (it lives in _NON_COMPONENT_KEYS below, with a reason). A schema
+# key that is neither fails the test and names itself, forcing a decision.
+
+using JSON3
+
+# Top-level schema keys that are deliberately NOT component collections.
+# Each entry is a decision, not an oversight — keep the rationale current.
+const _NON_COMPONENT_KEYS = Dict{String,String}(
+    "transformer"          => "subtype dispatch via TRANSFORMER_SUBTYPES, not a flat instance collection",
+    "linecode"             => "shared catalog referenced by lines; defines no terminals of its own",
+    "wire_data"            => "shared catalog of conductor properties",
+    "line_geometry"        => "shared catalog of tower/cable geometries",
+    "time_series"          => "data store keyed by series id, not a component",
+    "name"                 => "scalar document field",
+    "meta"                 => "document metadata",
+    "extras"               => "free-form passthrough block",
+    "terminal_conventions" => "document-level terminal-role convention block",
+)
+
+@testset "Component registry completeness" begin
+    schema_path = joinpath(@__DIR__, "..", "src", "validation", "schemas",
+                           "draft_bmopf_schema.json")
+    schema = JSON3.read(read(schema_path, String))
+
+    schema_keys = Set{String}(string(k) for k in keys(schema["properties"]))
+    registry    = Set{String}(BMOPFTools.COMPONENT_COLLECTIONS)
+    known_other = Set{String}(keys(_NON_COMPONENT_KEYS))
+
+    # 1. Every schema key is classified: component, or known non-component.
+    unclassified = setdiff(schema_keys, registry, known_other)
+    @test isempty(unclassified) ||
+        error("Top-level schema key(s) not classified: " *
+              join(sort(collect(unclassified)), ", ") *
+              " — add to COMPONENT_COLLECTIONS in src/BMOPFTools.jl if they are " *
+              "component collections, or to _NON_COMPONENT_KEYS here (with a reason) if not")
+
+    # 2. The registry contains no phantom types the schema has dropped.
+    phantom = setdiff(registry, schema_keys)
+    @test isempty(phantom) ||
+        error("COMPONENT_COLLECTIONS names type(s) absent from the schema: " *
+              join(sort(collect(phantom)), ", ") * " — remove them or update the schema")
+
+    # 3. Likewise for the non-component deny-list, so it cannot rot either.
+    stale = setdiff(known_other, schema_keys)
+    @test isempty(stale) ||
+        error("_NON_COMPONENT_KEYS names key(s) absent from the schema: " *
+              join(sort(collect(stale)), ", "))
+
+    # 4. A key cannot be both.
+    @test isempty(intersect(registry, known_other))
+
+    # 5. The time-series subset is a genuine subset. control_profile is the one
+    #    documented exclusion (nested control-law params the resolver cannot scale).
+    ts = Set{String}(BMOPFTools.TS_COMPONENT_COLLECTIONS)
+    @test issubset(ts, registry)
+    @test setdiff(registry, ts) == Set(["control_profile"])
+end
+
+@testset "Registry is actually consumed by the iteration helpers" begin
+    # A regression guard with teeth: build a net whose DC components carry
+    # integer terminals. each_terminal_array must normalise them, which only
+    # happens if it iterates the registry rather than a stale inline tuple.
+    raw = """
+    {"bus":{"b1":{"terminal_names":["1","2","3","n"],
+                  "perfectly_grounded_terminals":["n"],
+                  "v_min":[200.0,200.0,200.0],"v_max":[260.0,260.0,260.0]}},
+     "voltage_source":{"vs":{"bus":"b1","terminal_map":["1","2","3"],
+         "v_magnitude":[230.0,230.0,230.0],"v_angle":[0.0,-2.0944,2.0944]}},
+     "dc_bus":{"d1":{"terminal_names":[1,2]}},
+     "dc_load":{"dl1":{"dc_bus":"d1","terminal_map":[1,2],"p":1000.0}}}
+    """
+    net = parse_bmopf(raw; from_string=true)
+
+    @test all(t isa AbstractString for t in net["dc_bus"]["d1"]["terminal_names"])
+    @test all(t isa AbstractString for t in net["dc_load"]["dl1"]["terminal_map"])
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3813,6 +3813,11 @@ const IEEE13_FIXTURE = """
     include("timeseries_tests.jl")
 
     # -----------------------------------------------------------------------
+    # COMPONENT_COLLECTIONS registry — completeness against the schema
+    # -----------------------------------------------------------------------
+    include("registry_tests.jl")
+
+    # -----------------------------------------------------------------------
     # Network simplification
     # -----------------------------------------------------------------------
     include("simplify_tests.jl")


### PR DESCRIPTION
…t drift

each_terminal_array, _any_component_has_ts_ref and get_snapshot each kept their own inline tuple of component-type strings. The three had already drifted from one another and from the schema, with no signal when a new component type missed one of them.

Introduce COMPONENT_COLLECTIONS as the single source of truth, mirroring the existing TRANSFORMER_SUBTYPES pattern, plus TS_COMPONENT_COLLECTIONS for the subset get_snapshot can materialise. Point all three helpers at it.

A completeness test partitions every top-level schema property into either the registry or an explicitly-reasoned non-component deny-list, so a new schema key fails CI until it is classified.

Drift this surfaced and fixes:
- each_terminal_array never visited dc_bus/dc_branch/dc_load/dc_source, leaving their integer terminals un-normalised at ingest
- capacitor was absent from both time-series helpers
- "transformer" in _any_component_has_ts_ref's flat list was dead code; the nested subtype block below it does the real work

control_profile is registered but held out of TS_COMPONENT_COLLECTIONS: its scalable values are nested inside control-law sub-objects, which _resolve_component_ts! cannot reach, so including it would throw rather than resolve.