### PR TITLE
Add differentiable overhead line-constants kernel

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -75,6 +75,7 @@ IdealCoupling
 ## Line constants
 
 ```@docs
+overhead_line_constants
 compile_linecode
 compile_linecodes!
 ```

--- a/src/BMOPFTools.jl
+++ b/src/BMOPFTools.jl
@@ -726,6 +726,7 @@ include("lineconstants/earth.jl")
 include("lineconstants/series.jl")
 include("lineconstants/shunt.jl")
 include("lineconstants/kron.jl")
+include("lineconstants/overhead.jl")
 include("lineconstants/compile.jl")
 
 include("analysis/inventory.jl")
@@ -1202,7 +1203,7 @@ export transformer_yprim, export_yprim, write_yprim
 export ybus_passive, YbusResult
 export ybus_linearized, LinearizedYbus
 export ybus_augmented, AugYbusResult, IdealCoupling
-export compile_linecode, compile_linecodes!
+export overhead_line_constants, compile_linecode, compile_linecodes!
 
 # ---------------------------------------------------------------------------
 # Error hints

--- a/src/lineconstants/earth.jl
+++ b/src/lineconstants/earth.jl
@@ -27,7 +27,7 @@ const _MIN_HEIGHT = 0.01   # [m] height clamp for the image-based formulations
 const _EARTH_MODELS = ("modified_carson", "full_carson", "deri")
 
 "Carson equivalent return depth De = 2·e^(1/2)/(mₑ·e^γ) [m], mₑ = √(ωμ₀/ρ)."
-function _carson_return_depth(f::Float64, rho::Float64)::Float64
+function _carson_return_depth(f::Real, rho::Real)
     me = sqrt(2pi * f * _MU0 / rho)
     2 * exp(0.5) / (me * exp(MathConstants.eulergamma))
 end
@@ -37,7 +37,7 @@ Carson correction ΔZ = (ωμ₀/π)·(P + jQ) [Ω/m] to second order in
 k = a·S (a = √(ωμ₀/ρ), S = distance to the image conductor), with θ the
 angle at the image between the conductors.
 """
-function _carson_correction(k::Float64, theta::Float64, omega::Float64)::ComplexF64
+function _carson_correction(k::Real, theta::Real, omega::Real)
     c = cos(theta)
     c2, s2 = cos(2theta), sin(2theta)
     P = pi / 8 - k * c / (3 * sqrt(2)) +
@@ -54,8 +54,8 @@ vertical coordinate `y`. Uses the GMR in the external term, so the internal
 inductance is included implicitly — no separate internal-reactance term
 (adding one would double-count it).
 """
-function _z_self(model::String, r_ac::Float64, gmr::Float64, y::Float64,
-                 f::Float64, rho::Float64)::ComplexF64
+function _z_self(model::AbstractString, r_ac::Real, gmr::Real, y::Real,
+                 f::Real, rho::Real)
     omega = 2pi * f
     jk = im * omega * _MU0 / 2pi
     if model == "modified_carson"
@@ -79,9 +79,9 @@ Mutual impedance between conductors i and j separated by distance `d`
 (passed explicitly so cable-internal core↔shield pairs can override the
 centre-to-centre distance).
 """
-function _z_mutual(model::String, d::Float64,
-                   xi::Float64, yi::Float64, xj::Float64, yj::Float64,
-                   f::Float64, rho::Float64)::ComplexF64
+function _z_mutual(model::AbstractString, d::Real,
+                   xi::Real, yi::Real, xj::Real, yj::Real,
+                   f::Real, rho::Real)
     omega = 2pi * f
     jk = im * omega * _MU0 / 2pi
     if model == "modified_carson"

--- a/src/lineconstants/overhead.jl
+++ b/src/lineconstants/overhead.jl
@@ -1,0 +1,76 @@
+# Pure numerical entry point for overhead-line constants. Dictionary parsing,
+# network mutation, provenance, and user-facing validation remain in
+# `compile_linecode`; this API exists for numerical consumers such as parameter
+# studies and inverse problems that need primitive matrices directly.
+
+"""
+    overhead_line_constants(r_ac, gmr, radius, x, y;
+        cap_radius=radius, frequency, earth_model="modified_carson",
+        earth_resistivity=100.0) -> (; Z, C)
+
+Compute the full primitive series-impedance matrix `Z` [Ω/m] and Maxwell
+capacitance matrix `C` [F/m] of an overhead conductor arrangement. Input vectors
+are ordered by conductor and use SI units: `r_ac` [Ω/m], `gmr`, `radius`, `x`,
+`y`, and `cap_radius` [m]. `frequency` is required [Hz]; `earth_resistivity` is
+in Ω·m.
+
+Unlike [`compile_linecode`](@ref), this is a pure numerical API: it does not
+read or mutate a BMOPF dictionary, apply wire-data defaults, stamp provenance,
+or Kron-reduce any circuit conductor. It uses the same Carson/Deri and Maxwell
+kernels as the compiler. `compile_linecode` remains the preferred entry point
+for ordinary network data.
+
+The implementation is generic over `Real` element types so numerical clients
+can propagate alternative scalar types. Modified Carson is smooth on the
+interior of the physical domain (`gmr > 0`, positive separation, `y > 0`). The
+`full_carson` model retains its documented near-ground height clamp and is not
+smooth at that clamp.
+"""
+function overhead_line_constants(r_ac::AbstractVector{<:Real},
+                                 gmr::AbstractVector{<:Real},
+                                 radius::AbstractVector{<:Real},
+                                 x::AbstractVector{<:Real},
+                                 y::AbstractVector{<:Real};
+                                 cap_radius::AbstractVector{<:Real}=radius,
+                                 frequency::Real,
+                                 earth_model::AbstractString="modified_carson",
+                                 earth_resistivity::Real=100.0)
+    n = length(r_ac)
+    n > 0 || throw(ArgumentError("at least one conductor is required"))
+    all(==(n), (length(gmr), length(radius), length(x), length(y),
+                length(cap_radius))) ||
+        throw(DimensionMismatch("all conductor-property vectors must have equal length"))
+    earth_model in _EARTH_MODELS ||
+        throw(ArgumentError("unknown earth_model '$earth_model'"))
+    frequency > 0 || throw(ArgumentError("frequency must be > 0 Hz"))
+    earth_resistivity > 0 || throw(ArgumentError("earth_resistivity must be > 0 Ω·m"))
+    all(>(0), r_ac) || throw(ArgumentError("all r_ac values must be > 0 Ω/m"))
+    all(>(0), gmr) || throw(ArgumentError("all gmr values must be > 0 m"))
+    all(>(0), radius) || throw(ArgumentError("all radius values must be > 0 m"))
+    all(>(0), cap_radius) || throw(ArgumentError("all cap_radius values must be > 0 m"))
+    all(>(0), y) || throw(ArgumentError("all overhead conductor heights must be > 0 m"))
+    all(gmr[i] <= radius[i] * (1 + 1e-9) for i in 1:n) ||
+        throw(ArgumentError("every gmr must be less than or equal to its radius"))
+
+    for i in 1:n, j in i+1:n
+        d = hypot(x[i] - x[j], y[i] - y[j])
+        d >= radius[i] + radius[j] ||
+            throw(ArgumentError("conductors $i and $j overlap"))
+    end
+
+    # One promoted scalar type keeps the small dense kernels type-stable even
+    # when only some input vectors carry an alternative numeric scalar type.
+    T = promote_type(eltype(r_ac), eltype(gmr), eltype(radius), eltype(x),
+                     eltype(y), eltype(cap_radius), typeof(frequency),
+                     typeof(earth_resistivity))
+    isconcretetype(T) || throw(ArgumentError("input vectors need concrete scalar types"))
+    rac = T.(r_ac); gm = T.(gmr); rad = T.(radius)
+    xs = T.(x); ys = T.(y); cr = T.(cap_radius)
+    f = convert(T, frequency); rho = convert(T, earth_resistivity)
+
+    prims = [_PrimitiveConductor(rac[i], gm[i], xs[i], ys[i], nothing, zero(T))
+             for i in 1:n]
+    Z = _primitive_z(prims, earth_model, f, rho)
+    C = _overhead_shunt_c(cr, xs, ys)
+    (; Z, C)
+end

--- a/src/lineconstants/series.jl
+++ b/src/lineconstants/series.jl
@@ -7,17 +7,25 @@
 # One row of the primitive system. `pair` is the index of the conductor this
 # one is coaxial with (core ↔ its own shield), so the mutual distance is the
 # radial shield distance rather than the (zero) centre-to-centre distance.
-struct _PrimitiveConductor
-    r_ac::Float64
-    gmr::Float64
-    x::Float64
-    y::Float64
+struct _PrimitiveConductor{T<:Real}
+    r_ac::T
+    gmr::T
+    x::T
+    y::T
     pair::Union{Int,Nothing}
-    pair_distance::Float64
+    pair_distance::T
+end
+
+function _PrimitiveConductor(r_ac::Real, gmr::Real, x::Real, y::Real,
+                             pair::Union{Int,Nothing}, pair_distance::Real)
+    values = promote(r_ac, gmr, x, y, pair_distance)
+    T = typeof(values[1])
+    _PrimitiveConductor{T}(values[1], values[2], values[3], values[4], pair,
+                           values[5])
 end
 
 function _mutual_distance(ci::_PrimitiveConductor, cj::_PrimitiveConductor,
-                          i::Int, j::Int)::Float64
+                          i::Int, j::Int)
     (ci.pair == j) && return ci.pair_distance
     (cj.pair == i) && return cj.pair_distance
     hypot(ci.x - cj.x, ci.y - cj.y)
@@ -28,13 +36,16 @@ end
 
 Full primitive series-impedance matrix for the conductor system.
 """
-function _primitive_z(conds::Vector{_PrimitiveConductor}, model::String,
-                      f::Float64, rho::Float64)::Matrix{ComplexF64}
+function _primitive_z(conds::AbstractVector{<:_PrimitiveConductor},
+                      model::AbstractString, f::Real, rho::Real)
     n = length(conds)
-    Z = zeros(ComplexF64, n, n)
+    n > 0 || throw(ArgumentError("at least one conductor is required"))
+    z11 = _z_self(model, conds[1].r_ac, conds[1].gmr, conds[1].y, f, rho)
+    Z = Matrix{typeof(z11)}(undef, n, n)
+    Z[1, 1] = z11
     for i in 1:n
         ci = conds[i]
-        Z[i, i] = _z_self(model, ci.r_ac, ci.gmr, ci.y, f, rho)
+        i == 1 || (Z[i, i] = _z_self(model, ci.r_ac, ci.gmr, ci.y, f, rho))
         for j in i+1:n
             cj = conds[j]
             d = _mutual_distance(ci, cj, i, j)

--- a/src/lineconstants/shunt.jl
+++ b/src/lineconstants/shunt.jl
@@ -34,18 +34,38 @@ function _shunt_c(wires::Vector{_ResolvedWire},
     # overhead subsystem: potential coefficients with ground images
     oh = [i for i in 1:n if wires[i].kind == "overhead" && ys[i] > 0]
     isempty(oh) && return C
-    m = length(oh)
-    P = zeros(m, m)
-    for (a, i) in enumerate(oh)
-        P[a, a] = log(2 * ys[i] / wires[i].cap_radius) / (2pi * _EPS0)
-        for (b, j) in enumerate(oh)
-            b <= a && continue
-            d    = hypot(xs[i] - xs[j], ys[i] - ys[j])
+    C[oh, oh] = _overhead_shunt_c([wires[i].cap_radius for i in oh],
+                                  xs[oh], ys[oh])
+    C
+end
+
+"Maxwell potential-coefficient capacitance for above-ground conductors."
+function _overhead_shunt_c(cap_radius::AbstractVector{<:Real},
+                           xs::AbstractVector{<:Real},
+                           ys::AbstractVector{<:Real})
+    n = length(xs)
+    n > 0 || throw(ArgumentError("at least one conductor is required"))
+    length(cap_radius) == n == length(ys) ||
+        throw(DimensionMismatch("cap_radius, x, and y must have equal length"))
+
+    p11 = log(2 * ys[1] / cap_radius[1]) / (2pi * _EPS0)
+    P = Matrix{typeof(p11)}(undef, n, n)
+    P[1, 1] = p11
+    for i in 1:n
+        i == 1 || (P[i, i] = log(2 * ys[i] / cap_radius[i]) / (2pi * _EPS0))
+        for j in i+1:n
+            d = hypot(xs[i] - xs[j], ys[i] - ys[j])
             dimg = hypot(xs[i] - xs[j], ys[i] + ys[j])
-            P[a, b] = log(dimg / d) / (2pi * _EPS0)
-            P[b, a] = P[a, b]
+            P[i, j] = log(dimg / d) / (2pi * _EPS0)
+            P[j, i] = P[i, j]
         end
     end
-    C[oh, oh] = inv(P)
+    # Roundoff in a dense inverse can differ by a few ulps across the diagonal.
+    # The Maxwell matrix is reciprocal by construction, so materialise that
+    # invariant exactly rather than leaking numerical asymmetry downstream.
+    C = inv(P)
+    for i in 1:n, j in i+1:n
+        C[j, i] = C[i, j]
+    end
     C
 end

--- a/test/lineconstants_tests.jl
+++ b/test/lineconstants_tests.jl
@@ -36,6 +36,55 @@ _lc_z_permile(lc) = (BMOPFTools._pattern_keys_to_matrix(lc, "R_series_") .+
 
 @testset "Line constants — geometry-based impedance engine" begin
 
+    @testset "pure overhead numerical API matches compiler and preserves scalar type" begin
+        phase = _wire_556_acsr()
+        neutral = _wire_4_0_acsr()
+        geo = _geometry_601()
+        entries = geo["conductors"]
+        wires = [phase, phase, phase, neutral]
+        r_ac = [w["r_ac"] for w in wires]
+        gmr = [w["gmr"] for w in wires]
+        radius = [w["radius"] for w in wires]
+        x = [e["x"] for e in entries]
+        y = [e["y"] for e in entries]
+
+        constants = overhead_line_constants(r_ac, gmr, radius, x, y;
+            frequency=geo["frequency"], earth_model=geo["earth_model"],
+            earth_resistivity=geo["earth_resistivity"])
+
+        net = Dict{String,Any}(
+            "wire_data" => Dict("phase" => phase, "neutral" => neutral),
+            "line_geometry" => Dict("g" => Dict{String,Any}(
+                geo...,
+                "conductors" => Any[
+                    Dict{String,Any}(e..., "wire_data" => i <= 3 ? "phase" : "neutral")
+                    for (i, e) in enumerate(entries)
+                ])))
+        compile_linecode(net, "g")
+        lc = net["linecode"]["g"]
+        Zcompiled = BMOPFTools._pattern_keys_to_matrix(lc, "R_series_") .+
+                    im .* BMOPFTools._pattern_keys_to_matrix(lc, "X_series_")
+        Ccompiled = (BMOPFTools._pattern_keys_to_matrix(lc, "B_from_") .+
+                     BMOPFTools._pattern_keys_to_matrix(lc, "B_to_")) ./
+                    (2pi * geo["frequency"])
+        @test constants.Z ≈ Zcompiled rtol=1e-13
+        @test constants.C ≈ Ccompiled rtol=1e-13
+        @test constants.Z == transpose(constants.Z)
+        @test constants.C == transpose(constants.C)
+
+        big = overhead_line_constants(BigFloat.(r_ac), BigFloat.(gmr),
+            BigFloat.(radius), BigFloat.(x), BigFloat.(y);
+            frequency=big"60", earth_resistivity=big"100")
+        @test eltype(big.Z) == Complex{BigFloat}
+        @test eltype(big.C) == BigFloat
+        @test Float64.(real.(big.Z)) ≈ real.(constants.Z) rtol=1e-13
+
+        @test_throws DimensionMismatch overhead_line_constants(
+            r_ac[1:3], gmr, radius, x, y; frequency=60.0)
+        @test_throws ArgumentError overhead_line_constants(
+            r_ac, gmr, radius, x, zeros(4); frequency=60.0)
+    end
+
     # ─────────────────────────────────────────────────────────────────────────
     # IEEE 13 config 601: overhead 4-wire, modified Carson, 60 Hz, ρ=100.
     # Published phase matrix (Ω/mile) is the Kron reduction of our 4×4.


### PR DESCRIPTION
## Summary
- add a public, pure overhead_line_constants kernel for primitive overhead-line Z and C matrices
- accept generic real scalar types so callers can use ForwardDiff and higher precision
- reuse the same internal kernels as the existing engineering compiler
- preserve exact capacitance reciprocity without adding inverse-estimation functionality

## Scope
This is deliberately a forward-model API only. Candidate search, inverse Carson estimation, identifiability diagnostics, and BMOPF materialization remain outside BMOPFTools.

## Verification
- full test suite: 4,156 passed, 33 intentionally broken
- documentation build passes
- focused parity, symmetry, BigFloat, and input-contract tests pass

## Numerical note
The modified-Carson path is smooth in the physical interior. The existing full-Carson approximation retains its documented clamp and is therefore not recommended for gradient-based inverse estimation near that transition.