### PR TITLE
Strip inline line and dc_branch limits in solve_pf (fixes #354)

### DIFF
--- a/ext/BMOPFOpfExt/pf.jl
+++ b/ext/BMOPFOpfExt/pf.jl
@@ -86,9 +86,13 @@ const _PF_LIMIT_FIELDS = ("i_max", "i_max_from", "i_max_to", "s_max")
     _strip_operational_limits!(net)
 
 Delete current/thermal/apparent-power limit fields from every component and
-linecode in the (private working) network, so the power flow imposes no
-operational limits. Voltage bounds are never added by `build_pf!`, so they need
-no stripping.
+linecode in the (private working) network — including inline `line` limits
+(which override the linecode's) and `dc_branch` `i_max`/`p_max` — so the power
+flow imposes no operational limits. Voltage bounds are never added by
+`build_pf!`, so they need no stripping. Transformer `s_rating` is deliberately
+NOT stripped: it is a required field with a documented always-enforced
+contract (see transformer_models.md); remove it from the input net to compare
+against a limit-free reference.
 """
 function _strip_operational_limits!(net::Dict{String,Any})
     # linecodes carry line thermal limits (i_max)
@@ -99,13 +103,23 @@ function _strip_operational_limits!(net::Dict{String,Any})
         end
     end
 
-    # flat component collections: switch, generator, ibr
-    for coll in ("switch", "generator", "ibr")
+    # flat component collections: line (inline limits override the linecode's),
+    # switch, generator, ibr
+    for coll in ("line", "switch", "generator", "ibr")
         for (_, comp) in get(net, coll, Dict())
             comp isa Dict || continue
             for f in _PF_LIMIT_FIELDS
                 delete!(comp, f)
             end
+        end
+    end
+
+    # DC branches carry their own limit fields (i_max, p_max). p_max is removed
+    # only here — on generators/sources it is a dispatch setpoint, not a limit.
+    for (_, br) in get(net, "dc_branch", Dict())
+        br isa Dict || continue
+        for f in ("i_max", "p_max")
+            delete!(br, f)
         end
     end
 

--- a/ext/BMOPFOpfExt/pf.jl
+++ b/ext/BMOPFOpfExt/pf.jl
@@ -8,6 +8,11 @@
 #      limits). The power flow solves the network as-is and reports whatever
 #      currents and voltages result; rating violations are a separate validation
 #      concern. This mirrors PowerModels `build_pf_iv` (variable_*(bounded=false)).
+#      ONE deliberate exception: the transformer nameplate `s_rating` (a required
+#      field with an always-enforced per-coil cap, see transformer_models.md) is
+#      NOT stripped — a PF loading a coil beyond s_rating/n_ph returns
+#      LOCALLY_INFEASIBLE (see issue #355). Remove `s_rating` from the input dict
+#      for a limit-free reference solve.
 #   2. NO objective (Min 0). The voltage source fixes the slack-bus voltages and
 #      supplies the free swing current; constant-power loads/generators/IBRs
 #      and exact KCL then fully determine the nodal state.
@@ -30,6 +35,14 @@ objective** — the network's physics (fixed source voltages + constant-power
 injections + exact KCL) fully determine the solution. Device current/thermal
 limits and voltage bounds are intentionally ignored; use `solve_opf` (or a
 post-solve validation pass) when limits must be enforced.
+
+**One exception**: a transformer's nameplate `s_rating` is a required field
+whose per-coil apparent-power cap is **always enforced**, in the power flow
+too — loading any coil beyond `s_rating / n_phase` makes the PF
+`LOCALLY_INFEASIBLE` rather than reporting an overloaded state. This is easy
+to misread as a numerical failure (healthy voltages, no other limits). To
+solve without the nameplate — e.g. to compare against a limit-free OpenDSS
+solve — delete `s_rating` from the transformer dicts in the input net first.
 
 Generators must be specified as **fixed setpoints** (`p_min == p_max` and
 `q_min == q_max`); a non-degenerate P/Q range is rejected, since a power flow has

--- a/test/opf_tests.jl
+++ b/test/opf_tests.jl
@@ -2922,6 +2922,42 @@
     end
 
     # ─────────────────────────────────────────────────────────────────────────
+    # PF5d: the s_rating exception, pinned both ways (issue #355). The nameplate
+    # coil cap IS enforced in a power flow — a load beyond s_rating is
+    # LOCALLY_INFEASIBLE, not an overload report — and deleting s_rating from
+    # the input net is the documented escape hatch.
+    # ─────────────────────────────────────────────────────────────────────────
+    @testset "PF5d: transformer s_rating stays enforced in solve_pf (#355)" begin
+        mknet() = parse_bmopf("""
+        {"bus":{
+            "src":{"terminal_names":["1","n"],"perfectly_grounded_terminals":["n"]},
+            "lv": {"terminal_names":["1","n"],"perfectly_grounded_terminals":["n"]}},
+         "voltage_source":{"vs":{"bus":"src","terminal_map":["1"],
+             "v_magnitude":[1000.0],"v_angle":[0.0]}},
+         "transformer":{"single_phase":{"t1":{
+             "bus_from":"src","bus_to":"lv",
+             "terminal_map_from":["1","n"],"terminal_map_to":["1","n"],
+             "v_nom_from":1000.0,"v_nom_to":1000.0,"s_rating":5000.0,
+             "r_series_from":0.05,"x_series_from":0.1}}},
+         "load":{"ld1":{"bus":"lv","terminal_map":["1","n"],
+             "configuration":"SINGLE_PHASE",
+             "p_nom":[10000.0],"q_nom":[0.0]}}}
+        """; from_string=true)
+
+        # 10 kW load through a 5 kVA nameplate: the coil cap binds → infeasible.
+        res = solve_pf(mknet())
+        @test res["termination_status"] ∉ ("LOCALLY_SOLVED", "OPTIMAL")
+
+        # The documented escape hatch: delete s_rating → the same PF solves and
+        # reports the overloaded state.
+        net = mknet()
+        delete!(net["transformer"]["single_phase"]["t1"], "s_rating")
+        res2 = solve_pf(net)
+        @test res2["termination_status"] in ("LOCALLY_SOLVED", "OPTIMAL")
+        @test sum(ph["pd"] for ph in values(res2["load"]["ld1"])) ≈ 10000.0  rtol=1e-3
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────
     # Single-phase autotransformer / step voltage regulator
     #
     # Lossless ideal regulator collapses to V_to = n_eff·V_fr_pn.

--- a/test/opf_tests.jl
+++ b/test/opf_tests.jl
@@ -2848,6 +2848,80 @@
     end
 
     # ─────────────────────────────────────────────────────────────────────────
+    # PF5b: INLINE line limits are ignored too (issue #354). An inline i_max /
+    # s_max on the line dict overrides the linecode's in the OPF (branch.jl),
+    # so the PF must strip the line component itself, not just linecodes.
+    # ─────────────────────────────────────────────────────────────────────────
+    @testset "PF5b: inline line i_max/s_max are ignored by solve_pf (#354)" begin
+        net = parse_bmopf("""
+        {"bus":{
+            "sourcebus":{"terminal_names":["1","n"],
+                         "perfectly_grounded_terminals":["n"]},
+            "bus1":     {"terminal_names":["1","n"],
+                         "perfectly_grounded_terminals":["n"]}},
+         "voltage_source":{"vs":{"bus":"sourcebus","terminal_map":["1"],
+             "v_magnitude":[1000.0],"v_angle":[0.0]}},
+         "linecode":{"lc":{"R_series_1_1":0.5}},
+         "line":{"l1":{"bus_from":"sourcebus","bus_to":"bus1",
+             "terminal_map_from":["1"],"terminal_map_to":["1"],
+             "linecode":"lc","length":1.0,
+             "i_max":[1.0e-3],"s_max":[1.0e-3]}},
+         "load":{"ld1":{"bus":"bus1","terminal_map":["1","n"],
+             "configuration":"SINGLE_PHASE",
+             "p_nom":[100000.0],"q_nom":[0.0]}}}
+        """; from_string=true)
+
+        res = solve_pf(net)
+        @test res["termination_status"] in ("LOCALLY_SOLVED", "OPTIMAL")
+        @test res["line"]["l1"]["1"]["cm_fr"] > 1.0
+        # The caller's net must be untouched.
+        @test net["line"]["l1"]["i_max"] == [1.0e-3]
+        @test net["line"]["l1"]["s_max"] == [1.0e-3]
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────
+    # PF5c: the strip contract, unit-tested — line and dc_branch limit fields
+    # are removed; generator p_min/p_max are NOT (they are the PF's fixed
+    # setpoint, not an operational limit).
+    # ─────────────────────────────────────────────────────────────────────────
+    @testset "PF5c: _strip_operational_limits! covers line + dc_branch, keeps gen setpoints" begin
+        ext = Base.get_extension(BMOPFTools, :BMOPFOpfExt)
+        net = Dict{String,Any}(
+            "linecode"  => Dict{String,Any}("lc" => Dict{String,Any}(
+                "R_series_1_1" => 0.5, "i_max" => [10.0], "s_max" => [1.0e4])),
+            "line"      => Dict{String,Any}("l1" => Dict{String,Any}(
+                "linecode" => "lc", "i_max" => [10.0], "s_max" => [1.0e4])),
+            "switch"    => Dict{String,Any}("sw" => Dict{String,Any}("i_max" => [10.0])),
+            "generator" => Dict{String,Any}("g1" => Dict{String,Any}(
+                "i_max" => [10.0], "s_max" => [1.0e4],
+                "p_min" => [5.0e3], "p_max" => [5.0e3])),
+            "dc_branch" => Dict{String,Any}("dcb" => Dict{String,Any}(
+                "r" => 0.1, "i_max" => [10.0], "p_max" => 1.0e4)),
+            "transformer" => Dict{String,Any}("single_phase" => Dict{String,Any}(
+                "t1" => Dict{String,Any}(
+                    "i_max_from" => [10.0], "i_max_to" => [100.0],
+                    "s_rating" => 5.0e4))))
+        ext._strip_operational_limits!(net)
+
+        for (comp, fields) in (net["linecode"]["lc"]        => ("i_max", "s_max"),
+                               net["line"]["l1"]            => ("i_max", "s_max"),
+                               net["switch"]["sw"]          => ("i_max",),
+                               net["generator"]["g1"]       => ("i_max", "s_max"),
+                               net["dc_branch"]["dcb"]      => ("i_max", "p_max"),
+                               net["transformer"]["single_phase"]["t1"] =>
+                                   ("i_max_from", "i_max_to"))
+            for f in fields
+                @test !haskey(comp, f)
+            end
+        end
+        # Fixed generator setpoints survive; the transformer nameplate contract
+        # (always enforced) survives.
+        @test net["generator"]["g1"]["p_min"] == [5.0e3]
+        @test net["generator"]["g1"]["p_max"] == [5.0e3]
+        @test net["transformer"]["single_phase"]["t1"]["s_rating"] == 5.0e4
+    end
+
+    # ─────────────────────────────────────────────────────────────────────────
     # Single-phase autotransformer / step voltage regulator
     #
     # Lossless ideal regulator collapses to V_to = n_eff·V_fr_pn.


### PR DESCRIPTION
## Summary

Fixes #354. `solve_pf` promises a determined, **limit-free** solve, but `_strip_operational_limits!` never touched the `line` collection — and a line-level inline `i_max`/`s_max` *overrides* the linecode's in the OPF builder ([branch.jl:195-196]), so a power flow on a net with inline line ratings silently enforced them and returned `LOCALLY_INFEASIBLE` above the ampacity instead of reporting the physical overloaded state. `dc_branch` `i_max`/`p_max` had the same gap.

## Changes

- **`ext/BMOPFOpfExt/pf.jl`** — add `"line"` to the flat-collection strip loop; add a dedicated `dc_branch` pass for `(i_max, p_max)` (a separate tuple, because `p_max` on generators/DC sources is the PF's *fixed setpoint*, not an operational limit, and must survive). The docstring now states the full coverage and the one deliberate exception: transformer `s_rating` stays, per its documented always-enforced nameplate contract (`transformer_models.md` — remove it from the input dict for limit-free reference comparisons).
- **`test/opf_tests.jl`** — two regressions next to the existing PF5:
  - **PF5b** (end-to-end): inline `i_max = s_max = 1e-3` on the line; `solve_pf` must return `LOCALLY_SOLVED` with ~108 A flowing, and the caller's net must keep its fields (stripping happens on the working copy).
  - **PF5c** (unit): `_strip_operational_limits!` removes line/linecode/switch/generator/IBR/transformer/dc_branch limit fields while **preserving** generator `p_min`/`p_max` setpoints and transformer `s_rating`.

## Verification

- Without the fix, PF5b/PF5c fail exactly the 6 new assertions (bug confirmed reproducible); with it, all pass.
- Full `opf_tests.jl` (787 tests) and `dc_network_tests.jl` green locally; the change only *removes* limit fields from the PF's private working copy, so it can only relax PF problems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)