### PR TITLE
Tutorials: custom formulations & findings triage; judgment-spine refresh; notation polish

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -31,6 +31,7 @@ makedocs(
         "Analysis & diagnostics"  => [
             "Analysis & reports"       => "analysis.md",
             "Finding-code reference"   => "findings.md",
+            "Findings triage tutorial" => "tutorial_triage.md",
             "Trust but verify: validating a solve" => "tutorial_trust_but_verify.md",
             "Methodology notes"        => "methodology.md",
         ],
@@ -55,6 +56,7 @@ makedocs(
             "MVDC/LVDC converter stations" => "tutorial_mvdc.md",
             "Transformer tap optimisation" => "tutorial_tap.md",
             "Time series: a day on an LV feeder" => "tutorial_timeseries.md",
+            "Custom formulations: CVR, envelopes & hooks" => "tutorial_custom_formulations.md",
         ],
         "Bounds & feasibility"    => [
             "bounds/index.md",

--- a/docs/src/choose_tutorial.md
+++ b/docs/src/choose_tutorial.md
@@ -12,6 +12,7 @@ first — it is the one-sitting overview every path below assumes.
 | I want to… | Start here | Then |
 |---|---|---|
 | **Convert** OpenDSS / nameplate data into a BMOPF case | [From nameplate data to a defensible model](tutorial_nameplate.md) | [Conversion guide](conversion.md), [Case augmentation](augmentation.md) |
+| **Triage a messy import** (warnings, provenance, repairs) | [Findings triage](tutorial_triage.md) | [Finding-code reference](findings.md), [Analysis & reports](analysis.md) |
 | **Turn transformer test data into model fields** | [From test report to transformer model](tutorial_transformer_tests.md) | [Transformer models](transformer_models.md), [Transformer spec](spec/transformer.md) |
 | **Understand four-wire physics** (why terminals, neutrals, matrices) | [Buses & terminals primer](terminals_primer.md) | [Impedance models & OPF decisions](tutorial_impedance_models.md), [Line geometry](tutorial_line_geometry.md) |
 | **Get grounding, neutrals, and sequence coordinates right** | [Ground, neutral, and earth return](tutorial_grounding.md) | [Grounding spec](spec/grounding.md), [SWER case study](tutorial_swer.md) |
@@ -21,29 +22,54 @@ first — it is the one-sitting overview every path below assumes.
 | **Diagnose an infeasible case** | [Infeasibility diagnosis](tutorial_infeasibility.md) | [Bounds & feasibility](bounds/index.md), [Trusting the solver](bounds/solver_trust.md) |
 | **Verify a solved OPF** you don't yet trust | [Trust but verify](tutorial_trust_but_verify.md) | [Trusting the solver](bounds/solver_trust.md), [Validating the OPF](validation.md) |
 | **Model a specific device** (STATCOM, MVDC, regulator, PV droop) | [D-STATCOM study](tutorial_statcom.md) | [MVDC](tutorial_mvdc.md), [Tap optimisation](tutorial_tap.md), [VVWO](tutorial_vvwo.md) |
+| **Change the formulation** (custom objectives, constraints, multi-period) | [Custom formulations](tutorial_custom_formulations.md) | [OPF model](opf.md), [Units, bases & economics](tutorial_units.md) |
 | **Extend or debug the solver** | [OPF engine: scope & status](dev/opf_engine.md) | [OPF model](opf.md), [Contributing](dev/contributing.md) |
 
 ## The judgment spine
 
-Four of the tutorials, read in order, teach the reasoning a defensible study
+Six of the tutorials, read in order, teach the reasoning a defensible study
 needs — not just *how* to call the tools, but *when to trust the answer*:
 
-1. **Assumptions** — [From nameplate data to a defensible model](tutorial_nameplate.md).
+1. **Triage** — [Findings triage](tutorial_triage.md). A raw import arrives
+   with dozens of findings; learn to separate *defects* (fix), *judgment
+   calls* (decide and document), and *disclosures* (keep — they are the
+   case's provenance record).
+2. **Assumptions** — [From nameplate data to a defensible model](tutorial_nameplate.md).
    Incomplete datasheets in; a model out. What can be *derived*, what needs an
    *assumption*, and what must stay *unknown* — and the difference between
    standards-derived, standards-inspired, and synthetic values.
-2. **Solve** — [end-to-end tutorial](tutorial_end_to_end.md) and the
+3. **Solve** — [end-to-end tutorial](tutorial_end_to_end.md) and the
    [OPF model](opf.md). Turn the model into a solved dispatch.
-3. **Verify** — [Trust but verify](tutorial_trust_but_verify.md). Take one solved
+4. **Verify** — [Trust but verify](tutorial_trust_but_verify.md). Take one solved
    OPF and independently recompute KCL, voltage bounds, thermal loading, losses,
    and the objective — learning what a solver's `LOCALLY_SOLVED` status does and
    does *not* guarantee.
-4. **Consequences** — [Impedance models & OPF decisions](tutorial_impedance_models.md)
+5. **Consequences** — [Impedance models & OPF decisions](tutorial_impedance_models.md)
    and [Trusting the solver](bounds/solver_trust.md). How the modelling choices
-   made in step 1 change the answer, and where the remaining traps live.
+   made in step 2 change the answer, and where the remaining traps live.
+6. **Formulation** — [Custom formulations](tutorial_custom_formulations.md).
+   When least-cost dispatch is not your question: hooks, replaced objectives,
+   and multi-period coupling — with the discipline each rung demands.
 
-Read top to bottom you get the missing arc: **model assumptions → solve →
-independent verification → fidelity consequences.**
+Read top to bottom you get the missing arc: **triage → model assumptions →
+solve → independent verification → fidelity consequences → your own
+formulation.**
+
+### The modelling-choices track
+
+Step 2's "assumptions" fan out into deep dives, one per modelling choice —
+each demonstrating live how that choice *writes the answer*:
+
+- [Units, bases, scaling, and economics](tutorial_units.md) — the three unit
+  systems every result rests on.
+- [Impedance models & OPF decisions](tutorial_impedance_models.md) — network
+  fidelity, symmetry, and what balanced models hide.
+- [Choosing and identifying a load model](tutorial_load_models.md) — when
+  constant-P/I/Z, ZIP, or exponential behaviour is defensible.
+- [From test report to transformer model](tutorial_transformer_tests.md) —
+  test data into validated fields, with the conventions made explicit.
+- [Ground, neutral, and earth return](tutorial_grounding.md) — grounding
+  assumptions, Kron reduction, and sequence coordinates.
 
 !!! tip "Prerequisites"
     The solve/verify tutorials run a real OPF, so they need a Julia environment

--- a/docs/src/conventions.md
+++ b/docs/src/conventions.md
@@ -238,8 +238,8 @@ FAQ: a "wye" in the BMOPF sense always has the neutral return — a
 
 Generators additionally carry `cost` and optional `p_min/p_max/q_min/q_max`.
 `cost` is a **per-phase vector of energy prices** (\$/kWh), one element per
-phase term. For a snapshot, the objective contribution of phase `k` is the cost
-rate `cost[k]·P_k/1000` (\$/h), because `P_k` is stored in watts. A multi-period
+phase term. For a snapshot, the objective contribution of phase $k$ is the cost
+rate $c_k \, P_k / 1000$ (\$/h), because $P_k$ is stored in watts. A multi-period
 monetary objective must additionally multiply each rate by the period duration
 in hours. (There is no polynomial/quadratic cost form.) A generator without
 bounds is an unbounded
@@ -284,7 +284,7 @@ same per-conductor `i_max` convention.
       active-power injection *without* committing to converter physics (no
       apparent-power circle, no topology, no droop control).
     - **`ibr`** adds exactly that converter physics: an apparent-power nameplate
-      `s_max` with the `P²+Q²≤s_max²` circle, a `topology`
+      `s_max` with the $P^2 + Q^2 \le (S^{\max})^2$ circle, a `topology`
       (`SINGLE_PHASE`/`THREE_LEG`/`FOUR_LEG`) that fixes the voltage reference, a
       `prime_mover`, and reference-able `control_profile` droop laws.
 
@@ -314,12 +314,13 @@ they set a converter's active/reactive power from its *AC* terminal voltage (the
 DC-port counterpart is configured separately; see below). Each profile holds one or
 more optional sub-objects, and the *presence* of a sub-object activates that law:
 
-- **`volt_var`** — reactive-power droop `Q = f(U)`. Fields: `breakpoints`
-  `[U1,U2,U3,U4]` (V, non-decreasing); `q_limits` `[q_absorb ≤ 0, q_inject ≥ 0]`;
+- **`volt_var`** — reactive-power droop $Q = f(U)$. Fields: `breakpoints`
+  `[U1,U2,U3,U4]` (V, non-decreasing); `q_limits` `[q_absorb, q_inject]`
+  ($q_\text{absorb} \le 0 \le q_\text{inject}$);
   `q_unit` (`VA_FRACTION` of `s_max`, or `VAR`); `q_ref` (`VAR_MAX`, or
-  `VAR_AVAILABLE` scaling with `√(s_max² − P²)`); and `voltage_reference`.
+  `VAR_AVAILABLE` scaling with $\sqrt{(S^{\max})^2 - P^2}$); and `voltage_reference`.
   Optional `p_min_for_q` / `p_min_for_q_max` mirror OpenDSS's low-power cut-ins.
-- **`volt_watt`** — active-power curtailment cap `P ≤ f(U)`. Fields: `breakpoints`
+- **`volt_watt`** — active-power curtailment cap $P \le f(U)$. Fields: `breakpoints`
   `[U5,U6]`; `p_limits` `[p_low, p_high]`; `p_unit` (`VA_FRACTION` or `W`); `p_ref`
   (`S_MAX` / `P_MAX` / `P_AVAILABLE`); and `voltage_reference`.
 - **`power_factor`** — constant power factor: a signed `pf` (positive = lagging,
@@ -343,7 +344,8 @@ smooth constraint, and the [VVWO tutorial](tutorial_vvwo.md) for a worked exampl
 acts on the **signed DC-port voltage** rather than an AC magnitude, so it lives on
 the `ibr` directly via `dc_control` — not in a `control_profile`. Its `"droop"`
 mode is a **power–voltage (V–P) droop** stamped as an equality
-`P = dc_p_ref + (v_dc − dc_v_set)/dc_droop` (saturated at the converter limits)
+$P = P^\text{ref} + (v_\text{dc} - v_\text{dc}^\text{set})/k_\text{droop}$
+(fields `dc_p_ref`, `dc_v_set`, `dc_droop`; saturated at the converter limits)
 using the same smooth-ReLU machinery as `volt_var`/`volt_watt`. See the
 [DC network](@ref dc-network) section's `dc_control`.
 
@@ -351,9 +353,9 @@ using the same smooth-ReLU machinery as `volt_var`/`volt_watt`. See the
 
 A `capacitor` is a fixed shunt capacitor bank with fields `bus`, `terminal_map`,
 `configuration` (`WYE` / `SINGLE_PHASE` / `DELTA`), `q_rated` (var) and `v_nom`
-(V). It is a **constant susceptance** `B = q_rated / v_nom²` delivering the
-voltage-dependent reactive power `Q = B·V²` (= the nameplate `q_rated` only at
-`v_nom`). `q_rated` is a per-phase array for WYE, per-pair for DELTA, length 1
+(V). It is a **constant susceptance** $B = Q^\text{rated}/(V^\text{nom})^2$
+delivering the voltage-dependent reactive power $Q = B\,V^2$ (equal to the
+nameplate `q_rated` only at `v_nom`). `q_rated` is a per-phase array for WYE, per-pair for DELTA, length 1
 for SINGLE_PHASE; `v_nom` is phase-to-neutral (WYE/SINGLE_PHASE) or
 line-to-line (DELTA). It is electrically a connection-aware `shunt` and adds **no
 OPF variables** (fixed). A `shunt` remains the general constant-admittance
@@ -386,23 +388,24 @@ bounds are measured against.
 `perfectly_grounded_terminals` entry on the `dc_bus`) sets the signed-voltage
 reference and provides the earth-return path. `r = 0`/omitted is **perfect**
 grounding (the terminal's `v_dc` is fixed to 0, with a free earth-return current);
-`r > 0` is grounding **through impedance** (earth current `= v_dc / r`, with the
-electrode floating to the ground-potential rise `I·r`). Every connected DC island
+`r > 0` is grounding **through impedance** (earth current $i = v_\text{dc}/r$,
+with the electrode floating to the ground-potential rise $i\,r$). Every connected DC island
 needs at least one grounding, else `E.INT.NO_DC_VOLTAGE_REFERENCE` fires.
 
 **Converters are lossless** at this fidelity: a converter's DC-port power equals
 its AC active power, so a back-to-back SOP conserves power exactly and an MVDC tie
-loses only the `I²R` of its DC line.
+loses only the $I^2 R$ of its DC line.
 
 **DC-voltage control (`dc_control`).** Like an AC network needs a slack/reference,
 an MVDC zone needs a converter that sets the DC voltage — otherwise `v_dc` is
 underdetermined. Mirroring HVDC/MVDC practice (master–slave and droop):
 - `"P"` (default) — constant power; the OPF dispatches the converter's power.
-- `"V"` — DC-voltage **master**: holds `v_dc(pole−return) = dc_v_set` (a fixed
-  setpoint, like an AC source's `v_magnitude`); its AC power floats to balance the
-  zone.
+- `"V"` — DC-voltage **master**: holds the pole-to-return $v_\text{dc}$ at
+  `dc_v_set` (a fixed setpoint, like an AC source's `v_magnitude`); its AC power
+  floats to balance the zone.
 - `"droop"` — **saturated** V–P droop: the AC power follows
-  `P = dc_p_ref + (v_dc − dc_v_set)/dc_droop` inside an optional `±dc_deadband`,
+  $P = P^\text{ref} + (v_\text{dc} - v_\text{dc}^\text{set})/k_\text{droop}$
+  inside an optional `±dc_deadband`,
   and **clamps to the converter's power limits** outside the droop band (a
   piecewise-linear P–V curve, implemented with the smooth-ReLU machinery so it is
   Ipopt-friendly). Higher `dc_droop` = softer droop; `dc_droop → 0` is the stiff
@@ -479,7 +482,8 @@ base across the galvanic tie (no voltage-level change).
 single-phase autotransformer windings connected line-to-line across the phase
 pairs implied by `connection` (`ABBC`/`BCAC`/`CABA`, GridLAB-D convention),
 with per-regulator taps `tap_ratio = [a1, a2]`.  The phase common to both
-regulators is a **galvanic straight-through** (`V_shared,from = V_shared,to`),
+regulators is a **galvanic straight-through**
+($V^\text{shared}_\text{from} = V^\text{shared}_\text{to}$),
 the physically-correct "common neutral" model of Yan et al. (2018); the two
 regulated line-to-line voltages are boosted by their taps while the shared phase
 passes through unchanged.  See the [OPF reference](opf.md) and

--- a/docs/src/tutorial_custom_formulations.md
+++ b/docs/src/tutorial_custom_formulations.md
@@ -1,0 +1,331 @@
+# [Custom formulations: CVR, envelopes, and hooks](@id custom-formulations)
+
+*The reference OPF is a floor, not a ceiling: conservation voltage reduction
+without writing a hook, a connection-point export cap with one constraint, a
+phase-balancing objective with three lines — and a two-period energy budget
+through the staged API.*
+
+Research formulations rarely stop at least-cost dispatch: conservation voltage
+reduction (CVR), dynamic operating envelopes, unbalance mitigation, and
+multi-period coupling all *change the optimisation problem*. The engine's
+answer is a ladder of extension points, documented in the
+[OPF reference](opf.md) — the `model_hook!` seam and the
+[staged API](opf.md#staged-api). This tutorial climbs that ladder with worked
+studies, one rung at a time, and starts with the rung people skip: checking
+whether the study you want is *already expressible* without touching the
+formulation at all. Every block runs at build time.
+
+!!! note "Prerequisites"
+    A Julia environment with `BMOPFTools`, `JuMP` and `Ipopt`, and three
+    earlier tutorials this one leans on hard:
+    [units & economics](tutorial_units.md) (`ctx.bases`, the \$/h objective),
+    [load models](tutorial_load_models.md) (why voltage-dependence matters),
+    and [tap optimisation](tutorial_tap.md) (the free-tap mechanics).
+
+## 1. The extension ladder
+
+| Rung | Mechanism | Reach |
+|---|---|---|
+| 0 | data configuration only | anything the schema already says: costs, bounds, free taps, control profiles |
+| 1 | `model_hook!` adds constraints | couplings the schema cannot express (aggregate caps, fairness, custom devices via `ctx.kcl_r/i`) |
+| 2 | `model_hook!` replaces the objective (+ variables), `solution_hook!` reads back | different *questions*: minimax, unbalance, estimation |
+| 3 | staged API (`build_opf_model` → `generation_cost` → `enforce_kcl!` → `extract_result`) | several snapshots in one model: storage, ramps, energy budgets |
+
+Climb no higher than the study requires — every rung up costs reviewability,
+and a hook that re-implements something the schema already says is a bug
+farm. The running network: the LV1 14-bus feeder, augmented, grid import
+priced at 0.25 \$/kWh.
+
+```@example hooks
+using BMOPFTools, JuMP, Ipopt
+
+path = joinpath(pkgdir(BMOPFTools), "test", "data", "LV", "LV1_14bus", "Master.dss")
+base, _ = augment_case(from_dss(path); recipe = AugmentationRecipe())
+src_id  = first(keys(base["voltage_source"]))
+base["voltage_source"][src_id]["cost"] = [0.25, 0.25, 0.25]
+xfmr_id = first(keys(base["transformer"]["delta_wye"]))
+OPT = optimizer_with_attributes(Ipopt.Optimizer, "print_level" => 0)
+
+println("LV voltage floor from augmentation (vpn_min): ",
+        round(base["bus"]["b3230"]["vpn_min"][1]; digits = 1), " V")
+```
+
+## 2. Rung 0 — CVR needs no hook at all
+
+Conservation voltage reduction — operating the feeder at the low end of the
+voltage band so that voltage-dependent demand shrinks — sounds like a custom
+formulation. It is not. Its three ingredients are all data: a **voltage-dependent
+load model**, a **controllable voltage** (free the transformer tap with
+`tap_min < tap_max`), and the standard cost objective (import is priced, so
+minimising cost minimises demand). Run the 2×2 experiment — load model ×
+tap freedom:
+
+```@example hooks
+zip = Dict{String,Any}(
+    "alpha_z" => [0.4], "alpha_i" => [0.3], "alpha_p" => [0.3],
+    "beta_z"  => [0.4], "beta_i"  => [0.3], "beta_p"  => [0.3])
+
+println("case                      P_import      tap      LV Vmin")
+for (label, model, free_tap) in (
+        ("constant-P, fixed tap", "constant_power", false),
+        ("constant-P, free tap",  "constant_power", true),
+        ("ZIP, fixed tap",        "zip",            false),
+        ("ZIP, free tap",         "zip",            true))
+    net = deepcopy(base)
+    for (_, d) in net["load"]
+        d["model"] = model
+        model == "zip" && merge!(d, zip)
+    end
+    if free_tap
+        net["transformer"]["delta_wye"][xfmr_id]["tap_min"] = 0.90
+        net["transformer"]["delta_wye"][xfmr_id]["tap_max"] = 1.10
+    end
+    r = solve_opf(net; optimizer = OPT)
+    p_imp = sum(ph["ps"] for ph in values(r["voltage_source"][src_id]))
+    tap   = get(get(r["transformer"], xfmr_id, Dict()), "tap", 1.0)
+    vmin  = minimum(v["vm"] for (b, ts) in r["bus"] if b != "b2577"
+                            for (t, v) in ts if t != "n")
+    println(rpad(label, 24), lpad(round(p_imp; digits = 1), 10), " W",
+            lpad(round(tap; digits = 4), 9), lpad(round(vmin; digits = 1), 9), " V")
+end
+```
+
+Read the tap column: **the load model flips the sign of the optimal
+decision.** With constant-power loads the optimiser *raises* the feeder
+voltage (tap toward 0.91 — a higher secondary voltage means less current for
+the same power, so lower copper losses; worth a few tens of watts). With ZIP
+loads it slams the tap the other way (1.10) and rides the feeder down onto
+the augmentation's 0.9 pu voltage floor — shedding roughly a tenth of the
+demand. That *is* CVR, emerging from data alone; and it is also a warning
+shot from the [load-models tutorial](tutorial_load_models.md): run a CVR
+study with constant-power loads and the method looks worthless by
+construction. No `model_hook!` was harmed — nor needed.
+
+## 3. Rung 1 — a constraint the schema cannot express
+
+Now something genuinely inexpressible in data: two rooftop PV systems at
+different buses share **one connection agreement** — their *combined* export
+may not exceed a cap (the flat ancestor of a dynamic operating envelope).
+Per-device `p_max` cannot say "jointly"; a one-line hook can. The hook builds
+each generator's total active power the same way the engine's own objective
+does — the bilinear ``\sum_k \Delta v_k \cdot c^g_k`` over phase terms — and
+constrains the sum. One unit rule to burn in: **the hook sees the model in
+per-unit** (the default), so a physical literal must be divided by
+`ctx.bases.s_base` ([units tutorial](tutorial_units.md)).
+
+```@example hooks
+function with_ders(net; cost = 0.10)
+    n = deepcopy(net)
+    n["generator"] = Dict{String,Any}()
+    for (gid, bus) in (("pv1", "b3230"), ("pv2", "b2656"))
+        n["generator"][gid] = Dict{String,Any}(
+            "bus" => bus, "terminal_map" => ["a", "b", "c", "n"],
+            "configuration" => "WYE",
+            "p_min" => zeros(3),          "p_max" => fill(4000.0, 3),
+            "q_min" => fill(-2000.0, 3),  "q_max" => fill(2000.0, 3),
+            "cost"  => fill(cost, 3))
+    end
+    n
+end
+
+# a generator's total P as a JuMP expression, from the hook context
+function gen_p(ctx, gid)
+    vr, vi   = ctx.vars[:vr],  ctx.vars[:vi]
+    crg, cig = ctx.vars[:crg], ctx.vars[:cig]
+    g = ctx.net["generator"][gid]
+    b, tm = g["bus"], g["terminal_map"]
+    sum(@expression(ctx.model,
+            (vr[(b, tm[k])] - vr[(b, "n")]) * crg[(gid, k)] +
+            (vi[(b, tm[k])] - vi[(b, "n")]) * cig[(gid, k)]) for k in 1:3)
+end
+
+net = with_ders(base; cost = -0.05)            # export credited: both want full output
+r0  = solve_opf(net; optimizer = OPT)
+pg0 = sum(ph["pg"] for g in values(r0["generator"]) for ph in values(g))
+
+cap_W = 9_000.0
+r1 = solve_opf(net; optimizer = OPT, model_hook! = ctx -> begin
+    sb = ctx.bases === nothing ? 1.0 : ctx.bases.s_base   # W → per-unit
+    @constraint(ctx.model, gen_p(ctx, "pv1") + gen_p(ctx, "pv2") <= cap_W / sb)
+end)
+pg1 = sum(ph["pg"] for g in values(r1["generator"]) for ph in values(g))
+
+println("joint DER output, uncapped : ", round(pg0; digits = 1), " W")
+println("joint DER output, capped   : ", round(pg1; digits = 1), " W  (cap ", cap_W, ")")
+@assert isapprox(pg1, cap_W; rtol = 1e-4)
+```
+
+The cap binds exactly, and *how* the 9 kW splits between the two systems —
+and across their phases — is decided by the network: the optimiser curtails
+where it relieves the feeder most. That co-optimised allocation is precisely
+what per-device static limits cannot deliver, and scaling the same pattern
+over feeder scenarios is how operating-envelope studies are built.
+
+## 4. Rung 2 — replace the question: balance the feeder head
+
+The standard objective answers "cheapest dispatch". A distribution engineer
+often asks a different question: *how balanced can the substation infeed be?*
+That is a minimax problem — new variables, new objective. The hook adds
+epigraph variables bracketing the three per-phase source powers and minimises
+the spread; `solution_hook!` reads the achieved value back into the result in
+SI:
+
+```@example hooks
+src_p(ctx) = begin
+    vr, vi   = ctx.vars[:vr],     ctx.vars[:vi]
+    crs, cis = ctx.vars[:cr_src], ctx.vars[:ci_src]
+    vs = ctx.net["voltage_source"][src_id]
+    b, tm = vs["bus"], vs["terminal_map"]
+    [@expression(ctx.model,
+        (vr[(b, tm[k])] - vr[(b, "n")]) * crs[(src_id, k)] +
+        (vi[(b, tm[k])] - vi[(b, "n")]) * cis[(src_id, k)]) for k in 1:3]
+end
+
+net = with_ders(base; cost = 0.10)
+r0  = solve_opf(net; optimizer = OPT)
+p0  = sort([ph["ps"] for ph in values(r0["voltage_source"][src_id])])
+println("least-cost per-phase import : ", round.(p0; digits = 1),
+        "   spread ", round(p0[end] - p0[1]; digits = 1), " W")
+
+r2 = solve_opf(net; optimizer = OPT,
+    model_hook! = ctx -> begin
+        es   = src_p(ctx)
+        t_hi = @variable(ctx.model)
+        t_lo = @variable(ctx.model)
+        for e in es
+            @constraint(ctx.model, e <= t_hi)
+            @constraint(ctx.model, e >= t_lo)
+        end
+        @objective(ctx.model, Min, t_hi - t_lo)
+        ctx.model[:spread] = t_hi - t_lo
+    end,
+    solution_hook! = (ctx, result) -> begin
+        sb = ctx.bases === nothing ? 1.0 : ctx.bases.s_base
+        result["head_spread_W"] = abs(JuMP.value(ctx.model[:spread])) * sb
+    end)
+p2 = sort([ph["ps"] for ph in values(r2["voltage_source"][src_id])])
+println("balanced   per-phase import : ", round.(p2; digits = 1),
+        "   spread ", round(r2["head_spread_W"]; digits = 2), " W")
+```
+
+From a ``\sim 7`` kW spread (two single-phase customers plus asymmetric PV
+relief) to **exactly balanced** — the DERs re-dispatch per phase to make the
+MV network upstream see a symmetric load. But notice what we gave up: the
+objective now says *nothing* about cost, and any perfectly balanced operating
+point is optimal, so the solver returned an arbitrary member of that set. A
+replaced objective means you own the economics. The repair is composition —
+[`generation_cost`](@ref) hands you the engine's own \$/h expression to blend
+back in:
+
+```@example hooks
+r3 = solve_opf(net; optimizer = OPT, model_hook! = ctx -> begin
+    es   = src_p(ctx)
+    t_hi = @variable(ctx.model); t_lo = @variable(ctx.model)
+    for e in es
+        @constraint(ctx.model, e <= t_hi)
+        @constraint(ctx.model, e >= t_lo)
+    end
+    sb = ctx.bases.s_base
+    # spread is per-unit power → ×s_base/1000 puts it in kW, penalised at 1 $/kWh-equivalent,
+    # commensurate with generation_cost's $/h.
+    @objective(ctx.model, Min, generation_cost(ctx) + 1.0 * (t_hi - t_lo) * sb / 1000)
+end)
+p3 = sort([ph["ps"] for ph in values(r3["voltage_source"][src_id])])
+pg3 = sum(ph["pg"] for g in values(r3["generator"]) for ph in values(g))
+println("balanced + cheap: per-phase ", round.(p3; digits = 1),
+        "   DER output ", round(pg3; digits = 1), " W")
+```
+
+Still balanced to the watt — but now at the *cheap* balanced point: the DERs
+carry most of the load (≈ 18.5 kW of their 24 kW capability, versus the
+arbitrary dispatch the spread-only objective happened to land on). The
+weight is an explicit engineering choice with units; write it down in your
+study, because the objective value now mixes \$/h with a penalty term and is
+no longer a pure cost rate.
+
+## 5. Rung 3 — two snapshots, one model: an energy budget
+
+`solve_opf` fuses build–solve–extract for a single snapshot, so it cannot
+couple time steps. The [staged API](opf.md#staged-api) unbundles it. Here is
+the smallest genuinely multi-period study: two hours (normal load, then light
+load), one PV plant allowed at most **5 kWh across both** — a battery-like
+energy budget that forces the optimiser to *allocate* energy where it is
+worth most:
+
+```@example hooks
+netA = with_ders(base; cost = 0.10)                 # hour 1: full load
+netB = deepcopy(netA)
+for (_, d) in netB["load"]
+    d["p_nom"] = [0.4 * Float64(d["p_nom"][1])]     # hour 2: light load
+end
+
+model = JuMP.Model(Ipopt.Optimizer); JuMP.set_silent(model)
+ctxs  = [build_opf_model(n; model = model, add_objective = false) for n in (netA, netB)]
+
+Δt_h  = 1.0
+sb    = ctxs[1].bases.s_base
+Ppv1  = [gen_p(c, "pv1") for c in ctxs]
+@constraint(model, sum(Ppv1[t] * Δt_h for t in 1:2) <= 5_000.0 / sb)   # 5 kWh budget
+@objective(model, Min, sum(Δt_h * generation_cost(c) for c in ctxs))
+foreach(enforce_kcl!, ctxs)
+optimize!(model)
+
+results = [extract_result(c) for c in ctxs]
+for (t, r) in enumerate(results)
+    p1 = sum(ph["pg"] for ph in values(r["generator"]["pv1"]))
+    println("hour ", t, ": pv1 dispatches ", round(p1; digits = 1), " W")
+end
+used = sum(sum(ph["pg"] for ph in values(r["generator"]["pv1"])) for r in results) * Δt_h
+println("energy used: ", round(used; digits = 1), " Wh of the 5000 Wh budget")
+@assert used <= 5_000.0 * (1 + 1e-4)
+```
+
+The optimiser spends the entire budget in hour 1 — where demand (and thus
+displaced import) is high — and idles the plant in the light hour. Note the
+contract details that make this correct rather than merely runnable: every
+snapshot is built into the **same** `model` with `add_objective = false`; the
+objective duration-weights each snapshot's [`generation_cost`](@ref) (a
+*rate*, \$/h — see the [units tutorial](tutorial_units.md)); `enforce_kcl!`
+runs once per snapshot before the single `optimize!`; and each `ctx` extracts
+its own SI result afterwards. Real storage studies replace the one budget
+constraint with a state-of-charge recursion — the
+[OPF reference](opf.md#staged-api) shows that pattern.
+
+## 6. Hook hygiene
+
+Hard-won rules, in checklist form:
+
+- **Scale every physical literal.** The model is per-unit by default;
+  `ctx.bases` (`s_base`, per-bus `v_base`/`i_base`/`z_base`) is the
+  dictionary, and it is `nothing` in SI mode — the
+  `x / (ctx.bases === nothing ? 1.0 : ctx.bases.s_base)` guard keeps a hook
+  correct under both.
+- **Prefer rung 0.** If the schema can say it (§2), say it in data — it
+  round-trips, validates, and appears in `analyze` reports; hook code does
+  none of those.
+- **A replaced objective is a replaced question** (§4): re-anchor economics
+  explicitly via [`generation_cost`](@ref), and document your weights and
+  their units.
+- **Reuse the engine's own power expressions** (the ``\Delta v \cdot c``
+  bilinears of §3) rather than inventing new power variables — they are
+  exactly what the objective and results use, so your constraint means what
+  the report says.
+- **Read custom values back with `solution_hook!`**, scaling by `ctx.bases`
+  (§4). If your hook injects current via `ctx.kcl_r`/`ctx.kcl_i`, also write
+  its terminal power to `result["custom_injection"]` so
+  [`profile_solution`](@ref)'s power-balance check accounts for it
+  ([OPF reference](opf.md)).
+- **Verify like you would any solve.** A hooked model is still a nonconvex
+  NLP; the [trust-but-verify tutorial](tutorial_trust_but_verify.md)
+  discipline applies unchanged — more so, because the formulation is now
+  partly yours.
+
+!!! tip "Where to go next"
+    The [OPF reference](opf.md) documents the full `ctx` surface, the
+    `solution_hook!` contract, and the state-of-charge staged pattern;
+    [beyond OPF](opf.md#beyond-opf) sketches estimation-type problems on the
+    same seam. The [load-models tutorial](tutorial_load_models.md) explains
+    why §2's CVR result hinges on the load model, and the
+    [tap tutorial](tutorial_tap.md) covers the free-tap mechanics it used.
+    For inverter volt-var/volt-watt behaviour — control, not optimisation —
+    see the [VVWO tutorial](tutorial_vvwo.md) before reaching for a hook.

--- a/docs/src/tutorial_triage.md
+++ b/docs/src/tutorial_triage.md
@@ -1,0 +1,262 @@
+# [Findings triage: from raw import to defensible case](@id findings-triage)
+
+*A 3400-bus meshed import arrives with a hundred-plus findings. Learn to sort
+them into defects to fix, judgment calls to decide, and disclosures to keep —
+and to leave a paper trail for each.*
+
+Real network data is never clean. An OpenDSS feeder that has passed through
+utility GIS exports, student edits, and format conversions arrives carrying
+structural cruft, suspicious parameters, and modelling conventions that only
+made sense in the source tool. The reflex responses — ignore all warnings, or
+"fix" everything until the report is silent — are both wrong: the first ships
+defects, the second destroys provenance and can change the physics. This
+tutorial works a deliberately messy case end to end and builds the habit the
+[judgment spine](choose_tutorial.md#The-judgment-spine) starts with:
+**triage**. Every block runs at build time.
+
+!!! note "Prerequisites"
+    Only `BMOPFTools` — nothing here needs a solver. The
+    [analysis reference](analysis.md) and the
+    [finding-code reference](findings.md) are the companion pages;
+    the [end-to-end tutorial](tutorial_end_to_end.md) covers the
+    pipeline this one prepares a case *for*.
+
+## 1. The patient: a meshed MV/LV network
+
+The `MVLVmeshed` test case is a combined MV + LV network in which
+normally-open ties and switches were deliberately re-added — a stand-in for
+the real-world case where you receive a *system*, not a tidy radial feeder:
+
+```@example triage
+using BMOPFTools
+
+path = joinpath(pkgdir(BMOPFTools), "test", "data", "MVLVmeshed", "Master.dss")
+net  = from_dss(path)
+println(length(net["bus"]), " buses, ", length(net["line"]), " lines, ",
+        length(net["switch"]), " switches, ", length(net["load"]), " loads, ",
+        sum(length(d) for d in values(net["transformer"])), " transformers")
+```
+
+Two independent layers of messages describe what you just loaded, and they
+must not be conflated: what the **importer** could not carry across, and what
+the **analyzer** thinks of the network that arrived.
+
+## 2. Layer one: what the import could not represent
+
+[`from_dss`](@ref) records every piece of OpenDSS information it had to drop
+or reinterpret in `net["_meta"]["powerio_warnings"]` — the import's fidelity
+ledger:
+
+```@example triage
+pw = net["_meta"]["powerio_warnings"]
+println(length(pw), " import warnings; a sample:")
+for w in pw[1:3]
+    println("  • ", w)
+end
+```
+
+Triage layer one *first*, because nothing downstream can see what never
+arrived. Most entries here are cosmetic (`units` fields the schema carries
+differently), but this ledger is where a dropped regulator control or an
+unsupported element would appear — losses that no amount of downstream
+analysis can detect. Read it once, note anything electrical, and move on.
+
+## 3. Layer two: the findings report and its severity contract
+
+[`analyze`](@ref) runs the full validation battery and returns findings with
+a three-level severity contract:
+
+- **`E.*` errors** — the case is broken; solves will fail or be meaningless.
+  These are not judgment calls.
+- **`W.*` warnings** — something *deserves a decision*: possibly a data
+  defect, possibly a legitimate feature of this network. Your job.
+- **`I.*` infos** — disclosures: provenance, symmetry observations, benchmark
+  realism notes. They are the case's honesty record, not problems.
+
+```@example triage
+report = analyze(net)
+println("errors ", length(errors(report)),
+        " / warnings ", length(warnings(report)),
+        " / infos ", length(infos(report)))
+
+wcount = Dict{String,Int}()
+for f in warnings(report)
+    wcount[String(f.code)] = get(wcount, String(f.code), 0) + 1
+end
+println("\nwarnings by code:")
+for (c, n) in sort(collect(wcount))
+    println("  ", rpad(c, 26), n)
+end
+```
+
+Zero errors — the case is *usable* — and a set of warnings that now get
+individual verdicts, not a blanket one.
+
+## 4. Reading warnings like a reviewer
+
+Walk the table. Each code gets one of three verdicts: **fix** (a defect with
+a mechanical repair), **decide** (investigate, then either change the data or
+accept and document), or **disclose** (true of this network by design — keep
+the finding as part of the case's record).
+
+```@example triage
+for code in ("W.CONN.MESHED", "W.CONN.DANGLING", "W.DOM.XFMR_STEP_UP",
+             "W.OPS.XFMR_OVERLOADED")
+    f = first(f for f in warnings(report) if String(f.code) == code)
+    println(f.code, "\n   ", f.message, "\n")
+end
+```
+
+- **`W.CONN.MESHED` → disclose.** This case is meshed *on purpose* (the ties
+  are the point). On a supposedly radial feeder the same finding would be a
+  defect. The code cannot know which — that is exactly why it is a warning
+  and not an error.
+- **`W.CONN.DANGLING` → fix.** Hundreds of degree-1 buses with nothing
+  attached are conversion cruft (service points whose customers were
+  modelled elsewhere). They bloat the model and can hide genuine islands;
+  a mechanical repair exists (§5).
+- **`W.DOM.XFMR_STEP_UP` / `W.DOM.XFMR_REVERSED` → decide.** A transformer
+  oriented *away* from the source usually means swapped
+  `v_nom_from`/`v_nom_to` in the source data — but it can be a genuine boost
+  unit or, in a meshed network, an artefact of hop-counting through the
+  ties. Check these four against the source data; do not auto-"fix" what
+  might be real.
+- **`W.OPS.XFMR_OVERLOADED` → decide, urgently.** A transformer at thousands
+  of percent utilisation at nominal load is not an operating condition — it
+  is a **units or rating smell** (a kVA nameplate parsed where MVA was
+  meant, or a lumped load on a service transformer). This warning is doing
+  its most valuable work here: pointing at data whose *solve* would
+  otherwise quietly hit the nameplate cap and report heavy curtailment.
+- **`W.DIV.LOAD_SYMMETRIC` → disclose.** Nearly all loads share identical
+  nameplates — a benchmark-realism note straight out of the
+  [benchmarking-gap](benchmarking_gap.md) argument. Anyone consuming this
+  case should know its load diversity is synthetic.
+
+The verdicts differ per network. The discipline is that each warning code
+gets *a* verdict, written down — the triage table above is two sentences per
+code away from being the "data quality" section of your paper's appendix.
+
+## 5. Mechanical repairs: `fix_case`
+
+The "fix" verdicts have a dedicated tool. [`fix_case`](@ref) applies
+**lossless, semantics-preserving** structural repairs — largest connected
+component, series-line merging and dangling-stub removal (via
+[`simplify_network`](@ref)), zero-load removal, near-zero-impedance lines to
+switches, redundant source-bus bounds — and returns a manifest recording
+every change. Physics-*changing* repairs (promoting grounding shunts to
+perfect groundings, snapping placeholder impedances) exist but are **opt-in**
+flags on [`FixRecipe`](@ref), off by default:
+
+```@example triage
+fixed, manifest = fix_case(net)
+
+d = manifest_to_dict(manifest)
+counts = Dict{String,Int}()
+for e in d["entries"]
+    counts[string(get(e, "field", "?"))] = get(counts, string(get(e, "field", "?")), 0) + 1
+end
+println(length(d["entries"]), " manifest entries, by kind:")
+for (c, n) in sort(collect(counts); by = x -> -x[2])
+    println("  ", rpad(c, 22), n)
+end
+println("\nbuses ", length(net["bus"]), " → ", length(fixed["bus"]),
+        ",  lines ", length(net["line"]), " → ", length(fixed["line"]))
+```
+
+Note what the manifest records besides the changes: the *blocked* merges
+(different linecodes, switches mid-run, non-line elements) — refusals are
+part of the paper trail too, and one of them (`SWITCH_IN_CHAIN`) is itself a
+data smell worth a look. Also note the paired `SHUNT_DROPPED` entries: every
+removed stub that carried charging susceptance is called out, because
+dropping it perturbs the nodal balance — `fix_case` is honest about the
+edges of "lossless". Re-analyze to see the effect:
+
+```@example triage
+report2 = analyze(fixed)
+println("after fix_case: errors ", length(errors(report2)),
+        " / warnings ", length(warnings(report2)),
+        " / infos ", length(infos(report2)))
+for f in warnings(report2)
+    String(f.code) == "W.CONN.DANGLING" && println(f.message)
+end
+```
+
+Two instructive things happened. First, the dangling population collapsed
+(534 → 55 buses) but did **not** vanish: the survivors hang off *switches*,
+and `fix_case` deliberately refuses to treat an operable device as cruft —
+those 55 need a human verdict (normally-open points? metering stubs?).
+Second, compare the warning tables before and after: the transformer
+*orientation* warnings changed count. Findings are functions of the network
+— the orientation heuristic ranks source-distance in hops, and merging
+series lines changed the hop metric — so **re-triage after every
+transformation**; a verdict written for the raw network does not
+automatically transfer. The counts that remain are the "decide" and
+"disclose" verdicts of §4 — repairs were never going to (and never should)
+silence those.
+
+## 6. From triaged to solvable: bounds, costs, and the gates
+
+A triaged case still is not an optimisation case — this import carries no
+voltage bounds, no thermal limits, no costs (`I.PRE.NO_VOLT_BOUNDS` in the
+report). [`augment_case`](@ref) synthesizes the missing operating envelope,
+and its honesty mechanism is the point: *every* synthesized value is stamped
+with a provenance finding, so the info count explodes — by design:
+
+```@example triage
+ready, aug_manifest = augment_case(fixed; recipe = AugmentationRecipe())
+report3 = analyze(ready)
+println("after augment: errors ", length(errors(report3)),
+        " / warnings ", length(warnings(report3)),
+        " / infos ", length(infos(report3)))
+```
+
+Thousands of infos now record which bounds are standards-derived and which
+are synthetic — the [nameplate tutorial](tutorial_nameplate.md)'s confidence
+tiers, applied at scale. Two gates then say whether the result is ready for
+its intended use:
+
+```@example triage
+pre = infeasibility_preflight(ready, report3.findings)
+rdy = benchmark_readiness_check(ready, report3.findings)
+println("preflight keys : ", sort(collect(keys(pre))))
+println("readiness keys : ", sort(collect(keys(rdy))))
+for s in get(rdy, "suggestions", String[])
+    println("  suggestion: ", s)
+end
+```
+
+[`infeasibility_preflight`](@ref) screens for structurally-doomed solves
+*before* you spend solver time (the
+[infeasibility tutorial](tutorial_infeasibility.md) picks up when a solve
+fails anyway); [`benchmark_readiness_check`](@ref) asks the publication
+question — well-posed objective, meaningful constraints, no degeneracy traps
+— and its suggestions are your remaining to-do list. Here it lands the
+verdict this whole case has been building toward: with only the priced slack,
+the *dispatch* problem is trivial — a triaged, bounded, solvable case is
+still not a benchmark until it carries decisions worth optimising (the
+[DER placement tutorial](tutorial_ders.md) is that step).
+
+## 7. What a defensible case ships with
+
+The end state of triage is *not* a silent report. This case ships as: the
+repaired network, **plus** the residual warnings with their written verdicts
+(meshed by design; load symmetry synthetic; four transformer orientations
+checked against source; the overload smell resolved or documented), **plus**
+the import ledger and both manifests. That bundle is what makes the case
+*reviewable* — the difference between "we cleaned the data" and a benchmark
+someone can trust. It is deliberately the same discipline the engine applies
+to itself: derived values are stamped, approximations are listed, and
+refusals are recorded.
+
+This tutorial stopped at the gates on purpose — solving a 2700-bus meshed
+case is a topic of its own. Take the triaged case onward: the
+[simplification tutorial](tutorial_simplify.md) reduces it further where
+fidelity allows, and the [end-to-end tutorial](tutorial_end_to_end.md)'s
+solve-and-profile loop applies unchanged.
+
+!!! tip "Where to go next"
+    The [finding-code reference](findings.md) is the complete catalogue
+    behind §3–4; [analysis & reports](analysis.md) documents the report
+    object; [case augmentation](augmentation.md) details every pass §6
+    invoked; and the [nameplate tutorial](tutorial_nameplate.md) is the
+    per-device version of the same provenance discipline.

--- a/examples/custom_formulations_tutorial.jl
+++ b/examples/custom_formulations_tutorial.jl
@@ -1,0 +1,146 @@
+# Custom formulations — CVR without a hook, then up the extension ladder.
+#
+#   julia --project=test examples/custom_formulations_tutorial.jl
+#
+# Companion to docs/src/tutorial_custom_formulations.md. Both share the arc:
+#   rung 0: CVR is data (free tap + ZIP + priced import; the load model flips
+#   the optimal tap direction) → rung 1: model_hook! constraint the schema
+#   can't express (joint export cap across two PV systems) → rung 2: replace
+#   the objective (balance the feeder head; epigraph spread → 0), then
+#   re-anchor economics by composing generation_cost(ctx) → rung 3: staged
+#   API, two snapshots in one model under a shared 5 kWh energy budget.
+#
+# The point. Climb no higher than the study requires; scale every physical
+# literal by ctx.bases (the hook sees a per-unit model); a replaced objective
+# is a replaced question — you own the economics.
+
+using BMOPFTools, JuMP, Ipopt
+
+const OPT = optimizer_with_attributes(Ipopt.Optimizer, "print_level" => 0)
+sep(t) = println("\n" * "="^72 * "\n  " * t * "\n" * "="^72)
+
+path = joinpath(pkgdir(BMOPFTools), "test", "data", "LV", "LV1_14bus", "Master.dss")
+base, _ = augment_case(from_dss(path); recipe = AugmentationRecipe())
+src_id  = first(keys(base["voltage_source"]))
+base["voltage_source"][src_id]["cost"] = [0.25, 0.25, 0.25]
+xfmr_id = first(keys(base["transformer"]["delta_wye"]))
+
+# ── Rung 0: CVR from data alone ───────────────────────────────────────────────
+sep("Rung 0 — CVR: load model × free tap (no hook)")
+zip = Dict{String,Any}("alpha_z"=>[0.4],"alpha_i"=>[0.3],"alpha_p"=>[0.3],
+                       "beta_z"=>[0.4],"beta_i"=>[0.3],"beta_p"=>[0.3])
+for (label, model, free_tap) in (("constant-P, fixed tap","constant_power",false),
+                                 ("constant-P, free tap", "constant_power",true),
+                                 ("ZIP, fixed tap",       "zip",           false),
+                                 ("ZIP, free tap",        "zip",           true))
+    net = deepcopy(base)
+    for (_, d) in net["load"]
+        d["model"] = model
+        model == "zip" && merge!(d, zip)
+    end
+    if free_tap
+        net["transformer"]["delta_wye"][xfmr_id]["tap_min"] = 0.90
+        net["transformer"]["delta_wye"][xfmr_id]["tap_max"] = 1.10
+    end
+    r = solve_opf(net; optimizer = OPT)
+    p_imp = sum(ph["ps"] for ph in values(r["voltage_source"][src_id]))
+    tap   = get(get(r["transformer"], xfmr_id, Dict()), "tap", 1.0)
+    println(rpad(label, 24), "P_import=", rpad(round(p_imp; digits=1), 9),
+            " W  tap=", round(tap; digits=4))
+end
+
+function with_ders(net; cost = 0.10)
+    n = deepcopy(net)
+    n["generator"] = Dict{String,Any}()
+    for (gid, bus) in (("pv1","b3230"), ("pv2","b2656"))
+        n["generator"][gid] = Dict{String,Any}(
+            "bus" => bus, "terminal_map" => ["a","b","c","n"], "configuration" => "WYE",
+            "p_min" => zeros(3), "p_max" => fill(4000.0, 3),
+            "q_min" => fill(-2000.0, 3), "q_max" => fill(2000.0, 3),
+            "cost" => fill(cost, 3))
+    end
+    n
+end
+function gen_p(ctx, gid)
+    vr, vi   = ctx.vars[:vr],  ctx.vars[:vi]
+    crg, cig = ctx.vars[:crg], ctx.vars[:cig]
+    g = ctx.net["generator"][gid]; b, tm = g["bus"], g["terminal_map"]
+    sum(@expression(ctx.model,
+            (vr[(b,tm[k])] - vr[(b,"n")]) * crg[(gid,k)] +
+            (vi[(b,tm[k])] - vi[(b,"n")]) * cig[(gid,k)]) for k in 1:3)
+end
+
+# ── Rung 1: joint export cap ──────────────────────────────────────────────────
+sep("Rung 1 — model_hook!: joint 9 kW export cap across pv1+pv2")
+net = with_ders(base; cost = -0.05)
+r0 = solve_opf(net; optimizer = OPT)
+pg0 = sum(ph["pg"] for g in values(r0["generator"]) for ph in values(g))
+r1 = solve_opf(net; optimizer = OPT, model_hook! = ctx -> begin
+    sb = ctx.bases === nothing ? 1.0 : ctx.bases.s_base
+    @constraint(ctx.model, gen_p(ctx, "pv1") + gen_p(ctx, "pv2") <= 9_000.0 / sb)
+end)
+pg1 = sum(ph["pg"] for g in values(r1["generator"]) for ph in values(g))
+println("joint DER output uncapped/capped: ", round(pg0; digits=1), " / ",
+        round(pg1; digits=1), " W")
+@assert isapprox(pg1, 9_000.0; rtol = 1e-4)
+
+# ── Rung 2: balance the feeder head ───────────────────────────────────────────
+sep("Rung 2 — replace the objective: balanced substation infeed")
+src_p(ctx) = begin
+    vr, vi   = ctx.vars[:vr], ctx.vars[:vi]
+    crs, cis = ctx.vars[:cr_src], ctx.vars[:ci_src]
+    vs = ctx.net["voltage_source"][src_id]; b, tm = vs["bus"], vs["terminal_map"]
+    [@expression(ctx.model,
+        (vr[(b,tm[k])] - vr[(b,"n")]) * crs[(src_id,k)] +
+        (vi[(b,tm[k])] - vi[(b,"n")]) * cis[(src_id,k)]) for k in 1:3]
+end
+net = with_ders(base; cost = 0.10)
+r0 = solve_opf(net; optimizer = OPT)
+p0 = sort([ph["ps"] for ph in values(r0["voltage_source"][src_id])])
+println("least-cost per-phase import: ", round.(p0; digits=1),
+        " spread=", round(p0[end]-p0[1]; digits=1))
+r2 = solve_opf(net; optimizer = OPT,
+    model_hook! = ctx -> begin
+        es = src_p(ctx); t_hi = @variable(ctx.model); t_lo = @variable(ctx.model)
+        for e in es
+            @constraint(ctx.model, e <= t_hi); @constraint(ctx.model, e >= t_lo)
+        end
+        @objective(ctx.model, Min, t_hi - t_lo)
+        ctx.model[:spread] = t_hi - t_lo
+    end,
+    solution_hook! = (ctx, result) -> begin
+        sb = ctx.bases === nothing ? 1.0 : ctx.bases.s_base
+        result["head_spread_W"] = abs(JuMP.value(ctx.model[:spread])) * sb
+    end)
+p2 = sort([ph["ps"] for ph in values(r2["voltage_source"][src_id])])
+println("balanced per-phase import  : ", round.(p2; digits=1),
+        " spread=", round(r2["head_spread_W"]; digits=2), " W")
+r3 = solve_opf(net; optimizer = OPT, model_hook! = ctx -> begin
+    es = src_p(ctx); t_hi = @variable(ctx.model); t_lo = @variable(ctx.model)
+    for e in es
+        @constraint(ctx.model, e <= t_hi); @constraint(ctx.model, e >= t_lo)
+    end
+    sb = ctx.bases.s_base
+    @objective(ctx.model, Min, generation_cost(ctx) + 1.0*(t_hi - t_lo)*sb/1000)
+end)
+p3 = sort([ph["ps"] for ph in values(r3["voltage_source"][src_id])])
+println("balanced + cheap           : ", round.(p3; digits=1),
+        "  DER total ", round(sum(ph["pg"] for g in values(r3["generator"]) for ph in values(g)); digits=1), " W")
+
+# ── Rung 3: staged API, 2 periods, 5 kWh budget ──────────────────────────────
+sep("Rung 3 — staged API: two snapshots, one 5 kWh energy budget")
+netA = with_ders(base; cost = 0.10)
+netB = deepcopy(netA)
+for (_, d) in netB["load"]; d["p_nom"] = [0.4 * Float64(d["p_nom"][1])]; end
+model = JuMP.Model(Ipopt.Optimizer); JuMP.set_silent(model)
+ctxs = [build_opf_model(n; model = model, add_objective = false) for n in (netA, netB)]
+sb = ctxs[1].bases.s_base
+@constraint(model, sum(gen_p(c, "pv1") * 1.0 for c in ctxs) <= 5_000.0 / sb)
+@objective(model, Min, sum(1.0 * generation_cost(c) for c in ctxs))
+foreach(enforce_kcl!, ctxs)
+optimize!(model)
+results = [extract_result(c) for c in ctxs]
+for (t, r) in enumerate(results)
+    println("hour ", t, ": pv1 = ",
+            round(sum(ph["pg"] for ph in values(r["generator"]["pv1"])); digits=1), " W")
+end

--- a/examples/triage_tutorial.jl
+++ b/examples/triage_tutorial.jl
@@ -1,0 +1,85 @@
+# Findings triage — from raw import to defensible case (no solver needed).
+#
+#   julia --project=test examples/triage_tutorial.jl
+#
+# Companion to docs/src/tutorial_triage.md. Both share the same arc:
+#   load the deliberately messy MVLVmeshed case → layer one: the importer's
+#   fidelity ledger (net["_meta"]["powerio_warnings"]) → layer two: analyze
+#   severities (E = broken, W = decide, I = disclosure) → per-code verdicts
+#   (fix / decide / disclose) → mechanical repairs with fix_case + manifest →
+#   augment_case's provenance-stamped bounds → the preflight and
+#   benchmark-readiness gates.
+#
+# The point. Triage is classification, not silencing: a defensible case ships
+# with its residual warnings and written verdicts, its import ledger, and its
+# transformation manifests — that bundle is what makes a benchmark reviewable.
+
+using BMOPFTools
+
+sep(t) = println("\n" * "="^72 * "\n  " * t * "\n" * "="^72)
+
+# ── 1. The patient ────────────────────────────────────────────────────────────
+sep("1. MVLVmeshed: a combined MV+LV network with deliberate mesh ties")
+path = joinpath(pkgdir(BMOPFTools), "test", "data", "MVLVmeshed", "Master.dss")
+net  = from_dss(path)
+println(length(net["bus"]), " buses, ", length(net["line"]), " lines, ",
+        length(net["switch"]), " switches, ", length(net["load"]), " loads")
+
+# ── 2. Layer one: the import ledger ──────────────────────────────────────────
+sep("2. powerio_warnings — what the import could not carry")
+pw = net["_meta"]["powerio_warnings"]
+println(length(pw), " import warnings; first three:")
+for w in pw[1:3]; println("  • ", w); end
+
+# ── 3. Layer two: analyze severities ─────────────────────────────────────────
+sep("3. analyze: errors / warnings / infos")
+report = analyze(net)
+println("E/W/I = ", length(errors(report)), "/", length(warnings(report)), "/",
+        length(infos(report)))
+wcount = Dict{String,Int}()
+for f in warnings(report)
+    wcount[String(f.code)] = get(wcount, String(f.code), 0) + 1
+end
+for (c, n) in sort(collect(wcount)); println("  ", rpad(c, 26), n); end
+
+# ── 4. Verdicts ───────────────────────────────────────────────────────────────
+sep("4. Reading warnings like a reviewer")
+for code in ("W.CONN.MESHED", "W.CONN.DANGLING", "W.DOM.XFMR_STEP_UP",
+             "W.OPS.XFMR_OVERLOADED")
+    f = first(f for f in warnings(report) if String(f.code) == code)
+    println(f.code, ": ", f.message, "\n")
+end
+
+# ── 5. fix_case + manifest ────────────────────────────────────────────────────
+sep("5. fix_case: lossless repairs, recorded")
+fixed, manifest = fix_case(net)
+d = manifest_to_dict(manifest)
+counts = Dict{String,Int}()
+for e in d["entries"]
+    c = string(get(e, "field", "?"))
+    counts[c] = get(counts, c, 0) + 1
+end
+println(length(d["entries"]), " manifest entries, by kind:")
+for (c, n) in sort(collect(counts); by = x -> -x[2]); println("  ", rpad(c, 22), n); end
+println("buses ", length(net["bus"]), " → ", length(fixed["bus"]),
+        ", lines ", length(net["line"]), " → ", length(fixed["line"]))
+report2 = analyze(fixed)
+println("after fix: E/W/I = ", length(errors(report2)), "/", length(warnings(report2)),
+        "/", length(infos(report2)))
+w2 = Dict{String,Int}()
+for f in warnings(report2)
+    w2[String(f.code)] = get(w2, String(f.code), 0) + 1
+end
+for (c, n) in sort(collect(w2)); println("  ", rpad(c, 26), n); end
+
+# ── 6. augment + gates ────────────────────────────────────────────────────────
+sep("6. augment_case + the two gates")
+ready, _ = augment_case(fixed; recipe = AugmentationRecipe())
+report3 = analyze(ready)
+println("after augment: E/W/I = ", length(errors(report3)), "/",
+        length(warnings(report3)), "/", length(infos(report3)))
+pre = infeasibility_preflight(ready, report3.findings)
+rdy = benchmark_readiness_check(ready, report3.findings)
+println("preflight keys : ", sort(collect(keys(pre))))
+println("readiness keys : ", sort(collect(keys(rdy))))
+for s in get(rdy, "suggestions", String[]); println("  suggestion: ", s); end


### PR DESCRIPTION
## Summary

Closes the remaining docs backlog items in one PR, as discussed:

1. **Custom formulations tutorial** (`tutorial_custom_formulations.md`) — the extension-point coverage promised in `positioning.md`/`index.md` (CVR, operating envelopes), structured as a ladder with a worked, build-asserted study per rung:
   - **Rung 0 — check you don't need a hook**: CVR emerges from data alone (free tap + ZIP loads + priced import). The 2×2 experiment shows the load model *flipping the optimal tap direction* (0.91 with constant-P for loss reduction vs 1.10 with ZIP riding the 0.9 pu floor, −9.6 % import) — tying together the load-model and tap tutorials.
   - **Rung 1 — `model_hook!` constraint**: a joint 9 kW export cap across two PV systems (the schema can't say "jointly"); binds exactly; demonstrates the `ctx.bases` per-unit scaling rule.
   - **Rung 2 — replaced objective**: balance the substation infeed (epigraph spread 7129 W → 0.0), with the honesty lesson that a replaced objective means owning the economics — repaired by composing `generation_cost(ctx)` back in (balanced *and* cheap), plus `solution_hook!` readback in SI.
   - **Rung 3 — staged API**: two snapshots in one model under a shared 5 kWh energy budget; the optimiser allocates all of it to the expensive hour. Duration-weighting contract spelled out.
   - Hook-hygiene checklist (scale literals, prefer data, reuse the engine's power expressions, verify like any solve).
2. **Findings-triage tutorial** (`tutorial_triage.md`) — the dirty-network workflow on MVLVmeshed (3409 buses, meshed, 0 E / 40 W / 93 I + 46 import warnings): the two message layers, the severity contract, per-code **fix / decide / disclose** verdicts (meshed-by-design vs dangling cruft vs a 5343 % transformer-utilisation data smell), `fix_case` with the manifest summarised by kind — including its *refusals* — and two honest wrinkles the data itself provided: the dangling population drops 534 → 55 (switch-hung survivors need human verdicts, not deletion), and the transformer-orientation warnings shift 4 → 7 after repairs because hop-count heuristics are functions of the network (**re-triage after every transformation**). Ends at the `infeasibility_preflight` / `benchmark_readiness_check` gates, whose live verdict ("only slack generation — dispatch is trivial") hands off to DER placement. No solver needed; the 2700-bus solve is deliberately out of scope.
3. **Judgment-spine refresh** (`choose_tutorial.md`) — the spine grows to six steps (triage first, custom formulations last) and gains a *modelling-choices track* listing the five fidelity tutorials (units, impedance, load models, transformer tests, grounding) so the curriculum reads as one arc. Router rows added for both new pages.
4. **Math-notation normalisation** in `conventions.md` — the deferred cleanup: equations written as Unicode-in-backticks (`P²+Q²≤s_max²`, `Q = B·V²`, droop laws, √ expressions, …) moved to LaTeX per the `docs/README.md` convention at 11 sites; literal JSON field names stay in greppable code style.

## Verification

- Both twins (`examples/custom_formulations_tutorial.jl`, `examples/triage_tutorial.jl`) run end-to-end.
- Full docs build green — zero new warnings (only the pre-existing size-threshold ones).
- All quantitative prose checked against the rendered live output (CVR table, cap binding, spread values, 534→55, infos 41→2774, readiness suggestion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)