### PR TITLE
docs: address reviewer feedback on DER placement, thermal limits, and time series

### DIFF
--- a/docs/src/augmentation.md
+++ b/docs/src/augmentation.md
@@ -536,10 +536,61 @@ with these IBR-specific additions:
 - **`inverter_topology`** — `:infer` (FOUR_LEG when the host load has a neutral
   terminal, else SINGLE_PHASE), or a forced `:FOUR_LEG` / `:THREE_LEG` /
   `:SINGLE_PHASE`.
-- **sizing targets `s_max`**, not `p_max`: `size_basis` (same four bases as
-  generators) with `s_fraction` sets the apparent-power nameplate, and
-  `s_to_p_ratio` sets `p_avail = s_to_p_ratio × s_max` (1.0 = unity-rated PV;
-  below 1.0 leaves reactive headroom at full irradiance).
+- **sizing targets `s_max`**, not `p_max`: `size_basis` selects *how* the
+  nameplate is derived. The `:fraction_of_*` bases (`:fraction_of_local_load`,
+  `:fraction_of_transformer_rating`, `:fraction_of_downstream_load`) multiply a
+  network quantity by `s_fraction`; `:fixed_tiers` instead reads an **absolute
+  nameplate in VA** from the `fixed_tier_va` dict (per voltage-level family,
+  default `Dict(:LV => 30_000.0, :MV => 1_000_000.0)`). `s_to_p_ratio` then sets
+  `p_avail = s_to_p_ratio × s_max` (1.0 = unity-rated PV; below 1.0 leaves
+  reactive headroom at full irradiance).
+
+!!! tip "Sizing in absolute kVA, and placing at zero-load buses"
+    The default `:fraction_of_local_load` basis is convenient for scaling the
+    fleet to a feeder, but it has two awkward edges the reviewer-style questions
+    keep hitting:
+
+    - **You want to think in kVA, not "× local load."** Use
+      `size_basis = :fixed_tiers` and set the absolute nameplate directly:
+      `IBRRecipe(strategy = :load_following, size_basis = :fixed_tiers,
+      fixed_tier_va = Dict(:LV => 50_000.0))` places a 50 kVA unit on every LV
+      load bus regardless of that bus's load. (The generator analogue is
+      `GeneratorRecipe(size_basis = :fixed_tiers, fixed_tier_w = Dict(:LV => …))`,
+      in **W**.)
+    - **The bus has no local load but you still want a DER there.** A
+      `:fraction_of_local_load` size is *zero* at a zero-load bus, and
+      `min_local_load_va` will skip a low-load bus entirely. Two fixes: size with
+      `:fixed_tiers` (absolute, so load-independent), and/or choose candidates by
+      *topology* rather than by load —
+      `strategy = :topology_targeted, topology_mode = :leaves` (feeder ends) or
+      `:near_source`, which place at buses selected from the graph, not from where
+      demand happens to sit.
+
+!!! note "Modelling PV, batteries, EVs, and other DER technologies"
+    Two knobs are orthogonal and easy to conflate:
+
+    - **`strategy`** decides *where and how many* DERs are placed
+      (`:load_following` = one per load bus, `:topology_targeted`,
+      `:hosting_capacity`). The comment "one PV IBR per load bus" describes the
+      `:load_following` *strategy* — it is not a statement that IBRs are only PV.
+    - **`prime_mover`** decides *what technology* the converter is (`:PV`,
+      `:BATTERY`, `:GENERIC`, `:STATCOM`). `:PV` is the current placement default
+      (and the reason `p_min = 0` is injected — PV cannot absorb active power).
+
+    Mapping technologies onto objects: **PV, battery, or any converter-interfaced
+    DER → an `ibr`** with the matching `prime_mover`; a **synchronous / simple
+    dispatchable unit → a `generator`**. An **EV charger is demand, so it is a
+    `load`** (optionally time-varying via a charging profile — see the
+    [time-series tutorial](tutorial_timeseries.md)); model it as an `ibr` with
+    `prime_mover = "BATTERY"` only for a vehicle-to-grid (V2G) study where it
+    *injects*. `EV` is therefore not a `prime_mover` value — it is either a load
+    or a bidirectional battery, depending on the physics you mean.
+
+    One caveat on *automatic* placement: `add_ibrs` currently emits `:PV`
+    nameplates (the augment pass's `p_min = 0` is PV-specific; battery and
+    grid-forming placement is planned). To study other technologies today, author
+    the `ibr` with the intended `prime_mover` directly — the OPF engine models it
+    once the P/Q box is set — rather than relying on the placement recipe.
 
 Every field written is recorded as a `:synthetic` `TransformEntry` with rule
 `IBR_PLACEMENT/<strategy>`, and the run emits

--- a/docs/src/conventions.md
+++ b/docs/src/conventions.md
@@ -268,6 +268,28 @@ currents under unbalance compensation; a phases-only vector warns). A
 to a single limit; a length-1 vector is standardised to 2). Generators take the
 same per-conductor `i_max` convention.
 
+!!! note "Why both a `generator` and an `ibr` object?"
+    Most distributed generation in an unbalanced LV study *is* inverter-based, so
+    the reasonable question is why keep a separate `generator` at all. The two
+    objects sit at different modelling altitudes:
+
+    - **`generator`** is the *minimal* active-power dispatch object — `p_min/p_max`,
+      reactive box `q_min/q_max`, and a per-phase linear `cost`. It is the right
+      model for a synchronous/diesel unit, or wherever you want a dispatchable
+      active-power injection *without* committing to converter physics (no
+      apparent-power circle, no topology, no droop control).
+    - **`ibr`** adds exactly that converter physics: an apparent-power nameplate
+      `s_max` with the `P²+Q²≤s_max²` circle, a `topology`
+      (`SINGLE_PHASE`/`THREE_LEG`/`FOUR_LEG`) that fixes the voltage reference, a
+      `prime_mover`, and reference-able `control_profile` droop laws.
+
+    Both are kept because benchmark cases span both, and because a thin
+    `generator` avoids forcing the full converter model (and its extra variables)
+    onto a resource that does not need it. For a PV, battery, STATCOM, or any
+    converter-interfaced DER, prefer `ibr`; reach for `generator` for
+    non-converter or deliberately abstract dispatch. The placement passes mirror
+    this split: [`add_generators`](@ref) versus [`add_ibrs`](@ref).
+
 IBR control laws are attached by reference: `control_profile` names a
 shared [`control_profile`](#Control-profiles) entry carrying `volt_var`,
 `volt_watt`, or `power_factor`. Each droop law's `voltage_reference` selects the

--- a/docs/src/spec/timeseries.md
+++ b/docs/src/spec/timeseries.md
@@ -67,3 +67,9 @@ solved exactly as documented on the component pages. A time series is therefore 
     [IBRs](ibr.md#Reactive-power-control-law)) instead encodes a *control law* (constant
     power factor, Volt-VAr, Volt-Watt) that reacts to the solved voltage within a single
     snapshot. The two are independent mechanisms and can be combined.
+
+!!! tip "Worked example and modelling FAQ"
+    The [time-series tutorial](../tutorial_timeseries.md) walks a 24-hour sweep on
+    a real LV feeder and answers the common modelling questions — changing the
+    irradiance/PV shape, EV-charging and other load patterns, constant vs varying
+    power factor, and why storage/multi-period studies need a different mechanism.

--- a/docs/src/tutorial_ders.md
+++ b/docs/src/tutorial_ders.md
@@ -72,6 +72,19 @@ GEN_RECIPE = GeneratorRecipe(
 nothing # hide
 ```
 
+!!! note "`add_ibrs` vs `add_generators`, and why both here"
+    The two calls place *different objects*, not different siting rules.
+    [`add_ibrs`](@ref) places converter-interfaced `ibr` units — an
+    apparent-power nameplate `s_max`, a `topology`, and the `P²+Q²≤s_max²` circle;
+    [`add_generators`](@ref) places thin `generator` units carrying only an
+    active-power box and a cost. This tutorial places *both* so the merit order
+    below has two priced tiers (cheap PV IBRs, mid-priced generators) to sort
+    against the network limits. The `:load_following` **strategy** is what puts
+    "one per load bus"; the IBRs are PV because `:PV` is the placement default
+    `prime_mover`, not because IBRs must be PV. See
+    [Adding IBRs](augmentation.md#adding-IBRs-der-placement) for the object
+    choice, absolute (kVA) sizing, zero-load buses, and other DER technologies.
+
 The scenarios need a little network surgery before placement, so we wrap the
 whole preparation in one function: load the JSON, strip the pre-existing DERs
 (we place every DER from the recipes), tap the 11 kV source so the LV head sits

--- a/docs/src/tutorial_end_to_end.md
+++ b/docs/src/tutorial_end_to_end.md
@@ -160,6 +160,27 @@ net_ready, aug_mf = augment_case(net_der; recipe = AugmentationRecipe())
 render_manifest(aug_mf)
 ```
 
+**Where the thermal limits landed.** The thermal pass writes a heuristic
+per-conductor ampacity `i_max` (in A) onto each linecode that lacked one — this
+is the line/cable thermal limit the OPF enforces, and it is tagged `:synthetic`
+in the manifest above. Read it straight off the prepared linecodes:
+
+```@example e2e
+for (lc_id, lc) in sort(collect(net_ready["linecode"]); by = first)
+    imax = get(lc, "i_max", nothing)
+    println(rpad(lc_id, 16),
+            imax === nothing ? "no i_max (skipped — see manifest)" :
+                               string("i_max = ", imax, " A"))
+end
+```
+
+A **transformer's** thermal limit is a different mechanism: its nameplate
+`s_rating` (kVA) already plays that role and the OPF enforces it directly, so
+`augment_case` never adds a separate transformer thermal limit. The full
+pass-by-pass rationale — the R₁₁ → ampacity lookup table, its confidence gating,
+and the neutral-conductor rating — is in
+[Case augmentation](augmentation.md).
+
 ## 6. Re-validate
 
 Re-running [`analyze`](@ref) on the prepared case shows what the pipeline

--- a/docs/src/tutorial_impedance_models.md
+++ b/docs/src/tutorial_impedance_models.md
@@ -33,6 +33,12 @@ repository, which does not always flatter the strong version of the claim.
    per-segment error compounds on real feeders to the 1–4 % that the literature
    measures.
 
+The demonstrations below are presented in the order **step 2 → step 4 → step 3**,
+not 1 → 4. We first establish the structural symmetry break as an exact fact
+(step 2), then read off its decision consequence and honest magnitude (step 4),
+and only then return to the most heavily hedged claim — the solver-degeneracy
+argument (step 3) — so the careful caveats land after the evidence they qualify.
+
 Every code block runs at build time; the numbers are real. **Prerequisites:**
 `BMOPFTools`, `JuMP`, `Ipopt`, and the
 [line-geometry workflow](tutorial_line_geometry.md). This is the "why it matters"

--- a/docs/src/tutorial_timeseries.md
+++ b/docs/src/tutorial_timeseries.md
@@ -201,6 +201,48 @@ schedule against load level — there the sweep variable is a synthetic load
 multiplier; here it is the clock, with the shapes shipped inside the case
 itself so every consumer of the benchmark sweeps the *same* day.
 
+## Modelling notes & FAQ
+
+A time series is deliberately a *thin* mechanism — a named vector of
+multiplicative scale factors and a per-parameter binding (see the
+[spec page](spec/timeseries.md)). Most modelling questions reduce to *which
+parameter you bind to which profile*.
+
+**How do I change the irradiance / PV shape?** The PV ceiling is `p_max`/`p_avail`
+scaled by a solar profile. To study a cloudier day, a different latitude, or a
+seasonal shape, edit that profile's `values` (or bind `p_max` to a different
+profile id) — nothing else changes, because the profile is just the ceiling the
+OPF curtails under. The scale factors are unitless multipliers on the static
+nameplate, so a `values` entry of `0.8` means "80 % of `p_max` available this
+step."
+
+**How do I model different load or EV-charging patterns?** Author a new profile
+and bind the relevant `load`'s `p_nom` to it. An EV charger is demand, so it is a
+`load` whose `p_nom` follows a charging shape (e.g. an evening ramp); several
+charging behaviours are just several profiles over the same feeder. A load that
+should change power factor over the day binds `p_nom` and `q_nom` to *different*
+profiles; binding both to the **same** profile (as the feeder here does) holds
+the power factor constant while the magnitude varies.
+
+**Can I do a BESS / storage study, or ramp limits?** Not with this mechanism.
+Each `t_index` is an **independent snapshot** with no coupling between steps — no
+stored energy, no ramp constraints, no inter-temporal terms (see the scope
+warning above). Time series answer *hosting-capacity envelopes* and *worst-hour
+screening*; battery arbitrage and unit commitment need a genuinely multi-period
+model, which BMOPFTools does not currently build. A battery still appears as an
+`ibr` with `prime_mover = "BATTERY"` in each snapshot, but its state of charge is
+not carried across hours.
+
+**Why scale `p_max` rather than inject a fixed `p`?** Scaling the *bound* keeps
+the OPF free to curtail below the ceiling when the network requires it (the whole
+point of §4's midday regime). Binding a fixed injection instead would force the
+dispatch and defeat the optimisation.
+
+**Does augmentation need to run per step?** No. Bounds and costs are
+time-invariant, so `augment_case` runs **once** on the time-series network and
+the profiles pass through untouched (§3). Only `solve_opf`/`solve_pf`/
+`profile_solution` take the `t_index`.
+
 !!! tip "Where to go next"
     The [end-to-end tutorial](tutorial_end_to_end.md) covers the pipeline each
     snapshot passes through; [DER placement](tutorial_ders.md) grows the PV

--- a/docs/src/tutorial_vvwo.md
+++ b/docs/src/tutorial_vvwo.md
@@ -348,6 +348,22 @@ controllers cannot reach on its own, because the balanced-network equivalence
 that would license it no longer holds on a four-wire feeder under active
 curtailment.
 
+!!! note "What VV/VW control costs in this model"
+    There is **no explicit price on reactive support or on curtailment** here.
+    The only term in the objective is priced grid import; PV active power is
+    priced at zero, and reactive power is not priced at all. So the economic cost
+    of the droop is entirely *implicit* — it shows up as **foregone export
+    revenue** (Volt-watt curtailment lowers the exported active power, and the
+    reactive absorption of Volt-var consumes VA headroom that would otherwise
+    carry active export), which is exactly the objective increase from A→B→C in
+    the table. Note the native `cost` field prices **active power only**
+    (`cost[k]·P_k`); there is no built-in reactive-power price or curtailment
+    penalty. To model an *explicit* ancillary-service payment for reactive
+    support — or a compensation for curtailed active power — extend the objective
+    with a [`model_hook!`](opf.md) that adds the corresponding term (a cost on
+    `|Q|`, or a penalty on `p_avail − P`); the objective then prices those
+    services directly rather than only through lost export.
+
 ## Appendix: the monitored voltage — quantity and aggregation
 
 The voltage a droop law reacts to has two independent degrees of freedom, both


### PR DESCRIPTION
Follow-ups from a project reviewer's read of the docs. Each item below was checked against the source; several were already partly addressed and are strengthened rather than newly written.

## Changes

- **DER sizing in absolute kVA + zero-load buses** ([augmentation.md](../blob/docs/reviewer-feedback-followups/docs/src/augmentation.md)) — the default `:fraction_of_local_load` basis is awkward to think in and yields zero at load-free buses. New tip surfaces `size_basis = :fixed_tiers` (absolute VA/W via `fixed_tier_va`/`fixed_tier_w`) and `:topology_targeted` placement at non-load buses.
- **PV / EV / IBR vs generator** (augmentation.md, tutorial_ders.md) — new note separating **strategy** (where/how many) from **`prime_mover`** (technology), mapping PV/battery → `ibr`, synchronous → `generator`, EV charging → `load` (or V2G battery). Clarifies the "one PV IBR per load bus" comment.
- **Thermal limits shown** (tutorial_end_to_end.md) — an executed block now prints each linecode's augmented per-conductor `i_max`, plus prose that a transformer's thermal limit is its nameplate `s_rating` (enforced natively, not augmented).
- **Why two DER objects** (conventions.md) — note explaining the generator/ibr modelling-altitude split and when to use each.
- **VVWO control cost** (tutorial_vvwo.md) — clarifies VV/VW carries no explicit reactive/curtailment price; the cost is foregone export, and `model_hook!` is the seam to price those services explicitly (the native `cost` field prices active power only).
- **Impedance step order** (tutorial_impedance_models.md) — signpost explaining the deliberate step 2 → 4 → 3 demonstration order.
- **Time-series FAQ** (tutorial_timeseries.md + spec/timeseries.md) — new "Modelling notes & FAQ" covering irradiance/PV shape changes, EV and other load patterns, power factor, and why BESS/multi-period is out of scope; pointer from the spec page.

## Verification

- `julia --project=docs docs/make.jl` completes **exit 0** — no cross-reference or broken-link errors (only pre-existing HTML size-threshold warnings and the expected local deploy skip).
- All additions audited for the `](`​ bracket-paren markdown-link hazard fixed in #344 — none introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)