### PR TITLE
Fix objective units and strengthen scientific validation claims

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -60,6 +60,7 @@ sideload_coordinates!
 ## Admittance export
 
 ```@docs
+line_yprim
 transformer_yprim
 export_yprim
 write_yprim

--- a/docs/src/augmentation.md
+++ b/docs/src/augmentation.md
@@ -313,9 +313,10 @@ transformation manifest.
 **Slack cost.**  The voltage source is itself the network's current slack, so no
 slack *generator* is created. If a source has no `cost`, a per-phase cost is
 written onto the `voltage_source` (default 1.0 \$/kWh) so imported power is
-priced in the objective. No
-flow bounds are added, so the slack stays unconstrained and the OPF can always
-find a feasible point. Controlled by the recipe's `apply_slack_generator` /
+priced in the objective. No flow bounds are added, so the source can absorb the
+network's net active/reactive imbalance. This removes one common cause of
+infeasibility, but does not override voltage, thermal, device, or other hard
+constraints. Controlled by the recipe's `apply_slack_generator` /
 `slack_cost` fields (names kept for backwards compatibility).
 
 **Reactive bounds.**  For each generator that has `p_max` defined but lacks

--- a/docs/src/bounds/diagnostics.md
+++ b/docs/src/bounds/diagnostics.md
@@ -16,12 +16,12 @@ relaxed solution against the AC equations is the exactness test of
     The JuMP recipes below apply to *your* model. Two of these diagnostics already exist
     inside this package, and you should reach for them first:
 
-    - **AC-feasibility of a candidate point** (Symptom 3) is exactly what
-      [`solve_feasibility_opf`](../validation.md) measures: it adds an elastic slack
-      current at every non-source terminal and minimises its norm, so a returned
-      `total_slack_magnitude_A` ≈ 0 certifies the point satisfies every KCL/KVL and
-      component-model equation. This is the native, four-wire analogue of
-      `primal_feasibility_report` against the AC model.
+    - **AC-feasibility of a candidate point** (Symptom 3) can be tested by first
+      pinning its decisions with [`project_solution`](../validation.md), then
+      running [`solve_feasibility_opf`](../validation.md) on that determined
+      snapshot. A converged near-zero slack plus independently checked residuals
+      supplies a numerical feasible point. This is the native, four-wire analogue
+      of `primal_feasibility_report` against the AC model.
     - **Ill-posedness *before* you solve** — flat objectives, free injections, and
       cost degeneracy — is caught structurally by the benchmark-readiness flags
       (`W.BENCH.GEN_ZERO_COST`, `W.BENCH.GEN_DEGENERATE_COST`, `W.BENCH.GEN_NO_DOF`;
@@ -118,15 +118,16 @@ isempty(report) ? @info("AC-feasible: relaxation exact") :
 
 In BMOPFTools the same check is available natively for a four-wire network: pin the
 candidate dispatch into the case and call [`solve_feasibility_opf`](../validation.md),
-which minimises an injected slack current. A near-zero slack certifies the point is a
-valid AC power flow; a non-zero slack is the violation, localised to the terminals
-where it concentrates:
+which minimises an injected slack current. A converged near-zero slack, together
+with independently recomputed residuals, demonstrates a valid numerical power
+flow. A non-zero slack localises the residual used by that relaxed solve:
 
 ```julia
-res     = solve_feasibility_opf(net; optimizer = Ipopt.Optimizer)
+snap    = project_solution(net, result)
+res     = solve_feasibility_opf(snap; optimizer = Ipopt.Optimizer)
 slack_A = res["total_slack_magnitude_A"]
-slack_A < 1e-3 ? @info("AC-feasible: candidate is a valid power flow") :
-                 @info("AC-infeasible: relaxation/candidate INEXACT", slack_A)
+slack_A < 1e-3 ? @info("candidate has near-zero KCL slack; verify residuals") :
+                 @info("candidate/relaxation has residual current", slack_A)
 ```
 
 For the branch-flow relaxation on a **radial** network you can also read the gap directly
@@ -222,8 +223,9 @@ J = jacobian_of_active_constraints(model)   # your assembly of ∇g for active g
 ```
 
 For the AC-feasibility leg of this triage, reach for
-[`solve_feasibility_opf`](../validation.md): a near-zero `total_slack_magnitude_A`
-distinguishes "slow but feasible" from "genuinely infeasible."
+[`solve_feasibility_opf`](../validation.md): a verified near-zero
+`total_slack_magnitude_A` supplies a feasible point, while non-zero slack is a
+local diagnostic that should be checked across starts and formulations.
 
 ## Validation checklist against the benchmarks
 

--- a/docs/src/bounds/known_traps.md
+++ b/docs/src/bounds/known_traps.md
@@ -80,7 +80,8 @@ per-branch cone gap ([Diagnostics §3](diagnostics.md)). This is the headline re
 feasible relaxation is only a one-sided certificate.
 
 *In BMOPFTools:* check the AC side with [`solve_feasibility_opf`](../validation.md) — a
-non-zero `total_slack_magnitude_A` confirms the loading is past collapse.
+repeatable non-zero `total_slack_magnitude_A` is evidence consistent with the
+analytically predicted collapse, not by itself a global infeasibility certificate.
 
 ## Trap 4 — Loss-maximizing objective breaks exactness
 

--- a/docs/src/bounds/loss_maximization.md
+++ b/docs/src/bounds/loss_maximization.md
@@ -44,7 +44,8 @@ objective not on the safe list:
     The negative-coefficient row is exercised directly in the OPF suite: test **T4**
     ([Validating the OPF](../validation.md)) gives a generator a *negative* cost
     coefficient and confirms the optimum drives each phase to `p_max` with
-    `objective = −3·P_max` — i.e. min-cost has silently become max-generation. If your
+    `objective = −3·P_max/1000` (\$/h, with `P_max` in W) — i.e. min-cost has
+    silently become max-generation. If your
     own formulation reproduces that number, it is reproducing the trap, not a bug.
 
 ## Two that look risky but are mostly fine

--- a/docs/src/bounds/solver_trust.md
+++ b/docs/src/bounds/solver_trust.md
@@ -11,35 +11,38 @@ what Ipopt just told me?**
     - **Building or curating a dataset?** Read the *Takeaway* boxes and the
       [trust checklist](@ref "7. A trust checklist") at the end. The short version: once your
       bounds are sane, your objective is off the
-      [loss-maximization list](loss_maximization.md), and the benchmark flags are clear, a
-      reported `INFEASIBLE` almost certainly *is* infeasible and a reported
-      `LOCALLY_SOLVED` is almost certainly the operating point you wanted.
-    - **Validating a formulation?** Read everything. The two headline claims —
-      *infeasible likely means infeasible*, *locally optimal is probably global* — are
-      **calibrated trust, not proof**. The *Derivation* blocks say exactly what is and is
-      not certified, and Sections 4–6 catalogue the numerical reasons a *correct* model
-      can still misbehave.
+      [loss-maximization list](loss_maximization.md), and the benchmark flags are
+      clear, solver statuses become useful **hypotheses** to verify: multi-start
+      and a feasibility relaxation strengthen an infeasibility diagnosis, while
+      primal residual checks establish whether a locally solved point is a valid
+      operating point.
+    - **Validating a formulation?** Read everything. The two headline rules are:
+      *a local infeasibility status is not an infeasibility certificate*, and *a
+      local optimum is not a global optimum*. Sections 2–6 explain what additional
+      evidence can justify greater confidence without changing those facts.
 
 !!! tip "The two claims, up front"
     After the physics traps are excluded:
 
-    - **`INFEASIBLE` (a locally infeasible point) most likely means physically
-      infeasible.** Ipopt entered restoration, minimised the constraint violation, and
-      could not drive it to zero. With a compact, well-bounded feasible set this is a
-      strong signal — but on a nonconvex problem it is *evidence, not a certificate*.
-    - **`LOCALLY_SOLVED` is very likely the global, high-voltage optimum** — for a
-      loss/cost-minimising objective from a sane start. Again strong, again **not a
-      certificate**: only an exact relaxation or a global solver proves globality.
+    - **`INFEASIBLE` means this solver trajectory did not reach feasibility.**
+      Ipopt entered restoration, minimised constraint violation locally, and
+      could not drive it to zero. Repeated starts and a consistent slack-current
+      pattern strengthen the diagnosis but do not prove the feasible set is empty.
+    - **`LOCALLY_SOLVED` means a KKT point was found.** A high-voltage start and a
+      non-decreasing generation-cost objective often favour the operational
+      branch, but this does not establish global optimality. Only a valid global
+      bound — for example from an exact relaxation or global solver — can do that.
 
 ## 1. What Ipopt's verdicts actually certify
 
 !!! tip "Takeaway"
-    Ipopt is a **local** interior-point solver. `LOCALLY_SOLVED` certifies a point
-    satisfying the first-order (KKT) conditions to tolerance — a stationary point of a
-    *nonconvex* program, not a global optimum. `LOCALLY_INFEASIBLE` ("Converged to a
-    locally infeasible point") certifies that Ipopt's **restoration phase** found a local
-    minimiser of constraint violation with violation still above tolerance. Neither word
-    means what its convex-optimization namesake means.
+    Ipopt is a **local** interior-point solver. `LOCALLY_SOLVED` reports that its
+    termination tests for approximate first-order (KKT) conditions passed — a
+    stationary-point claim for a *nonconvex* program, not a global optimum.
+    `LOCALLY_INFEASIBLE` ("Converged to a locally infeasible point") reports that
+    Ipopt's **restoration phase** reached a local minimiser of constraint violation
+    with violation still above tolerance. Independently inspect primal residuals
+    before treating either status as evidence about the represented system.
 
 Ipopt solves a sequence of barrier subproblems with a filter line search
 ([Wächter & Biegler, 2006](https://doi.org/10.1007/s10107-004-0559-y)). When a step
@@ -65,18 +68,18 @@ violation. The two terminal messages map onto this machinery directly:
     first-order **certificate** of local infeasibility exist, but they are specially
     constructed; stock Ipopt does not hand you one.
 
-    The practical upshot is the whole reason this page exists: you cannot lift `INFEASIBLE`
-    to a proof for free, but you *can* raise your confidence in it to near-certainty by
-    excluding the alternative explanations — which is Sections 2 through 6.
+    The practical upshot is the whole reason this page exists: you cannot lift
+    `INFEASIBLE` to a proof for free, but you can accumulate reproducible evidence
+    by excluding alternative explanations — which is Sections 2 through 6.
 
-## 2. Why infeasible likely means infeasible — here
+## 2. Building evidence for physical infeasibility
 
 !!! tip "Takeaway"
-    With full operational bounds and the collapse region excluded
-    ([§3](index.md) and [§4](index.md) of the main note), the feasible set is **compact**
-    and the only reasons a solve fails are (a) the instance really is infeasible, or
-    (b) a numerical pathology from Sections 4–6. Rule out (b) and `INFEASIBLE` is as good
-    as a verdict gets without a global solver.
+    Full operational bounds and a positive voltage floor can make the search
+    region bounded and remove common collapse/zero-voltage pathologies
+    ([§3](index.md) and [§4](index.md)). They do not make the problem convex or
+    make restoration exhaustive. Treat agreement across starts, formulations,
+    and residual diagnostics as evidence, not as a binary proof.
 
 The main note's [§4](index.md) makes the physical case sharp: with constant-power loads,
 the edge of the AC feasible region *is* the loadability boundary, and beyond the nose the
@@ -86,40 +89,39 @@ equations have **no real solution** — genuine infeasibility, not a modelling s
 The hedge is nonconvexity: restoration is start-dependent. Two cheap cross-checks promote
 the signal toward certainty:
 
-- **Multi-start.** Re-solve from several starts (flat, high-voltage, a linear-model warm
-  start). If *every* start lands in restoration with a comparable residual, the case is
-  almost surely infeasible; if one start succeeds, it was never infeasible — see
-  [Symptom 5](diagnostics.md).
+- **Multi-start.** Re-solve from several materially different starts (flat,
+  high-voltage, a linear-model warm start). If every start lands in restoration
+  with a comparable residual, confidence in the diagnosis increases; one
+  independently verified feasible point disproves infeasibility — see [Symptom
+  5](diagnostics.md).
 - **The slack-current measure.** [`solve_feasibility_opf`](../validation.md) adds an
-  elastic slack current at every non-source terminal and minimises its norm, so it
-  *always* returns a point and reports how far that point is from feasible. A non-zero
-  `total_slack_magnitude_A` localises *where* the infeasibility concentrates — the
-  four-wire analogue of an IIS for this question.
+  elastic slack current at every non-source terminal and minimises its norm. For
+  a converged relaxed solve, a non-zero `total_slack_magnitude_A` localises where
+  that local solution uses residual current. Unlike an IIS for a convex/linear
+  problem, it does not certify that no zero-slack solution exists elsewhere.
 
-## 3. Why locally optimal is probably global
+## 3. Why a local solve often reaches the high-voltage branch
 
 !!! tip "Takeaway"
-    Under a loss- or cost-minimising objective (non-decreasing in generation) with full
-    bounds, the operationally meaningful **high-voltage solution is the unique attractor**
-    that fixed-point, relaxation, and energy-function methods all converge to *on radial
-    networks*. So a `LOCALLY_SOLVED` from a sane start is very likely *the* physical
-    optimum. The only *proof* of globality is an exact relaxation or a global solver — and
-    on the meshed or multiphase/unbalanced networks this engine also targets, even the
-    attractor argument is extrapolation, not theorem.
+    Some radial single-phase results establish useful uniqueness or attraction
+    properties for the high-voltage power-flow solution under stated conditions.
+    Those results motivate a high-voltage start and a loss/cost-minimising
+    objective here. They do not establish uniqueness or global optimality for the
+    meshed, multiphase, unbalanced OPFs this engine also targets.
 
 This is the optimistic mirror of [§2](index.md) and [§5](index.md). On a radial network
 the high-voltage solution is the last one to vanish as the system loads toward its limit,
 and the standard computational routes return exactly it when one exists
 ([Dvijotham, Mallada & Simpson-Porco, 2017](https://arxiv.org/abs/1706.05290), a radial,
-single-phase result). A loss-minimising objective is the lever ([§5](index.md)) that pins
-the nonconvex solve to that branch. Put together: sane start + loss-min objective + full
-bounds ⇒ the local optimum Ipopt returns is, with high probability, the global one — with
-the caveat that the underlying uniqueness theorems are radial and single-phase, so
-on a four-wire unbalanced feeder this is calibrated trust resting on an analogy, not a
-guarantee that carries over ([Bernstein et al., 2018](https://doi.org/10.1109/TPWRS.2018.2823277)).
+single-phase result). A loss-minimising objective can favour that branch
+([§5](index.md)). For a four-wire unbalanced feeder this is a useful
+initialisation heuristic and modelling analogy, not a probability statement or
+a theorem that carries over ([Bernstein et al.,
+2018](https://doi.org/10.1109/TPWRS.2018.2823277)). Globality remains an open
+claim until a valid lower bound closes the optimality gap.
 
 !!! details "Derivation: what an actual globality certificate would require"
-    "Probably global" is a statement about attractors, not a theorem about your specific
+    Attraction to a familiar branch is not a theorem about your specific
     instance. A genuine certificate comes from one of two places:
 
     - **An exact convex relaxation.** Solve the SOC/SDP relaxation, then confirm exactness
@@ -346,11 +348,13 @@ Work top to bottom; each step removes one alternative explanation for the solver
        across several starts ([Symptom 4–5](diagnostics.md)).
 
 !!! note "Then read the verdict this way"
-    - **`INFEASIBLE`** after steps 1–6 ⇒ trust it as **physical** infeasibility; confirm
-      *where* with `solve_feasibility_opf`'s slack current.
-    - **`LOCALLY_SOLVED`** after steps 1–6 ⇒ trust it as **the operating point**; it is
-      very likely the global optimum. For a *certificate* of globality, solve the
-      relaxation and confirm exactness ([Symptom 3](diagnostics.md)).
+    - **`INFEASIBLE`** after steps 1–6 ⇒ report a strengthened but still local
+      infeasibility diagnosis; show the multi-start outcomes and localise the
+      residual with `solve_feasibility_opf`.
+    - **`LOCALLY_SOLVED`** after steps 1–6 ⇒ treat it as a candidate operating
+      point after independently checking primal feasibility. Do not label it
+      globally optimal unless a relaxation/global solve supplies a matching valid
+      bound ([Symptom 3](diagnostics.md)).
     - **Slow / churning / suspicious duals** ⇒ you are in Section 4, 5, or a collapse
       regime; localise with [Symptom 5](diagnostics.md) before trusting *any* number.
 

--- a/docs/src/conventions.md
+++ b/docs/src/conventions.md
@@ -235,9 +235,12 @@ FAQ: a "wye" in the BMOPF sense always has the neutral return — a
 2-terminal load is `SINGLE_PHASE`, not a degenerate wye.
 
 Generators additionally carry `cost` and optional `p_min/p_max/q_min/q_max`.
-`cost` is a **per-phase vector of linear coefficients** (\$/W), one element per
-phase term; the objective contribution of phase `k` is `cost[k]·P_k`. (There is
-no polynomial/quadratic cost form.) A generator without bounds is an unbounded
+`cost` is a **per-phase vector of energy prices** (\$/kWh), one element per
+phase term. For a snapshot, the objective contribution of phase `k` is the cost
+rate `cost[k]·P_k/1000` (\$/h), because `P_k` is stored in watts. A multi-period
+monetary objective must additionally multiply each rate by the period duration
+in hours. (There is no polynomial/quadratic cost form.) A generator without
+bounds is an unbounded
 (slack-style) unit.
 
 **Voltage source as slack.** The `voltage_source` fixes its terminal voltages

--- a/docs/src/findings.md
+++ b/docs/src/findings.md
@@ -98,10 +98,10 @@ Symmetries in data create symmetric optima and degrade NLP convergence
 | `E.DOM.NEGATIVE_VALUE` | E | Negative value in an inherently nonnegative field (length, diagonal resistance). |
 | `W.DOM.LOAD_PF_LOW` | W | Load power factor below 0.70 — plausible but unusual for aggregated demand; often a P/Q unit mix-up. |
 | `W.DOM.GEN_COST_NEGATIVE` | W | Negative generation cost — the optimizer will dispatch it to its bound; verify it is intended (e.g. must-run subsidy). |
-| `W.DOM.GEN_COST_HIGH` | W | Cost above 10 \$/kWh — beyond any realistic tariff; suspect units. |
+| `W.DOM.GEN_COST_HIGH` | W | Cost above 10 \$/kWh — outside the package's default plausibility threshold; check units and whether an extreme scarcity/subsidy scenario is intentional. |
 | `E.DOM.GEN_SMAX_NONPOSITIVE` | E | Generator `s_max` (optional per-phase apparent-power rating) has a non-positive entry — the apparent-power circle is empty, so no operating point exists. |
 | `E.DOM.GEN_IMAX_NONPOSITIVE` | E | Generator `i_max` (optional per-phase current limit) has a non-positive entry — the current circle is empty, so no operating point exists. |
-| `W.DOM.COST_PHASE_NONUNIFORM` | W | A dispatchable element (`generator` or `voltage_source`) has a per-phase `cost` vector whose entries differ across phases. Costs are normally a single \$/W price applied symmetrically; a non-uniform vector is more often a data-entry slip than an intended per-phase price signal. Scalar costs are uniform by definition and never flag. |
+| `W.DOM.COST_PHASE_NONUNIFORM` | W | A dispatchable element (`generator` or `voltage_source`) has a per-phase `cost` vector whose entries differ across phases. Costs are normally a single \$/kWh price applied symmetrically; a non-uniform vector is more often a data-entry slip than an intended per-phase price signal. Scalar costs are uniform by definition and never flag. |
 | `W.DOM.LC_ZERO_R` | W | Near-zero or negative self-resistance on **any** linecode diagonal — a superconducting conductor, usually a placeholder. |
 | `E.DOM.XFMR_VREF_INVALID` | E | A transformer has `v_nom_from ≤ 0` or `v_nom_to ≤ 0`. The turns ratio N = v\_ref\_from / v\_ref\_to is undefined or infinite; the OPF cannot be built. Usually caused by a missing field defaulting to zero or a unit error (kV entered as 0.0). |
 | `W.DOM.XFMR_RATIO_OOB` | W | Direction-agnostic transformer step ratio `max(r, 1/r)` above 1000:1. Calibrated so standard distribution step-downs (e.g. 11 kV/433 V ≈ 25:1) do **not** flag. |

--- a/docs/src/opf.md
+++ b/docs/src/opf.md
@@ -4,10 +4,13 @@ Despite the name, the ambition of this Task Force extends well beyond the
 classical OPF problem of minimising generation cost subject to network
 constraints.  The unifying theme of the benchmark problems targeted here is
 the need to **accurately represent distribution network physics** rather than
-any particular objective function.  Generation cost minimisation is a
-convenient and well-posed starting point — it admits a unique solution, is
-straightforward to compare across solvers, and is equivalent to loss
-minimisation under mild conditions — but the same network physics underpins a
+any particular objective function. Generation cost minimisation with explicit
+operational bounds is a convenient starting point: its objective and feasibility
+conditions are straightforward to compare across solvers. With fixed demand and
+one uniform non-negative price on every real-power injection, minimizing total
+injection is equivalent to minimizing real losses. That special case does
+**not** imply uniqueness or global optimality in this
+nonconvex formulation. The same network physics underpins a
 much broader class of distribution-network-constrained optimisation problems
 of practical relevance: maximum load delivery, conservation voltage reduction
 (CVR), Dynamic Operating Envelopes (DOEs) for distributed energy resources,
@@ -220,16 +223,21 @@ not commit the solver to computing in SI.
 
 ### Objective
 
-Minimise total active-power generation cost (linear in current variables):
+Minimise total active-power generation cost **rate** (linear in active power;
+bilinear in generator/IBR voltage-current variables):
 
 $$\min \sum_{g \in \mathcal{G}} \sum_{k=1}^{|\mathcal{T}_g^\phi|}
-  c^g_k \cdot \bigl(\Delta v^r_k \, c^{r,g}_{g,k} + \Delta v^i_k \, c^{i,g}_{g,k}\bigr)$$
+  \frac{c^g_k}{1000} \cdot
+  \bigl(\Delta v^r_k \, c^{r,g}_{g,k} + \Delta v^i_k \, c^{i,g}_{g,k}\bigr)$$
 
-where $c^g_k$ (currency/W) is the **per-phase** linear cost coefficient — the
-`cost` field is a vector with one entry per phase term, indexed by $k$ — and
+where $c^g_k$ (currency/kWh) is the **per-phase** energy price — the `cost`
+field is a vector with one entry per phase term, indexed by $k$ — and
 $\Delta v_k$ is the phase-to-neutral (WYE) or line-to-line (DELTA) voltage at
 generator $g$'s $k$-th phase terminal (see [Generators](@ref generators-section)
-below). The same per-phase `cost` vector prices the voltage source and IBRs.
+below). Division by 1000 converts the active-power expression from W to kW, so
+the snapshot objective has units currency/h. The same per-phase `cost` vector
+prices the voltage source and IBRs. To obtain currency over a time interval,
+multiply this rate by the interval duration in hours.
 
 ---
 
@@ -1113,7 +1121,7 @@ windings — only the coil↔terminal incidence differs. The coil voltage $U_{j,
 is **phase-to-neutral** for a `WYE` winding and **line-to-line** (phase $k$ minus
 its delta partner $k^{\pm}$, selected by the winding's `delta_roll`) for a
 `DELTA` winding, whose $V^\text{ref}$ is its line-to-line coil voltage — so the
-$\sqrt3$/coil-base factor lives entirely in $N_j$ and $V^r_j$ stays consistent
+$\sqrt{3}$ coil-base factor lives entirely in $N_j$, and $V^r_j$ stays consistent
 (per-unit needs no $\sqrt3$ correction, since the bus base is line-to-neutral).
 A `WYE` coil injects $-c^{w}_{x,j,k}$ at its phase and $+\sum_k c^{w}_{x,j,k}$ at
 its neutral; a `DELTA` coil injects $-c^{w}_{x,j,k}$ at phase $k$ and
@@ -1208,36 +1216,44 @@ centre-tap secondary starts with a 60° leg error.
 
 `solve_feasibility_opf` adds an **elastic slack current**
 $(c^{r,\varepsilon}_{b,t},\, c^{i,\varepsilon}_{b,t})$ at every ungrounded,
-non-source terminal, making KCL always satisfiable:
+non-source terminal. These variables can absorb any KCL residual at those
+terminals, but they do not relax contradictory source fixes, inconsistent hard
+bounds, or other hard equalities:
 
 ```math
 \kappa^r_{b,t} + c^{r,\varepsilon}_{b,t} = 0, \qquad
 \kappa^i_{b,t} + c^{i,\varepsilon}_{b,t} = 0
 ```
 
-The cost objective is replaced by the $\ell_2^2$ norm of all slack injections:
+The primary cost objective is replaced by the $\ell_2^2$ norm of all slack
+injections:
 
 ```math
 \min \sum_{(b,t)} \Bigl[\bigl(c^{r,\varepsilon}_{b,t}\bigr)^2
                        + \bigl(c^{i,\varepsilon}_{b,t}\bigr)^2\Bigr]
 ```
 
-All device models — load, generator, **IBR**, shunt, transformer, switch,
-and the voltage-source slack — are built identically to `solve_opf`. The only
-differences are the deliberate ones: operational **network** bounds (voltage
-magnitude/sequence, line thermal-angle, bus limits) are **not** hard constraints
-here, and the objective is the slack norm rather than cost. Voltage bounds are
-evaluated post-solve by `diagnose_infeasibility`.
+The implementation adds a tiny linear transformer-current tie-break to select a
+numerical representative when Yd/Dy delta circulation is unobservable. Therefore
+the raw solver `objective` is an implementation metric; interpret the SI-valued
+slack fields instead.
 
-A zero-slack solution certifies physical feasibility.  Non-zero slacks at
-$(b, t)$ reveal where the network cannot balance KCL without external
-intervention.
+All device models and non-KCL hard constraints — including voltage, sequence,
+thermal, and angle limits — are built identically to `solve_opf`. The deliberate
+changes are the elastic KCL currents and the slack-norm objective. Thus the
+relaxed feasible set contains the original feasible set; it is not identical to
+it, and contradictory remaining hard constraints can still make it empty.
+
+A converged, independently residual-checked zero-slack point demonstrates
+numerical feasibility. Non-zero slacks at $(b,t)$ show where that local relaxed
+solution uses external current; they do not prove that no zero-slack solution
+exists elsewhere.
 
 ```julia
 fopf   = solve_feasibility_opf(net)
 diag   = diagnose_infeasibility(fopf, net)
 
-println(diag["is_feasible"])            # false if network is overloaded
+println(diag["is_feasible"])            # local classification from status/slack
 println(diag["total_infeasibility_A"])  # L2 norm of all slacks (A)
 ```
 
@@ -1305,7 +1321,7 @@ add your own inter-temporal constraints, solve once, and extract each snapshot:
 | function | role |
 |---|---|
 | `build_opf_model(net; model, add_objective, model_hook!, …)` | build one snapshot's devices/bounds into a (shared) model; no KCL, no solve |
-| `generation_cost(ctx)` | that snapshot's cost expression, unset — sum across snapshots for one combined objective |
+| `generation_cost(ctx)` | that snapshot's cost-rate expression (\$/h), unset — duration-weight and sum across snapshots for one monetary objective |
 | `enforce_kcl!(ctx)` | pin KCL for one snapshot (call once per snapshot before solving) |
 | `extract_result(ctx; solution_hook!)` | extract one snapshot's SI result after the shared solve |
 
@@ -1321,17 +1337,24 @@ ctxs  = [build_opf_model(nets[t]; model=model, add_objective=false,
                          model_hook! = battery_port!(t)) for t in 1:T]
 
 # inter-temporal state of charge: SOC[t+1] = SOC[t] − P[t]·Δt, cyclic
+duration_hours = fill(1.0, T)  # use the actual duration of every period
 @variable(model, soc[1:T+1]); @constraint(model, soc[1] == soc[T+1])
 for t in 1:T
-    @constraint(model, soc[t+1] == soc[t] - Pexpr[t]*Δt)
+    @constraint(model, soc[t+1] == soc[t] - Pexpr[t]*duration_hours[t])
     @constraint(model, 0 <= soc[t+1] <= E_max)
 end
 
-@objective(model, Min, sum(generation_cost(c) for c in ctxs))
+@objective(model, Min,
+    sum(duration_hours[t] * generation_cost(ctxs[t]) for t in 1:T))
 foreach(enforce_kcl!, ctxs)
 JuMP.optimize!(model)
 results = [extract_result(c) for c in ctxs]
 ```
+
+`generation_cost(ctx)` is a **rate**, not an interval total. A bare sum of rates
+preserves the same optimizer only when all periods have equal duration; it does
+not report a monetary total. Duration weighting is required when periods differ
+or when the objective value will be interpreted as currency.
 
 Everything a snapshot exposes for coupling — `ctx.model`, `ctx.vars`,
 `ctx.bases`, `ctx.kcl_r`/`ctx.kcl_i` — is the same context object a `model_hook!`

--- a/docs/src/results.md
+++ b/docs/src/results.md
@@ -9,7 +9,7 @@ id, then by terminal name (or winding label for transformers).
 result = solve_opf(net)
 
 result["termination_status"]   # "LOCALLY_SOLVED", "INFEASIBLE", …
-result["objective"]            # total generation cost
+result["objective"]            # objective value; units depend on solve mode
 result["solve_time"]           # wall-clock time in seconds
 
 result["bus"]["b1"]["1"]["vm"] # phase-1 voltage magnitude at bus b1 (V)
@@ -42,7 +42,7 @@ The `termination_status` and `solve_time` fields are always valid.
 | Key | Type | Description |
 |---|---|---|
 | `termination_status` | String | JuMP termination status (e.g. `"LOCALLY_SOLVED"`, `"INFEASIBLE"`, `"TIME_LIMIT"`) |
-| `objective` | Float64 | Objective value in cost units (matches the generator cost model) |
+| `objective` | Float64 | For default `solve_opf`, cost rate (\$/h). For `solve_feasibility_opf`, the squared-slack objective in solver working coordinates (plus its transformer tie-break). Custom objectives retain caller-defined units. |
 | `solve_time` | Float64 | Solver wall-clock time (s) |
 | `bus` | Dict | Per-bus, per-terminal voltage results |
 | `line` | Dict | Per-line, per-conductor current results |

--- a/docs/src/spec/objective.md
+++ b/docs/src/spec/objective.md
@@ -8,17 +8,21 @@ defined in [Notation](notation.md).
 
 ## Objective
 
-The default objective minimises total **active-power dispatch cost**, summed over every
-dispatchable element (generators, the voltage source, IBRs) and every phase:
+The default snapshot objective minimises total **active-power dispatch cost
+rate**, summed over every dispatchable element (generators, the voltage source,
+IBRs) and every phase:
 
 ```math
-\min \; \sum_{e} \sum_{k} \textcolor{red}{c_{e,k}}\; P_{e,k},
+\min \; \sum_{e} \sum_{k} \textcolor{red}{c_{e,k}}\; P_{e,k}/1000,
 ```
 
-where $\textcolor{red}{c_{e,k}}$ (currency/W, from each element's per-phase `cost`
-array) is the linear cost coefficient of phase $k$, and $P_{e,k}$ is that phase's
-injected active power — the same bilinear expression the element defines
-($P_{e,k}=\Delta v^r\,c^r + \Delta v^i\,c^i$).
+where $\textcolor{red}{c_{e,k}}$ (currency/kWh, from each element's per-phase
+`cost` array) is the energy price of phase $k$, and $P_{e,k}$ is that phase's
+injected active power in watts — the same bilinear expression the element defines
+($P_{e,k}=\Delta v^r\,c^r + \Delta v^i\,c^i$). The factor $1/1000$ converts W to
+kW, so this snapshot objective is a cost **rate** in currency/h. For a
+multi-period monetary objective, multiply every snapshot rate by its duration in
+hours before summing.
 
 ### Sign convention
 
@@ -53,8 +57,10 @@ into that terminal's KCL:
 \kappa^{\Re}_{i,p} + s^r_{i,p} = 0, \qquad \kappa^{\Im}_{i,p} + s^i_{i,p} = 0.
 ```
 
-Because the slack is unconstrained, KCL is **always satisfiable** — the relaxed problem
-always has a solution.
+Where a slack pair is present, it can absorb any residual in that terminal's KCL.
+This does **not** guarantee that the complete relaxed NLP is feasible or that a
+local solver will converge: fixed source voltages, hard bounds, device equalities,
+or terminals without slacks can still conflict.
 
 ### Objective
 
@@ -67,21 +73,21 @@ injections:
 
 ### Interpretation
 
-The relaxation carries the **same hard constraints** as the standard OPF — voltage
-bounds, bus/line angle limits, and every device current limit — so its feasible set is
-identical; the nodal current residual is the *only* relaxation, and it relaxes KCL.
-Consequently:
+The relaxation retains the standard OPF's hard constraints — voltage bounds,
+bus/line angle limits, and every device current limit — while enlarging the
+feasible set only through the nodal-current slacks. Consequently, for a
+successfully converged solve:
 
-- A **zero** slack solution certifies the network is physically feasible under its
-  loading.
-- **Non-zero** slack at a terminal localises and quantifies where KCL cannot balance —
-  the origin and magnitude of the infeasibility.
-- Voltages still respect their hard bounds (a constrained voltage sits at its bound and
-  the imbalance surfaces as residual current), so infeasibility on *either* power
-  balance or a voltage/angle bound is diagnosed by the residual pattern rather than a
-  solver failure. A genuine solver-infeasible status is reserved for hard bounds that
-  no nodal current can reconcile (e.g. a fixed source voltage contradicting a bound on
-  the same terminal).
+- An independently residual-checked **zero-slack** point demonstrates numerical
+  feasibility under the represented loading and constraints.
+- **Non-zero** slack at a locally optimal relaxed point identifies where that
+  solve paid to violate KCL and by how much current. It is diagnostic evidence,
+  not a proof that the original nonconvex problem has no zero-slack solution.
+- Voltages still respect their hard bounds. When those hard constraints remain
+  mutually consistent, an unreachable operating bound commonly surfaces as
+  residual current. Contradictory hard constraints can instead leave even the
+  relaxed problem infeasible (for example, a fixed source voltage contradicting
+  a bound on the same terminal).
 
 ## Implementation in BMOPFTools
 
@@ -91,14 +97,16 @@ Consequently:
 - **Feasibility** — `solve_feasibility_opf` (`feasibility_opf.jl`) reuses the full OPF
   build (`_add_voltage_and_bus_bounds!`, `_add_device_constraints!`), then adds one
   `(cs_r, cs_i)` pair per KCL node into the accumulators and sets the $\ell_2^2$
-  objective. Post-solve, `extract_feasibility!` reports `slack_injections` and
-  `total_slack_magnitude_A` per terminal, consumed by `diagnose_infeasibility`.
+  objective. Post-solve, `extract_feasibility!` reports per-terminal
+  `slack_injections` and the scalar L2 norm `total_slack_magnitude_A`, consumed by
+  `diagnose_infeasibility`.
 - **Degeneracy tie-break** — for Yd/Dy transformers the delta circulation current is
-  unobservable; a tiny ($-10^{-6}$) linear term on the delta-side current selects the
-  physical branch without competing with the slack term.
-- **Warm start** — the feasibility model has no voltage bounds pinning the degenerate
-  $v=0$ / high-voltage minima, so level-aware start values seed LV buses near their
-  nominal (≈250 V) rather than the source voltage.
+  unobservable; a tiny ($-10^{-6}$) linear term on the delta-side current selects one
+  numerical representative. Consequently the raw solver objective is an
+  implementation metric, not exactly the physical squared-slack norm; use the
+  reported SI slack fields for interpretation.
+- **Warm start** — when a case lacks useful voltage bounds, level-aware start
+  values seed LV buses near their nominal (≈250 V) rather than the source voltage.
 
 ### Source map
 

--- a/docs/src/spec/scope.md
+++ b/docs/src/spec/scope.md
@@ -25,8 +25,10 @@ directly — the distribution analogue of transmission-side benchmark libraries.
 Although "OPF" names this document, the goal is broader than minimising generation cost.
 The unifying requirement of the target problems is **an accurate conductor-level
 representation of an unbalanced network subject to a selectable set of bounds** — not any
-one objective. Cost minimisation is a convenient, well-posed starting point (unique
-solution, solver-comparable, loss-equivalent under mild conditions), but the same physics
+one objective. Bounded cost minimisation is a convenient, solver-comparable
+starting point. With fixed demand and one uniform non-negative price on every
+real-power injection, minimizing total injection is equivalent to minimizing
+real losses. It does not make the nonconvex feasible set or optimum unique. The same physics
 underpins maximum load delivery, conservation voltage reduction, dynamic operating
 envelopes, and state estimation.
 

--- a/docs/src/terminals_primer.md
+++ b/docs/src/terminals_primer.md
@@ -82,12 +82,16 @@ unfamiliar to a MATPOWER/PowerModels user:
   OPF can solve directly in SI or in an internally-scaled per-unit copy
   (`per_unit`), and which one better conditions the nonlinear program is an open,
   instance-dependent question — see [Units & scaling](opf.md#Units-and-scaling).
-- **There are no symmetrical components.** The symmetrical-component transform is
-  only valid for a balanced, transposed network [ref. 17](methodology.md#refs) —
-  exactly what a feeder is not — so the model stays in phase/conductor
-  coordinates. A useful tell that a method has *quietly* assumed a balanced
-  three-phase system is stray $\sqrt{3}$ factors or complex phase-shift
-  multipliers in its equations; none appear here [ref. 16](methodology.md#refs).
+- **Sequence coordinates are derived, not the network state.** The
+  symmetrical-component transform is an invertible change of coordinates for
+  any three-phase phasor vector. What requires a cyclically symmetric network
+  (commonly obtained from balanced/transposed parameters) is the stronger step
+  of treating the positive-, negative-, and zero-sequence networks as
+  **decoupled** [ref. 17](methodology.md#refs). This formulation therefore solves
+  in phase/conductor coordinates and uses Fortescue components only as derived
+  quantities for sequence-voltage limits. A stray $\sqrt{3}$ or phase-shift
+  multiplier is not by itself evidence of a balanced model; the tell is whether
+  mutual coupling and unequal conductor states have been discarded.
 - **The formulation is rectangular current–voltage (IVR), not power-balance
   polar.** The decision variables are *currents* ($c^r, c^i$) and *rectangular*
   voltages ($v^r, v^i$); KCL is written in currents, and power is a bilinear

--- a/docs/src/tutorial_end_to_end.md
+++ b/docs/src/tutorial_end_to_end.md
@@ -225,7 +225,7 @@ optimizer = optimizer_with_attributes(Ipopt.Optimizer, "print_level" => 0)
 result = solve_opf(net_ready; optimizer = optimizer, per_unit = true)
 
 println("Termination : ", result["termination_status"])
-println("Objective   : ", round(result["objective"]; sigdigits = 6))
+println("Cost rate   : ", round(result["objective"]; sigdigits = 6), " \$/h")
 ```
 
 The **negative objective is correct**: the PV fleet placed in step 4 is priced

--- a/docs/src/tutorial_infeasibility.md
+++ b/docs/src/tutorial_infeasibility.md
@@ -10,9 +10,9 @@ infeasibility verdict is **a claim, not a certificate**
 the runnable companion to the [Bounds, Branches, and Feasibility](bounds/index.md)
 chapter: the three-tool diagnosis workflow on one small feeder, end to end.
 
-The punchline up front: instead of interrogating a failed solve, you run a
-**relaxed problem that always solves** — [`solve_feasibility_opf`](@ref) — and read
-*where* and *by how much* the network misses feasibility off its elastic slack
+The punchline up front: instead of interrogating only the failed solve, you run
+an **elastic KCL relaxation** — [`solve_feasibility_opf`](@ref) — and, when it
+converges, read *where* and *by how much* that local relaxed point uses its slack
 variables. [`infeasibility_preflight`](@ref) catches the statically detectable
 mistakes before any solver runs, and [`diagnose_infeasibility`](@ref) turns the raw
 slack pattern into a ranked, classified diagnosis. Every code block below executes
@@ -121,8 +121,9 @@ Zero conflicts, zero errors: `222.0 < 253.0` is a perfectly consistent bound pai
 on paper. (The adequacy ratio of 0.0 just says there is no local generation — this
 feeder imports everything through the source, which is normal.) Whether 222 V is
 *reachable* through 0.8 Ω of cable under 4 kW of load is a power-flow question that
-static analysis cannot answer. For that we need the solver back — but on a problem
-that cannot fail.
+static analysis cannot answer. For that we need the feasibility-relaxed solver,
+which is designed to expose KCL imbalance while retaining the other hard
+constraints.
 
 ## 4. The elastic problem: `solve_feasibility_opf`
 
@@ -130,9 +131,11 @@ that cannot fail.
 hard voltage bounds, angle limits, and device current limits — with one surgical
 relaxation: an elastic slack current ``(c^s_r, c^s_i)`` is injected into KCL at
 every non-source bus terminal, and the objective minimises ``\sum_k |c^s_k|^2``
-instead of generation cost. KCL can now always balance, so the problem solves even
-when the original could not; any terminal that *needed* its slack to balance is a
-terminal where the physics and the bounds disagree. It is the four-wire analogue
+instead of generation cost. At every terminal carrying a slack variable, KCL can
+balance by paying a residual-current penalty. If the remaining hard constraints
+are consistent and the relaxed solve converges, a terminal using slack identifies
+where that local relaxed solution could not close KCL without intervention. It is
+the four-wire analogue
 of an irreducible-infeasible-subsystem search, run as a single least-squares NLP
 (see [Diagnostics & validation](bounds/diagnostics.md)).
 
@@ -231,9 +234,9 @@ println("is_feasible : ", d_fix["is_feasible"],
         "   residual : ", d_fix["total_infeasibility_A"], " A")
 ```
 
-`LOCALLY_SOLVED`, and the feasibility OPF's residual collapses to numerical zero —
-a near-zero `total_slack_magnitude_A` is precisely the certificate that a point
-satisfying every KCL, KVL and device equation exists
+`LOCALLY_SOLVED`, and the feasibility OPF's residual collapses to numerical zero.
+Together with an independent residual check, this supplies an explicit
+numerically feasible point satisfying the represented KCL, KVL, and device equations
 ([Diagnostics & validation](bounds/diagnostics.md)). The loop is closed: claim,
 localisation, quantified fix, confirmation.
 
@@ -241,9 +244,9 @@ localisation, quantified fix, confirmation.
 
 - **The verdict is calibrated trust, not proof.** With sane bounds, a
   loss/cost-minimising objective, and the numerical traps excluded,
-  `LOCALLY_INFEASIBLE` almost always *is* physical infeasibility — work through the
-  [trust checklist](bounds/solver_trust.md) before concluding, and remember that
-  restoration is start-dependent ([2](@ref refs-infeas)).
+  repeated `LOCALLY_INFEASIBLE` outcomes are evidence of physical infeasibility —
+  work through the [trust checklist](bounds/solver_trust.md) before concluding,
+  and remember that restoration is start-dependent ([2](@ref refs-infeas)).
 - **Slacks are fictitious nodal currents.** A non-zero `cs_mag` at a terminal is
   the current a hypothetical device would have to inject *at that node* to make the
   bounds hold — its location says *where*, its magnitude (times the upstream
@@ -251,11 +254,13 @@ localisation, quantified fix, confirmation.
 - **Preflight first, always.** It is free, and crossed bounds or out-of-window
   source setpoints produce infeasibilities no amount of solver forensics explains
   faster. What it cannot see is impedance: reachability questions need §4.
-- **A converged feasibility OPF with near-zero slack is a feasibility
-  certificate**; a converged one with structured slack is a diagnosis. The rare
+- **A converged feasibility OPF with independently verified near-zero slack gives
+  an explicit feasible point**; a converged one with structured slack is a local
+  diagnosis, not an infeasibility certificate. The rare
   case where even the *elastic* problem fails to converge (flagged by
-  `solver_infeasible` in the diagnosis) means a hard bound conflicts with a fixed
-  source voltage — data to inspect directly, not physics.
+  `solver_infeasible` in the diagnosis) can indicate a remaining hard-constraint
+  conflict, poor conditioning, or a failed local trajectory; inspect status,
+  residuals, and source/bound consistency before classifying it.
 - The failure modes behind stubborn cases — collapse proximity, branch
   multiplicity, degenerate duals — are catalogued in the
   [Known traps](bounds/known_traps.md) gallery.

--- a/docs/src/tutorial_mvdc.md
+++ b/docs/src/tutorial_mvdc.md
@@ -287,8 +287,8 @@ carries a **real, quantified line loss** that the optimiser now trades against t
 AC-side losses when it chooses the transfer.
 
 **Remember to widen the far bus.** The pole drop pushes `dcB` down to `1352 V`,
-*below* the master's `1400 V` floor — so if `dcB` inherited `dcA`'s `[1400, 1800]`
-window the problem is genuinely infeasible, not just harder:
+*below* the master's `1400 V` floor — so if `dcB` inherits `dcA`'s `[1400, 1800]`
+window, this operating point is excluded and the local solve reports infeasibility:
 
 ```@example mvdc
 r_narrow = solve_opf(feeder_tie(; v_dc_min_far = 1400.0); optimizer = OPT)

--- a/docs/src/tutorial_nameplate.md
+++ b/docs/src/tutorial_nameplate.md
@@ -80,9 +80,12 @@ end
 
 Reading those tiers back as engineering judgment:
 
-- **Standards-derived** (`:standard`) — the number *is* in a published standard.
-  The voltage envelopes come straight from EN 50160 (`EN50160:2010§3.5`), and the
-  slack generation from the Task Force spec. Trust these.
+- **Standards-derived** (`:standard`) — the rule is traceable to a published
+  standard. The voltage envelopes use EN 50160 (`EN50160:2010§3.5`), and the
+  slack convention follows the Task Force spec. This is strong provenance, not
+  universal applicability: confirm the jurisdiction, voltage class, revision,
+  planning/operational purpose, and any local connection agreement before using
+  the value in a published study.
 - **Inferred, heuristic** (`:high` / `:medium` / `:low`) — the thermal ratings
   (`heuristic_ampacity_estimate`). The pass reads each conductor's diagonal
   resistance R₁₁ as a *size fingerprint* and looks up a representative ampacity.

--- a/docs/src/tutorial_trust_but_verify.md
+++ b/docs/src/tutorial_trust_but_verify.md
@@ -4,11 +4,11 @@
 
 A nonlinear OPF solver ends with a verdict like `LOCALLY_SOLVED`. It is tempting
 to read that as "the answer is correct." It is not what the status means. A
-`LOCALLY_SOLVED` status certifies that the solver found a point satisfying the
-first-order optimality (KKT) conditions of **the problem as posed**, to its
-internal tolerances. It says nothing about whether that problem is the one you
-meant, whether the optimum is global, or whether the numbers are physically
-sensible.
+`LOCALLY_SOLVED` status reports that the solver's termination tests for
+approximate first-order optimality (KKT) conditions of **the problem as posed**
+passed at its internal tolerances. It is not an independently checked
+certificate. It says nothing about whether that problem is the one you meant,
+whether the optimum is global, or whether the numbers are physically sensible.
 
 The antidote is cheap and worth building once by hand: take a solved case and
 **independently recompute** the physics — Kirchhoff's current law, Ohm's law,
@@ -178,9 +178,10 @@ sbad = solution_check(badfeeder(), rbad, fbad)
 ```
 
 The status is identical to the healthy case; only the independent loss check
-tells them apart. This is the general lesson. A `LOCALLY_SOLVED` verdict
-guarantees, to tolerance, a KKT point of the model you handed the solver. It
-does **not** guarantee that:
+tells them apart. This is the general lesson. A `LOCALLY_SOLVED` verdict reports
+an approximate KKT point of the model you handed the solver; independent
+residual checks determine whether the returned point actually meets your
+acceptance tolerance. The verdict does **not** guarantee that:
 
 - the optimum is **global** — nonconvex OPF can have several local optima, and
   which one you land on depends on the start point (see

--- a/docs/src/tutorial_vvwo.md
+++ b/docs/src/tutorial_vvwo.md
@@ -357,7 +357,7 @@ curtailment.
     reactive absorption of Volt-var consumes VA headroom that would otherwise
     carry active export), which is exactly the objective increase from A→B→C in
     the table. Note the native `cost` field prices **active power only**
-    (`cost[k]·P_k`); there is no built-in reactive-power price or curtailment
+    (`cost[k]·P_k/1000`, a \$/h rate with `P_k` in W); there is no built-in reactive-power price or curtailment
     penalty. To model an *explicit* ancillary-service payment for reactive
     support — or a compensation for curtailed active power — extend the objective
     with a [`model_hook!`](opf.md) that adds the corresponding term (a cost on

--- a/docs/src/validation.md
+++ b/docs/src/validation.md
@@ -5,55 +5,88 @@ validate cases and profile solutions. A reference solver is only as useful as it
 own validation, so this page documents **how that engine is tested** — both so you
 can judge the results and so you can **reuse the setup for your own tool**. 
 
-The goal of our implementation is to be consistent with generally accepted circuit modeling practice
-in the presence of nonlinear elements, including but not limited to constant power loads. We generally
-trust OpenDSS's implementation correctness, however, modelers may disagree on
-what appropriate models are. In this context, we recommend to study the paper "A perspective on transformer 
-modeling for distribution system analysis", with full bibliographic details below. 
+The goal of our implementation is to be consistent with generally accepted
+circuit-modelling practice in the presence of nonlinear elements, including
+constant-power loads. OpenDSS is used as an external reference implementation,
+not assumed to be ground truth; agreement can reveal implementation consistency
+but cannot decide which modelling assumptions are appropriate. For the latter,
+see "A perspective on transformer modeling for distribution system analysis",
+with full bibliographic details below.
 
-Three questions every distribution-OPF engine must answer, and the suite tests
-each separately:
+Three questions every distribution-OPF engine must answer. The suite treats
+them as separate evidence axes and records explicit gaps where coverage is not
+yet complete:
 
-1. **Is the solution a valid power flow?** — *feasibility*: do the solved
+1. **Is the solution a valid power flow for the implemented equations?** — *feasibility*: do the solved
    voltages and currents actually satisfy Kirchhoff's laws and the component
    models? We check this against **OpenDSS**. The same check is available for
    **your own** solved cases by [projecting the OPF onto a determined power
    flow](@ref opf-projection).
-2. **Is it the optimum?** — *optimality*: given the objective and the operating
-   bounds, does the optimizer reach the right dispatch? We check this against
-   **closed-form solutions** and against **PowerModelsDistribution (PMD)**. 
-   Note that we don't claim global optimality, just local. 
-3. **Are the network limits encoded correctly?** — *limit correctness*: does
-   each modeled limit (voltage magnitude, angle, current, power, sequence) hold
+2. **Does it reproduce a known or external dispatch target?** — *optimality
+   evidence*: given the objective and operating bounds, does the optimizer reach
+   the analytic target on cases with a derivable optimum, and does it reproduce
+   selected **PowerModelsDistribution (PMD)** regressions? PMD agreement is a
+   cross-implementation regression, not a global-optimality certificate.
+3. **Are tested network limits encoded correctly?** — *limit correctness*: does
+   each covered limit (voltage magnitude, angle, current, power, sequence) hold
    the engineering meaning it claims, given that the variables are *rectangular*
    and most limits are therefore **not** box bounds on a variable? OpenDSS has no
    OPF limits to compare against, so we check each limit by **driving the network
    onto it and recomputing the limited quantity from the primal solution**.
 
 The philosophy is the one stated in [the OPF formulation](opf.md): the accuracy of
-the network physics matters more than any single objective, so feasibility is
-validated exhaustively and component-by-component, while optimality is pinned to
-independently-derived optima.
+the network physics matters more than any single objective. The suite therefore
+samples component models across isolated fixtures, checks a smaller set of
+analytic optima, and exposes the remaining limit-test backlog below. It does not
+claim exhaustive coverage of every parameter combination.
+
+!!! warning "What this validation does and does not establish"
+    Agreement with OpenDSS establishes **cross-implementation consistency for
+    deliberately aligned equations**. Analytic fixtures establish correctness on
+    those restricted cases. Neither is empirical validation against field
+    measurements, nor proof that a chosen load/source/grounding model is adequate
+    for a particular real feeder. Likewise, a successful local NLP solve is not a
+    global-optimality certificate. Read the results as implementation evidence
+    within the documented model scope.
 
 If you are building your own engine there are **two ways to reuse this**: adopt
 the *harness* (the `.dss` cases and the comparison method), or adopt the
 *locked-in numbers* (the objective and voltage baselines tabulated below) as
-regression targets. The test files are the source of truth; the tables here
-reproduce their headers.
+regression targets. The test files are the source of truth. Inventory counts are
+computed during the documentation build rather than copied by hand; numerical
+tables below state assertion targets and tolerances but should still be reviewed
+when the underlying fixtures change.
 
 ## Feasibility — agreement with OpenDSS
 
 Source: [`test/powerflow_comparison_tests.jl`](https://github.com/frederikgeth/BMOPFTools.jl/blob/main/test/powerflow_comparison_tests.jl)
-(24 testsets) over the 18 OpenDSS cases in
+and the OpenDSS fixtures in
 [`test/data/pf_comparison/`](https://github.com/frederikgeth/BMOPFTools.jl/tree/main/test/data/pf_comparison).
+
+The current inventory is generated from the checked-out sources:
+
+```@example validation_inventory
+using BMOPFTools
+root = pkgdir(BMOPFTools)
+test_source = read(joinpath(root, "test", "powerflow_comparison_tests.jl"), String)
+n_testsets = length(collect(eachmatch(r"@testset\b", test_source)))
+case_dir = joinpath(root, "test", "data", "pf_comparison")
+n_dss_cases = count(f -> endswith(lowercase(f), ".dss"), readdir(case_dir))
+(testsets_in_file = n_testsets, dss_fixtures = n_dss_cases)
+```
+
+This is an implementation inventory, not a count of statistically independent
+experiments: nested testsets and multiple operating points can exercise the same
+fixture.
 
 ### The method: a power flow expressed as a feasibility OPF
 
 There is no separate power-flow solver to validate — instead each case is solved
 with [`solve_feasibility_opf`](opf.md#Feasibility-relaxation), which adds an
 **elastic slack current** at every non-source terminal and minimises its squared
-norm. When the optimal slack is ≈ 0, every KCL/KVL and component-model constraint
-is satisfied exactly, so the solution *is* a valid power flow:
+norm. When a converged solution has slack ≈ 0 and the independently recomputed
+residuals are within tolerance, it is an explicit feasible point of the
+implemented power-flow equations:
 
 ```julia
 res     = solve_feasibility_opf(net; optimizer = Ipopt.Optimizer)
@@ -63,8 +96,8 @@ slack_A = res["total_slack_magnitude_A"]
 
 The same network is then solved in OpenDSS through OpenDSSDirect.jl, and the
 complex node voltages are compared one-to-one. OpenDSS is solved *live* at test
-time — there are no stored golden voltages; the `.dss` files themselves are the
-immutable baseline (see [Voltage source as current slack](opf.md#source-slack)
+time — there are no stored golden voltages; the version-controlled `.dss` files
+define the baseline for a given repository revision (see [Voltage source as current slack](opf.md#source-slack)
 for how the source/slack convention is matched).
 
 On the BMOPF side the optimizer is **Ipopt at its defaults** — `tol = 1e-8`,
@@ -72,10 +105,12 @@ On the BMOPF side the optimizer is **Ipopt at its defaults** — `tol = 1e-8`,
 deliberate change is in the feasibility variant, which sets
 `acceptable_tol = 1e-8` to disable Ipopt's "acceptable level" early stop, so the
 bilinear constant-power and thermal constraints converge to the full tolerance
-rather than to an acceptable-but-loose point. Both sides of the comparison
-therefore solve to near machine precision (OpenDSS at `1e-8`, Ipopt at `1e-8`),
-which is what lets the residual be read as a *model* difference rather than the
-slop of either solver.
+rather than to an acceptable-but-loose point. Both sides use tight stopping
+tolerances (`1e-8`). A tolerance setting is not by itself proof of
+machine-precision solution accuracy; the voltage, KCL-slack, and loss assertions
+below are the observed checks. A residual difference can reflect an
+implementation/model mismatch or incomplete convergence, so convergence status
+is inspected separately.
 
 The node-name mapping bridges the two conventions:
 
@@ -88,16 +123,16 @@ The node-name mapping bridges the two conventions:
 ### Aligning the OpenDSS reference with the BMOPF model
 
 The `.dss` cases deliberately depart from a default OpenDSS run. The point of
-every deviation is the same: make OpenDSS evaluate the *same mathematical model*
-that BMOPF solves, so a voltage mismatch can only mean a genuine modelling
-disagreement — never a convergence convenience, a silent fallback, or an
-ambient default. None of these settings tune the answer; they remove confounds.
+every deviation is the same: make OpenDSS evaluate the *same intended
+mathematical model* that BMOPF solves. This removes known defaults and fallbacks
+as confounds; a remaining mismatch must still be triaged among implementation
+differences, conversion differences, and incomplete convergence.
 
 | Setting (in every case `.dss`) | OpenDSS default | Why we override it |
 |---|---|---|
 | `New Circuit … model=ideal` | source has an internal (Thévenin) impedance from `MVAsc1`/`MVAsc3` | BMOPF fixes the source-bus voltage directly (the [current-slack convention](opf.md)). A non-ideal source would sag under load, so the source bus itself would disagree on every case. `model=ideal` collapses the internal impedance to zero — a true fixed-voltage slack. |
 | `Load`/`PVSystem … Vminpu=0 Vmaxpu=2` (and `Vcutoff=0` for ZIP/exponential) | ≈ `Vminpu=0.95`, `Vmaxpu=1.05` | Outside that band OpenDSS silently switches a constant-power load to constant-impedance — a convergence aid BMOPF has no equivalent for. Widening the band keeps `model=1` strictly constant-P/Q (and the ZIP/exponential models on their true curve) across the whole voltage sweep. |
-| `Set Tolerance=1e-8` | `1e-4` (per-unit voltage-change convergence) | At the default, OpenDSS's own iteration error is ≈ `1e-4` pu — about `1.1 V` on an 11 kV base, comparable to the voltage-comparison `atol` and far larger than the ≈ 0.1–0.3 V agreement the cases actually achieve. Tightening to `1e-8` drives OpenDSS's solution to near machine precision so its convergence slop cannot masquerade as a model error. |
+| `Set Tolerance=1e-8` | `1e-4` (per-unit voltage-change convergence) | At the default, OpenDSS permits a voltage-change stopping threshold of ≈ `1e-4` pu — about `1.1 V` on an 11 kV base and comparable to the voltage-comparison `atol`. Tightening to `1e-8` reduces this convergence confound; the resulting voltage/residual assertions, not the setting alone, measure agreement. |
 | `Set MaxIterations=100` | `15` | Headroom so the tighter tolerance is actually reached rather than silently capping out. |
 | `Set DefaultBaseFreq=50` | `60` (or whatever a Windows GUI session persisted to the registry/environment) | Line and transformer reactances are interpreted *at the base frequency*, so an ambient default silently rescales every `X`. BMOPF models at 50 Hz ([`to_pmd`](api.md)), so the cases pin 50 Hz explicitly. The absolute value matters less than locking it unambiguously: with the solve frequency tracking the base frequency, the ohmic reactances are used as written either way — but the lock removes the dependency on the host's configuration so the cases are portable and reproducible. |
 
@@ -110,13 +145,13 @@ math, don't tune the answer" claim stays honest:
   `VoltageBases`/`CalcVoltageBases` (reporting only) and the solution `Algorithm`
   (left at the default `Normal`) are likewise untouched — neither changes the
   physics.
-- **The open-delta regulator case (`pf_open_delta_reg`) does not converge in
-  OpenDSS** at *any* tolerance or iteration cap — it is a known limitation of
-  OpenDSS's fixed-point and Newton solvers on that topology, not a regression from
-  the tighter tolerance (it did not converge at the `1e-4` default either). Its
-  last iterate still matches BMOPF's exact solution within the comparison
-  tolerance, which is itself evidence the comparison is robust to OpenDSS's
-  solver behaviour. The remaining 17 cases converge to `1e-8` in ≤ 16 iterations.
+- **The open-delta regulator fixture (`pf_open_delta_reg`) does not produce a
+  converged OpenDSS reference** under the attempted algorithms/tolerances. Its
+  last iterate is retained as a diagnostic comparison, but a non-converged last
+  iterate is **not validation evidence** and is excluded from claims about
+  converged cross-engine agreement. The fixture should become a validated oracle
+  case only when a converged independent reference and residual report are
+  available.
 
 ### Tolerances and their rationale
 
@@ -381,14 +416,15 @@ oracle mismatch can be attributed.
 
 ### The three-way triangulation
 
-With a determined snapshot in hand there are three independent estimates of the
-same voltages, and comparing them *localises* any disagreement:
+With a determined snapshot in hand there are three computational routes to the
+same voltages. Only route C uses an external engine; comparing all three still
+helps localise disagreements:
 
 | | Source | What it is |
 |---|---|---|
 | **A** | `result["bus"]` | the OPF's own predicted voltages |
-| **B** | `solve_pf(project_solution(net, result))` | BMOPF re-solving the pinned snapshot as a power flow (self-oracle) |
-| **C** | OpenDSS solving `to_dss(...)` of the snapshot | an *independent* engine (external oracle) |
+| **B** | `solve_pf(project_solution(net, result))` | BMOPF re-solving the pinned snapshot as a power flow (self-consistency check, not an independent oracle) |
+| **C** | OpenDSS solving `to_dss(...)` of the snapshot | an external engine (independent implementation comparator, not ground truth) |
 
 Reading the pattern:
 
@@ -425,7 +461,7 @@ net    = from_dss("my_feeder.dss")
 result = solve_opf(net)                    # your OPF solution
 
 snap   = project_solution(net, result)     # pin every setpoint → determined snapshot
-res_B  = solve_pf(snap)                     # B: BMOPF self-oracle  (expect A ≈ B)
+res_B  = solve_pf(snap)                     # B: BMOPF self-check  (expect A ≈ B)
 
 deck   = dispatch_as_loads(snap)            # generators/IBRs → negative loads
 to_dss(deck, "snap.dss")                    # C: hand to OpenDSS   (expect A ≈ B ≈ C)
@@ -439,10 +475,11 @@ comparison method verbatim — the only new machinery is the pinning.
 runs this on DER-augmented feeders and free-tap fixtures (the raw `pf_comparison`
 cases have no decision variables, so projection is a no-op there).
 
-## Optimality — agreement with known optima
+## Dispatch evidence — analytic targets and cross-tool regressions
 
-Feasibility proves the physics; optimality proves the optimizer reaches the right
-point. Three complementary tiers, each with a different source of truth.
+Feasibility checks agreement with the implemented physics; the tests below add
+dispatch evidence. Three complementary tiers use different reference targets,
+with different evidential strength.
 
 ### Tier 1 — closed-form analytic targets
 
@@ -460,23 +497,25 @@ and dispatch/cost tests pin the objective directly:
 | Test | Analytic target | Tolerance |
 |---|---|---|
 | T1 — single-phase resistive | `V = (V_s + √(V_s² − 4RP))/2 ≈ 947.214 V` | 0.01 V |
-| T3 — forced generator dispatch | `V ≈ 974.342 V`, `objective = cost·P_gen` | 0.01 V / 0.1 |
-| T4 — negative cost ⇒ `p_max` binding | each phase at `p_max = 50 kW`, `objective = −3·P_max` | 1.0 W / 10 |
+| T3 — forced generator dispatch | `V ≈ 974.342 V`, `objective = cost·P_gen/1000` (\$/h) | 0.01 V / 1e-4 \$/h |
+| T4 — negative cost ⇒ `p_max` binding | each phase at `p_max = 50 kW`, `objective = −3·P_max/1000` (\$/h) | 1.0 W / 0.01 \$/h |
 | T5 — power-balance identity | `P_source = P_load + P_line_loss` | 0.1 W |
 | T10 — sequence voltage bounds | tight `vneg_max`/`vzero_max` ⇒ balanced `V_phase = vpos_max` | 5.0 V |
 
 The suite also pins per-unit ⇄ SI agreement, immutability of the input network,
 and the result-dictionary contract (see [the result schema](results.md)).
 
-### Tier 2 — golden objectives ported from PowerModelsDistribution
+### Tier 2 — regression targets ported from PowerModelsDistribution
 
 Source: [`test/pmd_opf_port_tests.jl`](https://github.com/frederikgeth/BMOPFTools.jl/blob/main/test/pmd_opf_port_tests.jl).
 These fixtures rebuild PMD's small OPF test networks directly in BMOPF's native
-schema (no PMD dependency) and assert the **published PMD objective** — the slack
+schema (no PMD dependency) and assert the **published PMD dispatch totals** — the slack
 injection summed over phases, reported as `voltage_source[...]["ps"|"qs"]`. The
 2/3-bus cases target PMD's `IVRUPowerModel` (the formulation closest to BMOPF's
-current-voltage engine); the 4/5-bus and delta cases target PMD's AC formulations,
-whose objectives are formulation-independent.
+current-voltage engine); the 4/5-bus and delta cases target PMD's AC formulations.
+Because the values are ported rather than recomputed live by an independent
+global method, they are regression targets rather than proofs of the true/global
+optimum.
 
 **Locked-in baseline** (reuse these as regression targets; `atol = 1e-2 kW/kvar`
 unless noted):
@@ -516,7 +555,7 @@ droop curve in every regime:
   (`PG_PER_PHASE`) and phase-to-neutral (`PN_PER_PHASE`) dispatch differently once
   the neutral is displaced from ground.
 
-## Limit correctness — each network limit encodes what it claims
+## Limit-encoding evidence and coverage
 
 Feasibility checks the physics and optimality checks the dispatch — but both take
 the **constraint set as given**. Neither asks the prior question: does each
@@ -590,17 +629,17 @@ row is one unit test to develop, and the *status* column tracks coverage.
 
 ## Reusing this for your own tool
 
-| You want to … | Use | What it proves |
+| You want to … | Use | Evidence obtained |
 |---|---|---|
-| validate your power-flow / component models | the `.dss` cases + a live OpenDSS solve, compared as above | the network physics is correct |
-| validate your optimizer | the Tier-1 analytic targets and the Tier-2 PMD objective table as regression checks | the optimizer reaches the true optimum |
+| test power-flow / component implementations | the `.dss` cases + a live OpenDSS solve, compared as above | agreement with OpenDSS for the aligned fixture models |
+| test optimization behaviour | Tier-1 analytic targets, plus Tier-2 PMD values as cross-tool regressions | analytic correctness on Tier 1; regression agreement on Tier 2, not general globality |
 | validate smart-IBR control | the Tier-3 droop setpoints | control laws are enforced as modelled |
-| validate your network-limit encodings | the bind-and-recompute method + the limit inventory | each limit means what it claims, in rectangular variables |
+| validate your network-limit encodings | the bind-and-recompute method + the limit inventory | agreement with the intended quantity on the tested binding fixtures |
 
 The two reuse paths are complementary: the analytic and PMD numbers are
 *self-contained* baselines (copy the table, no dependency), while the `.dss`
 feasibility cases need an OpenDSS solve to regenerate the reference — which is the
-point, since OpenDSS is the de-facto distribution power-flow oracle.
+point, since OpenDSS is the external reference implementation used by this suite.
 
 ## Running the suite
 

--- a/ext/BMOPFOpfExt/BMOPFOpfExt.jl
+++ b/ext/BMOPFOpfExt/BMOPFOpfExt.jl
@@ -51,9 +51,9 @@ function adds its contribution to the KCL accumulator dicts `(kcl_r, kcl_i)`;
 | `load.jl`           | Constant-power load constraints (WYE / DELTA)     |
 | `generator.jl`      | Generator P/Q bounds                              |
 | `source.jl`         | Voltage-source voltage fixing + slack current/bounds |
-| `objective.jl`      | Generation-cost objective (linear + quadratic)    |
+| `objective.jl`      | Linear-in-power generation-cost-rate objective    |
 | `results.jl`        | Solution extraction to `Dict{String,Any}`         |
-| `feasibility_opf.jl`| Elastic KCL-slack formulation (always feasible)   |
+| `feasibility_opf.jl`| Elastic KCL-slack diagnostic formulation          |
 """
 module BMOPFOpfExt
 

--- a/ext/BMOPFOpfExt/branch.jl
+++ b/ext/BMOPFOpfExt/branch.jl
@@ -274,8 +274,7 @@ end
     _add_line_angle_constraints!(model, net, vars)
 
 Enforce per-line angle-difference bounds (`va_diff_min`, `va_diff_max`, radians) between
-the from- and to-end voltages on each conductor. Only called from `solve_opf` (operational
-limits, not the feasibility formulation).
+the from- and to-end voltages on each conductor. Shared by OPF and feasibility OPF.
 
 For each conductor k:
   s = vr_fr·vi_to − vi_fr·vr_to   (imaginary part of V_fr · conj(V_to))

--- a/ext/BMOPFOpfExt/bus.jl
+++ b/ext/BMOPFOpfExt/bus.jl
@@ -79,7 +79,7 @@ end
 """
     _add_bus_limit_constraints!(model, net, bus_terminals, grounded, vars)
 
-Enforce operational bus-level voltage limits (not called from feasibility OPF):
+Enforce operational bus-level voltage limits (shared by OPF and feasibility OPF):
 
 - Neutral voltage upper bound (`vn_max`, V): |v_n|² ≤ vn_max² when neutral is ungrounded.
 - Phase-to-neutral voltage magnitude bounds (`vpn_min`, `vpn_max`): applied to each

--- a/ext/BMOPFOpfExt/core.jl
+++ b/ext/BMOPFOpfExt/core.jl
@@ -140,8 +140,8 @@ end
     _add_voltage_and_bus_bounds!(ctx)
 
 Add the hard operational voltage bounds and bus-limit constraints. Shared by
-`solve_opf` and `solve_feasibility_opf` (both carry the identical hard feasible
-set); a future power-flow recipe would simply not call this.
+`solve_opf` and `solve_feasibility_opf` (both carry the same non-KCL hard
+constraints); the power-flow recipe does not call this.
 """
 function _add_voltage_and_bus_bounds!(ctx::OpfContext)
     _add_voltage_bounds!(ctx.model, ctx.net, ctx.bus_terminals, ctx.grounded, ctx.vars)

--- a/ext/BMOPFOpfExt/feasibility_opf.jl
+++ b/ext/BMOPFOpfExt/feasibility_opf.jl
@@ -3,37 +3,37 @@
 # Identical to solve_opf except:
 #   1. A free slack current (cs_r, cs_i) is added at every ungrounded,
 #      non-source bus terminal and injected directly into KCL.
-#      This makes the KCL system always satisfiable regardless of loading.
+#      This lets those KCL equations absorb residual current; it does not relax
+#      the remaining hard constraints or guarantee NLP feasibility/convergence.
 #   2. The objective minimises the L2² norm of all slack injections rather
-#      than generation cost.
+#      than generation cost, with a documented transformer tie-break term.
 #
-# Interpretation: non-zero slacks after solving indicate terminals where the
-# network cannot balance KCL under its physical constraints — i.e. the origin
-# and magnitude of infeasibility. Pass the result to diagnose_infeasibility()
-# for a ranked, classified breakdown.
+# Interpretation: at a converged local solution, non-zero slacks indicate where
+# that relaxed point uses residual current. This is a local diagnostic, not a
+# proof that the original feasible set is empty. Pass the result to
+# diagnose_infeasibility() for a ranked, classified breakdown.
 
 """
     BMOPFTools.solve_feasibility_opf(net; optimizer, t_index) -> Dict
 
 Feasibility-relaxed four-wire IVR-EN OPF. Adds an elastic slack current
 injection (the nodal current residual) at every non-source bus terminal and
-minimises ∑ |sₖ|² (L2² over all slack terminals).
+uses ∑ |sₖ|² (L2² over all slack terminals) as its primary objective, plus the
+documented transformer degeneracy tie-break.
 
-The model carries the **same hard constraints as [`solve_opf`](@ref)** — voltage
-bounds, bus/line angle limits, and all device current limits — so its feasible
-set is identical to the OPF's. The current residual is the *only* relaxation, and
-it relaxes **KCL**: at each node it injects whatever current is needed to balance
-power. Because of this, voltages still satisfy their hard bounds (a constrained
-bus voltage simply sits at its bound), and the resulting power mismatch surfaces
-as a non-zero residual at that node — so a network infeasible on either power
-balance *or* a voltage/angle bound is diagnosed by the residual pattern, not by a
-solver failure. The problem therefore stays solvable in the usual case; a
-genuine solver-infeasible status is reserved for hard bounds that even an
-arbitrary nodal current cannot reconcile (e.g. a fixed source voltage directly
-contradicting a bound on the same terminal), which `feasible == false` flags.
+The model retains [`solve_opf`](@ref)'s **non-KCL hard constraints** — voltage
+bounds, bus/line angle limits, and device limits — while the nodal-current
+variables enlarge the feasible set by relaxing **KCL**. They can absorb residual
+current wherever they are present, but cannot reconcile mutually contradictory
+hard constraints or guarantee convergence of the nonconvex NLP.
 
-Non-zero residuals localise and quantify the infeasibility. Pass the result to
-[`BMOPFTools.diagnose_infeasibility`](@ref) to interpret it.
+For a converged solve, non-zero residuals localise and quantify where that local
+relaxed point pays to violate KCL. They do not certify that the original problem
+has no zero-residual solution elsewhere. The raw `"objective"` is the squared
+slack norm in the model's working coordinates (plus the documented transformer
+tie-break); use the SI-valued `"slack_injections"` and
+`"total_slack_magnitude_A"` fields for physical interpretation. Pass the result
+to [`BMOPFTools.diagnose_infeasibility`](@ref) for a ranked breakdown.
 """
 function BMOPFTools.solve_feasibility_opf(net::Dict{String,Any};
                                            optimizer=Ipopt.Optimizer,
@@ -56,8 +56,8 @@ function BMOPFTools.solve_feasibility_opf(net::Dict{String,Any};
                      verbose, solver_options, model_hook!, solution_hook!)
 end
 
-# Disable "acceptable level" early stopping so Ipopt always converges to the
-# regular tolerance (1e-8).  Without this, problems with bilinear P/Q
+# Disable "acceptable level" early stopping so Ipopt must meet the regular
+# tolerance (1e-8) before reporting normal convergence. Without this, problems with bilinear P/Q
 # constraints and active thermal limits can exit prematurely, producing
 # inaccurate voltages. Ipopt-specific: skipped (with a warning) for any other
 # optimizer instead of erroring on an unsupported attribute.
@@ -84,19 +84,17 @@ function build_feasibility!(ctx::OpfContext, slack::Dict{Symbol,Any})
     kcl_r = ctx.kcl_r; kcl_i = ctx.kcl_i
 
     # Use level-aware start values so that LV buses are initialised at ~250 V
-    # rather than at the source voltage (~6350 V). Without voltage bounds the
-    # unconstrained NLP has a degenerate high-voltage local minimum; correct
-    # initialisation ensures Ipopt finds the physical solution instead.
+    # rather than at the source voltage (~6350 V). When a case lacks useful
+    # voltage bounds, this reduces attraction to a degenerate high-voltage local
+    # minimum; it is an initialisation heuristic, not a convergence guarantee.
     _set_level_aware_start_values!(vars, working, bus_terminals, grounded)
     _set_yd_dy_start_values!(vars, working, grounded)
 
-    # Bound parity with solve_opf: the feasibility model carries the *identical*
-    # hard constraints (voltage bounds, bus limits, line/bus angle limits, and
-    # all device current limits) so its feasible set equals the OPF's. The ONLY
-    # relaxation is the free nodal current residual (cs_r, cs_i) added to KCL
-    # below and penalised in the least-squares objective. Voltages thus respect
-    # their hard bounds; any resulting power imbalance shows up as residual
-    # current at the affected node rather than as an unbounded voltage.
+    # Bound parity with solve_opf: the feasibility model carries the same
+    # non-KCL hard constraints (voltage bounds, bus limits, line/bus angle limits,
+    # and device limits). Its feasible set is larger only because the free nodal
+    # residual (cs_r, cs_i) relaxes KCL below. Voltages still respect their hard
+    # bounds; contradictory remaining hard constraints can still be infeasible.
     _add_voltage_and_bus_bounds!(ctx)
 
     _add_device_constraints!(ctx)

--- a/ext/BMOPFOpfExt/objective.jl
+++ b/ext/BMOPFOpfExt/objective.jl
@@ -1,7 +1,8 @@
 # Objective: minimise total generation cost.
 #
-# `cost` is a per-phase vector of linear coefficients, one element per phase term
-# of the element ($/W): the cost of phase k is cost[k] * P_k, where
+# `cost` is a per-phase vector of energy-price coefficients, one element per
+# phase term of the element ($/kWh). For a snapshot, the cost rate of phase k is
+# cost[k] * P_k / 1000 ($/h), where
 #   P_k = dvr * cr[k] + dvi * ci[k]
 # is the per-phase active power (bilinear in voltage and current).
 #
@@ -16,14 +17,16 @@
 # with free DERs. Do not flip the sign for the source; the convention is enforced
 # by the "uniform cost convention (source ≡ generator)" OPF test.
 
-# Linear cost coefficient for loop position `idx` (1-based). `cost` must be a
-# per-phase vector; a scalar (legacy/polynomial form) is rejected.
+# Cost-rate coefficient for loop position `idx` (1-based). `cost` must be a
+# per-phase vector; a scalar (legacy/polynomial form) is rejected. Dividing by
+# 1000 converts the active-power expression from W to kW, so multiplying this
+# coefficient by P_W produces $/h.
 function _phase_cost(cost, idx::Int, kind::AbstractString, id::AbstractString)::Float64
     cost isa AbstractVector ||
         error("$kind '$id': cost must be a per-phase vector of linear coefficients, got a scalar")
     idx <= length(cost) ||
         error("$kind '$id': cost vector has length $(length(cost)) but phase index $idx requested")
-    Float64(cost[idx])
+    Float64(cost[idx]) / 1000.0
 end
 
 """
@@ -32,9 +35,11 @@ end
 Set the JuMP objective to minimise total active-power generation cost.
 
 The `"cost"` field on generators, the voltage source, and IBRs is a
-**per-phase vector of linear coefficients** `[c_1, …, c_nphase]` (\$/W); the
-objective contribution of phase `k` is `cost[k]·P_k`.  Costs are linear in the
-IVR-EN power expression and added exactly — there is no polynomial/quadratic term.
+**per-phase vector of energy prices** `[c_1, …, c_nphase]` (currency/kWh). For a
+snapshot, the objective contribution of phase `k` is `cost[k]·P_k/1000` in
+currency/hour, with `P_k` in W. Costs are linear in the IVR-EN power expression and added
+exactly — there is no polynomial/quadratic term. A multi-period caller must
+multiply each snapshot's cost rate by its duration in hours to obtain currency.
 """
 function _add_objective!(model, net, vars)
     @objective(model, Min, _generation_cost_expr(model, net, vars))

--- a/ext/BMOPFOpfExt/per_unit.jl
+++ b/ext/BMOPFOpfExt/per_unit.jl
@@ -251,7 +251,8 @@ function _pu_scale_sources!(net, bases)
         for f in ("p_min", "p_max", "q_min", "q_max")
             haskey(vs, f) && (vs[f] = Float64.(vs[f]) ./ sb)
         end
-        # Cost: per-phase linear coefficient $/W in SI → $/PU-W in PU (× s_base)
+        # Cost: $/kWh price is multiplied by s_base because the objective uses
+        # P_pu; _phase_cost then applies the W→kW factor (1/1000).
         if haskey(vs, "cost")
             c = vs["cost"]
             vs["cost"] = c isa AbstractVector ? Float64.(c) .* sb : Float64(c) * sb
@@ -375,8 +376,8 @@ function _pu_scale_generators!(net, bases)
         if haskey(gen, "i_max")
             gen["i_max"] = Float64.(gen["i_max"]) ./ ib
         end
-        # Cost: per-phase linear coefficient $/W in SI → $/PU-W in PU (× s_base)
-        # (cost per PU power = cost_si * s_base, since P_pu = P_si/s_base)
+        # Cost: $/kWh price is multiplied by s_base because P_pu = P_si/s_base;
+        # _phase_cost applies the remaining W→kW factor (1/1000).
         if haskey(gen, "cost")
             c = gen["cost"]
             gen["cost"] = c isa AbstractVector ? Float64.(c) .* sb : Float64(c) * sb
@@ -403,6 +404,12 @@ function _pu_scale_ibrs!(net, bases)
         # The power_factor control_profile "pf" field is dimensionless and the
         # PF equality constraint is scale-invariant — nothing to scale here.
         # topology / terminal_map are structural — untouched.
+        # Cost follows the same scaling as generator/source cost. Omitting this
+        # would change both the objective value and the merit order in PU mode.
+        if haskey(inv, "cost")
+            c = inv["cost"]
+            inv["cost"] = c isa AbstractVector ? Float64.(c) .* sb : Float64(c) * sb
+        end
     end
 end
 
@@ -852,8 +859,11 @@ function _from_per_unit(result_pu::Dict{String,Any}, bases, net::Dict{String,Any
         end
     end
 
-    # Objective: cost_pu * P_pu = (cost_si * s_base) * (P_si / s_base) = cost_si * P_si
-    # The s_base factors cancel, so the PU objective is already in SI — no rescaling needed.
+    # Default OPF objective cost rate: (cost_kWh * s_base / 1000) * P_pu
+    # = cost_kWh * P_si / 1000 ($/h). The s_base factors cancel, so this
+    # objective is already in the same $/h units as the SI solve. A feasibility
+    # OPF's raw objective instead remains a working-coordinate slack metric; its
+    # physically interpretable slack fields are converted below.
 
     # Feasibility OPF slack injections
     if haskey(result, "slack_injections")

--- a/ext/BMOPFOpfExt/results.jl
+++ b/ext/BMOPFOpfExt/results.jl
@@ -14,7 +14,9 @@ Returned top-level keys
 -----------------------
 - `"termination_status"` — string form of `JuMP.termination_status`
 - `"feasible"`           — `true` iff the solver reached a (locally) optimal/solved status
-- `"objective"`          — objective value (cost units)
+- `"objective"`          — objective value (currency/hour for default `solve_opf`;
+                           working-coordinate slack metric for feasibility OPF;
+                           caller-defined units for a custom objective)
 - `"solve_time"`         — solver wall-clock time (s)
 - `"bus"`        — `bus_id => terminal => {vr, vi, vm [V], va [rad]}`
 - `"ground"`     — `bus_id => terminal => {cg_r, cg_i [A], cgm [A]}` for every

--- a/ext/BMOPFOpfExt/variables.jl
+++ b/ext/BMOPFOpfExt/variables.jl
@@ -380,8 +380,8 @@ end
 Like `_set_voltage_start_values!` but uses per-bus nominal voltages derived
 from the BFS voltage propagation (`_assign_nominal_voltages`). This correctly
 initialises LV buses at ~250 V rather than at the source voltage (~6350 V),
-preventing Ipopt from converging to the degenerate high-voltage local minimum
-that arises in the unconstrained feasibility OPF.
+reducing attraction to a degenerate high-voltage local minimum when the case
+supplies no useful voltage bounds.
 """
 function _set_level_aware_start_values!(vars, net, bus_terminals, grounded)
     vr = vars[:vr]; vi = vars[:vi]

--- a/src/BMOPFTools.jl
+++ b/src/BMOPFTools.jl
@@ -1013,7 +1013,8 @@ via the `[augment.smart_ibr]` config section.
 
 Returns a results dict with keys:
 - `"termination_status"` — JuMP termination status string
-- `"objective"` — optimal objective value (total generation cost, W·\\\$/W)
+- `"objective"` — optimal default-objective cost rate (currency/hour); custom
+  `model_hook!` objectives retain whatever units the caller defines
 - `"solve_time"` — wall-clock solve time (s)
 - `"bus"` — per-bus voltage results: `"vr"`, `"vi"`, `"vm"`, `"va"` per terminal
 - `"line"` — per-line from/to current results per conductor
@@ -1034,13 +1035,19 @@ Feasibility-relaxed variant of [`solve_opf`](@ref). Adds elastic slack current
 injections at every non-source bus terminal so that KCL can always be satisfied,
 then minimises the L2² norm of those slacks.
 
-Because the problem is always feasible, the solver always converges. Non-zero
-slacks in the result indicate where the network cannot satisfy its physical
-constraints. Use [`diagnose_infeasibility`](@ref) to interpret the result.
+The added variables can absorb KCL residuals at the terminals where they are
+present, but they do not relax contradictory hard bounds or guarantee convergence
+of the nonconvex NLP. For a converged solve, non-zero slacks identify where that
+relaxed solution paid to violate KCL; they are diagnostic evidence rather than a
+global infeasibility certificate. Use [`diagnose_infeasibility`](@ref) to
+interpret the result.
 
 Requires JuMP and Ipopt (same as `solve_opf`).
 
 Additional result keys beyond `solve_opf`:
+- `"objective"`                  — squared-slack metric in solver working
+  coordinates (plus the transformer tie-break); use the SI slack fields below
+  for physical interpretation
 - `"slack_injections"`        — per-bus, per-terminal `cs_r`, `cs_i`, `cs_mag` (A)
 - `"total_slack_magnitude_A"` — L2 norm of all slack injections (A)
 - `"is_feasibility_opf"`      — always `true`, used by `diagnose_infeasibility`
@@ -1094,11 +1101,13 @@ Typical multi-period skeleton:
 ```julia
 using JuMP, Ipopt
 model = JuMP.Model(Ipopt.Optimizer)
+duration_hours = fill(1.0, T)  # replace with each period's actual duration
 ctxs  = [build_opf_model(net; t_index=t, model=model, add_objective=false,
                          model_hook! = storage_ports!) for t in 1:T]
 # couple snapshots: SOC[t+1] = SOC[t] + Δt·(charge − discharge) …
 link_soc!(model, ctxs)
-JuMP.@objective(model, Min, sum(generation_cost(c) for c in ctxs) + storage_cost)
+JuMP.@objective(model, Min,
+    sum(duration_hours[t] * generation_cost(ctxs[t]) for t in 1:T) + storage_cost)
 foreach(enforce_kcl!, ctxs)
 JuMP.optimize!(model)
 results = [extract_result(c) for c in ctxs]
@@ -1125,10 +1134,13 @@ export enforce_kcl!
 """
     generation_cost(ctx) -> JuMP.QuadExpr
 
-The snapshot's total active-power generation-cost expression — the quantity
-[`solve_opf`](@ref) minimises — returned WITHOUT setting it on the model. Sum
-these across snapshots (adding any custom terms) and call `JuMP.@objective` once
-for a multi-period solve. Pairs with `build_opf_model(...; add_objective=false)`.
+The snapshot's total active-power generation-cost-rate expression (currency/hour) — the
+quantity [`solve_opf`](@ref) minimises — returned WITHOUT setting it on the
+model. For a multi-period monetary objective, multiply each expression by that
+period's duration in hours before summing it with any custom cost terms; a bare
+sum is only valid when all periods have the same duration and only the optimizer,
+not the reported currency total, matters. Pairs with
+`build_opf_model(...; add_objective=false)`.
 Implemented in the `BMOPFOpfExt` extension.
 """
 function generation_cost end

--- a/src/BMOPFTools.jl
+++ b/src/BMOPFTools.jl
@@ -1200,7 +1200,7 @@ export merge_series_lines, remove_dangling_lines
 export remove_open_switches, collapse_closed_switches
 export simplify_network
 export transformer_yprim, export_yprim, write_yprim
-export ybus_passive, YbusResult
+export ybus_passive, YbusResult, line_yprim
 export ybus_linearized, LinearizedYbus
 export ybus_augmented, AugYbusResult, IdealCoupling
 export overhead_line_constants, compile_linecode, compile_linecodes!

--- a/src/augmentation/der_placement.jl
+++ b/src/augmentation/der_placement.jl
@@ -300,7 +300,7 @@ end
 # ── Cost ─────────────────────────────────────────────────────────────────────
 
 # The OPF objective reads `cost` as a per-phase vector of linear coefficients
-# ($/W per phase). We emit one identical coefficient per phase so dispatch is
+# ($/kWh per phase). We emit one identical coefficient per phase so dispatch is
 # priced linearly across all phases.
 function _cost_der(recipe::GeneratorRecipe, n_phases::Int, level::Symbol)::Vector{Float64}
     c = if recipe.cost_basis == :cheaper_than_slack

--- a/src/infeasibility/infeasibility.jl
+++ b/src/infeasibility/infeasibility.jl
@@ -3,10 +3,10 @@
 # Post-processing of solve_feasibility_opf results.
 #
 # The feasibility OPF adds elastic slack current injections (cs_r, cs_i) at
-# every non-source bus terminal so KCL can always balance. Non-zero slacks
-# reveal where the network cannot satisfy its physical constraints without
-# external intervention. This module turns that raw slack pattern into a
-# ranked, classified diagnosis.
+# every non-source bus terminal so those KCL equations can absorb residual.
+# At a converged local solution, non-zero slacks reveal where that relaxed point
+# needs external current intervention; they do not prove global infeasibility.
+# This module turns that raw slack pattern into a ranked, classified diagnosis.
 
 """
     _phase_vbounds(bus, v_nom) -> (ordered_phase_terminals, lb_of, ub_of)

--- a/src/io/ybus.jl
+++ b/src/io/ybus.jl
@@ -327,6 +327,22 @@ function _line_yprim(line::Dict{String,Any}, linecodes::AbstractDict)
     (nodes, Y)
 end
 
+"""
+    line_yprim(line, linecodes) -> (nodes, Y)
+
+Return one line's nominal-Π primitive admittance block in the same convention as
+[`ybus_passive`](@ref): `I_into = Y * V_to_ground`, with positive terminal
+currents flowing from the bus into the line. `nodes` lists the from-side
+terminals followed by the to-side terminals; `Y` is SI siemens and symmetric
+under `transpose` (not conjugate transpose).
+
+This public element-level seam is useful for branch-current and branch-power
+measurements without reconstructing a branch model from a network Ybus.  It
+uses exactly the linecode, terminal-map truncation, and shunt-stamping rules
+used by `ybus_passive` and the OPF branch formulation.
+"""
+line_yprim(line::Dict{String,Any}, linecodes::AbstractDict) = _line_yprim(line, linecodes)
+
 # Shunt: admittance matrix Y = G + jB over the single bus's terminals.
 function _shunt_yprim(shunt::Dict{String,Any})
     G = _pattern_keys_to_matrix(shunt, "G_")

--- a/src/validation/domain_rules.jl
+++ b/src/validation/domain_rules.jl
@@ -412,7 +412,7 @@ function _check_generator_cost(net, findings, thresh, n_checks)
     for (id, g) in get(net, "generator", Dict())
         haskey(g, "cost") || continue
         n_checks[] += 1
-        # cost is a per-phase linear-coefficient vector ($/W); a scalar is
+        # cost is a per-phase energy-price vector ($/kWh); a scalar is
         # tolerated here for validation only (the OPF requires the vector form)
         c = g["cost"]
         costs = c isa AbstractVector ? Float64.(c) : [Float64(c)]
@@ -434,7 +434,7 @@ end
     _check_cost_phase_uniformity(net, findings, n_checks)
 
 Warn when a dispatchable element's per-phase `cost` vector is non-uniform across
-phases. Costs usually represent a single \$/W price applied symmetrically; a
+phases. Costs usually represent a single \$/kWh price applied symmetrically; a
 vector with differing entries is more often a data-entry slip than an intended
 per-phase price signal. Covers `generator` and `voltage_source` today; extend the
 `elements` list as further dispatchable element types gain a `cost` field.

--- a/test/admittance_tests.jl
+++ b/test/admittance_tests.jl
@@ -1,3 +1,16 @@
+@testset "line_yprim public primitive" begin
+    line = Dict{String,Any}(
+        "bus_from" => "a", "bus_to" => "b",
+        "terminal_map_from" => ["1"], "terminal_map_to" => ["1"],
+        "linecode" => "lc", "length" => 2.0,
+    )
+    linecodes = Dict{String,Any}("lc" => Dict{String,Any}("R_series_1_1" => 0.5))
+    nodes, Y = line_yprim(line, linecodes)
+    @test nodes == [("a", "1"), ("b", "1")]
+    @test Y ≈ ComplexF64[1 -1; -1 1]
+    @test Y ≈ transpose(Y)
+end
+
 @testset "Transformer Yprim export" begin
 
     # ─── helpers ──────────────────────────────────────────────────────────────

--- a/test/opf_tests.jl
+++ b/test/opf_tests.jl
@@ -134,13 +134,13 @@
         @test res["termination_status"] in ("LOCALLY_SOLVED", "OPTIMAL")
         @test res["bus"]["bus1"]["1"]["vm"]          ≈ V_exp         atol=0.01
         @test res["generator"]["gen1"]["1"]["pg"]   ≈ P_gen         atol=1.0
-        @test res["objective"]                      ≈ cost * P_gen  atol=0.1
+        @test res["objective"]                      ≈ cost * P_gen / 1000  atol=1e-4
     end
 
     # ─────────────────────────────────────────────────────────────────────────
     # T4: Cost-optimal dispatch — negative unit cost drives output to p_max
     #
-    # cost = −1 $/W → minimising the objective maximises Pg → each phase
+    # cost = −1 $/kWh → minimising the objective maximises Pg → each phase
     # should hit its p_max bound.  A near-zero-impedance line ensures the
     # voltage constraint does not interfere.
     # ─────────────────────────────────────────────────────────────────────────
@@ -177,13 +177,13 @@
         for ph in ("1","2","3")
             @test res["generator"]["gen1"][ph]["pg"] ≈ P_max_ph   atol=1.0
         end
-        @test res["objective"] ≈ -3.0 * P_max_ph   atol=10.0
+        @test res["objective"] ≈ -3.0 * P_max_ph / 1000   atol=0.01
     end
 
     # ─────────────────────────────────────────────────────────────────────────
     # T4b: Uniform cost convention — voltage source ≡ generator
     #
-    # The `cost` field is `$/W of active power INJECTED into the network`, with the
+    # The `cost` field is `$/kWh of active energy INJECTED into the network`, with the
     # SAME sign convention for generators and the voltage source (both stamp +I
     # into KCL; both report power as +injection). So a POSITIVE cost minimises that
     # element's injection in both cases:
@@ -556,7 +556,7 @@
     # g1 injects 200 kW; load is 100 kW → net 100 kW exported to sourcebus.
     # V_bus1 rises above V_s (reverse current direction).
     # Analytical: V² − V_s·V − R·P_net = 0 → V = (V_s + √(V_s²+4·R·P_net))/2 ≈ 1047.7 V
-    # cost = -0.05 $/W → objective = -0.05 × 200 000 = -10 000 $/s
+    # cost = -0.05 $/kWh → objective rate = -0.05 × 200 kW = -10 $/h
     _pu_net() = parse_bmopf("""
     {"bus":{
         "sourcebus":{"terminal_names":["1","n"],
@@ -595,9 +595,9 @@
         V_exp = (V_s + sqrt(V_s^2 + 4*R*P_net)) / 2   # ≈ 1047.7 V
         @test res["bus"]["bus1"]["1"]["vm"] ≈ V_exp   atol=0.5
 
-        # Profit-seeking generator (cost=-0.05 $/W) binds at p_max=200 000 W.
-        # objective = -0.05 × 200 000 = -10 000; pg in W, not PU.
-        @test res["objective"] ≈ -10_000.0   rtol=1e-3
+        # Profit-seeking generator (cost=-0.05 $/kWh) binds at p_max=200 000 W.
+        # objective rate = -0.05 × 200 kW = -10 $/h; pg remains in W.
+        @test res["objective"] ≈ -10.0   rtol=1e-3
         @test res["generator"]["g1"]["1"]["pg"] ≈ 200_000.0   rtol=1e-3
     end
 
@@ -655,7 +655,7 @@
         net = _pu_net()
 
         # model_hook! can replace the objective — the standard cost objective
-        # (−10 000, see T11) is overridden with a feasibility objective.
+        # (−10 $/h, see T11) is overridden with a feasibility objective.
         res = solve_opf(net; model_hook! = ctx -> JuMP.@objective(ctx.model, Min, 0.0))
         @test res["termination_status"] in ("LOCALLY_SOLVED", "OPTIMAL")
         @test abs(res["objective"]) < 1e-6
@@ -676,7 +676,7 @@
                 vi[("bus1","1")]*cig[("g1",1)] <= 150_000.0 / sb)
         end)
         @test res2["termination_status"] in ("LOCALLY_SOLVED", "OPTIMAL")
-        @test res2["objective"] ≈ -0.05 * 150_000.0   rtol=1e-3
+        @test res2["objective"] ≈ -0.05 * 150_000.0 / 1000   rtol=1e-3
         @test res2["generator"]["g1"]["1"]["pg"] ≈ 150_000.0   rtol=1e-3
 
         # solver_options are applied as raw solver attributes.
@@ -873,7 +873,8 @@
             JuMP.@constraint(model, soc[t+1] <= Δpu(emax_Wh))
         end
         JuMP.@constraint(model, soc[T+1] == Δpu(soc0_Wh))     # cyclic
-        JuMP.@objective(model, Min, sum(generation_cost(ctxs[t]) for t in 1:T))
+        JuMP.@objective(model, Min,
+            sum(dt_h * generation_cost(ctxs[t]) for t in 1:T))
         foreach(enforce_kcl!, ctxs)
         JuMP.optimize!(model)
 
@@ -1047,7 +1048,7 @@
             @test isapprox(va_si, va_pu; atol=1e-6)
         end
 
-        # Objective (in W·$/W = SI) must match; both should be ≈ -10 000.
+        # Objective cost rate ($/h) must match; both should be ≈ -10.
         @test isapprox(r_si["objective"], r_pu["objective"]; rtol=1e-3)
 
         # Line current magnitude at from-end must match.
@@ -1930,6 +1931,10 @@
             # Sanity: PU-mode dispatch is in SI watts, near p_max (cheaper than slack)
             @test pu["pg"] ≈ 2700.0   atol=5.0
         end
+        # Cost coefficients on both the source and IBR must scale with s_base;
+        # otherwise the PU solve has a different economic objective even if this
+        # simple merit order happens to return the same dispatch.
+        @test res_pu["objective"] ≈ res_si["objective"] rtol=1e-4
     end
 
     # ─────────────────────────────────────────────────────────────────────────
@@ -2324,10 +2329,10 @@
     # ─────────────────────────────────────────────────────────────────────────
     # T-PCOST: non-uniform per-phase cost. A generator is forced (p_min=p_max)
     # to distinct per-phase outputs that exactly serve the per-phase load, so
-    # the objective is the deterministic Σ cost_k · P_k:
-    #   0.1·10000 + 0.2·20000 + 0.3·30000 = 14 000.
+    # the objective is the deterministic cost rate Σ cost_k · P_k/1000:
+    #   0.1·10 + 0.2·20 + 0.3·30 = 14 $/h.
     # The old polynomial reading ([c2,c1,c0]) would have applied a single c1 to
-    # every phase (0.2·60000 = 12 000), so this value distinguishes the two.
+    # every phase (0.2·60 = 12 $/h), so this value distinguishes the two.
     # ─────────────────────────────────────────────────────────────────────────
     @testset "T-PCOST: per-phase linear cost → objective" begin
         net = parse_bmopf("""
@@ -2348,7 +2353,7 @@
         """; from_string=true)
         res = solve_opf(net)
         @test res["termination_status"] in ("LOCALLY_SOLVED", "OPTIMAL")
-        @test res["objective"] ≈ 14_000.0   atol=1.0
+        @test res["objective"] ≈ 14.0   atol=1e-3
     end
 
     # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- standardize dispatch cost as per-phase energy prices in $/kWh and report snapshot cost rates in $/h
- apply the W-to-kW conversion consistently and fix missing IBR cost scaling in per-unit mode
- document duration weighting for multi-period monetary objectives
- replace unsupported uniqueness, global-optimality, and solver-certificate claims with evidence-calibrated language
- reconcile feasibility-relaxation documentation with the implemented hard constraints and KCL relaxation
- reframe OpenDSS and PMD comparisons as scoped cross-implementation evidence
- generate validation inventory counts from the checked-out test sources instead of maintaining stale totals

## Regression coverage

- absolute objective assertions lock in the W-to-kW conversion
- SI-versus-per-unit objective equality locks in IBR cost scaling
- existing analytic, per-phase cost, custom-hook, and staged multi-period tests were updated to the documented units

## Verification

- `julia --project=. -e "using Pkg; Pkg.test()"`: 4,160 passed, 33 expected broken
- `julia --project=docs/ docs/make.jl`: passed; only existing page-size and local deployment warnings remain
- `git diff --check`: clean