### PR TITLE
fix: correct LV voltage base in the SWER test feeder

### DIFF
--- a/test/data/SWER/Master.dss
+++ b/test/data/SWER/Master.dss
@@ -65,7 +65,13 @@ Redirect Transformers.dss
 Redirect Groundings.dss
 Redirect Loads.dss
 
-Set VoltageBases=[22.0, 12.7, 0.24]
+! OpenDSS VoltageBases are LINE-TO-LINE, so each entry is divided by sqrt(3) to
+! get a bus's phase-to-earth kVBase.  22.0 therefore covers both the 3-phase MV
+! bus and the 12.7 kV SWER buses (12.7 = 22/sqrt(3)) -- a listed 12.7 would be
+! redundant.  The LV entry must likewise be the sqrt(3)-scaled 0.24 kV:  entering
+! 0.24 directly bases the LV buses at 0.1386 kV and reports nominal 240 V as
+! 1.723 pu.
+Set VoltageBases=[22.0, 0.41569]
 CalcVoltageBases
 ! Tolerance 1e-8 (<< the voltage-comparison tolerance) removes OpenDSS-side
 ! convergence slop; MaxIterations raised so the tighter target is reached.


### PR DESCRIPTION
Fixes #359

OpenDSS VoltageBases entries are line-to-line and are divided by sqrt(3) to give each bus its phase-to-earth kVBase. The feeder listed 0.24 for its 240 V LV section, which bases those buses at 0.24/sqrt(3) = 0.1386 kV and reports nominal 240 V as 1.723 pu.

Use the sqrt(3)-scaled 0.41569 instead, giving kVBase = 0.24 and ~0.99 pu at nominal. Power flow is unaffected -- voltage bases drive only pu reporting -- and no test asserts pu values on this feeder.

The SWER base was correct only by coincidence: the feeder's 12.7 kV is 22/sqrt(3), so the 22.0 entry already covered it and the listed 12.7 was redundant. That coincidence does not generalise to SWER systems at other voltages, so the reasoning is now recorded in the file.


Claude-Session: https://claude.ai/code/session_01VWRPPa1h5unNf2KNba6LRW