### PR TITLE
Expose line primitive admittance API

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -60,6 +60,7 @@ sideload_coordinates!
 ## Admittance export
 
 ```@docs
+line_yprim
 transformer_yprim
 export_yprim
 write_yprim

--- a/src/BMOPFTools.jl
+++ b/src/BMOPFTools.jl
@@ -1200,7 +1200,7 @@ export merge_series_lines, remove_dangling_lines
 export remove_open_switches, collapse_closed_switches
 export simplify_network
 export transformer_yprim, export_yprim, write_yprim
-export ybus_passive, YbusResult
+export ybus_passive, YbusResult, line_yprim
 export ybus_linearized, LinearizedYbus
 export ybus_augmented, AugYbusResult, IdealCoupling
 export overhead_line_constants, compile_linecode, compile_linecodes!

--- a/src/io/ybus.jl
+++ b/src/io/ybus.jl
@@ -327,6 +327,22 @@ function _line_yprim(line::Dict{String,Any}, linecodes::AbstractDict)
     (nodes, Y)
 end
 
+"""
+    line_yprim(line, linecodes) -> (nodes, Y)
+
+Return one line's nominal-Π primitive admittance block in the same convention as
+[`ybus_passive`](@ref): `I_into = Y * V_to_ground`, with positive terminal
+currents flowing from the bus into the line. `nodes` lists the from-side
+terminals followed by the to-side terminals; `Y` is SI siemens and symmetric
+under `transpose` (not conjugate transpose).
+
+This public element-level seam is useful for branch-current and branch-power
+measurements without reconstructing a branch model from a network Ybus.  It
+uses exactly the linecode, terminal-map truncation, and shunt-stamping rules
+used by `ybus_passive` and the OPF branch formulation.
+"""
+line_yprim(line::Dict{String,Any}, linecodes::AbstractDict) = _line_yprim(line, linecodes)
+
 # Shunt: admittance matrix Y = G + jB over the single bus's terminals.
 function _shunt_yprim(shunt::Dict{String,Any})
     G = _pattern_keys_to_matrix(shunt, "G_")

--- a/test/admittance_tests.jl
+++ b/test/admittance_tests.jl
@@ -1,3 +1,16 @@
+@testset "line_yprim public primitive" begin
+    line = Dict{String,Any}(
+        "bus_from" => "a", "bus_to" => "b",
+        "terminal_map_from" => ["1"], "terminal_map_to" => ["1"],
+        "linecode" => "lc", "length" => 2.0,
+    )
+    linecodes = Dict{String,Any}("lc" => Dict{String,Any}("R_series_1_1" => 0.5))
+    nodes, Y = line_yprim(line, linecodes)
+    @test nodes == [("a", "1"), ("b", "1")]
+    @test Y ≈ ComplexF64[1 -1; -1 1]
+    @test Y ≈ transpose(Y)
+end
+
 @testset "Transformer Yprim export" begin
 
     # ─── helpers ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Adds a public `line_yprim(line, linecodes)` API for branch-current and branch-power consumers. The implementation delegates to the same primitive used by Ybus and OPF stamping, with focused admittance tests.