### PR TITLE
Make skipping enforce_kcl! an error, not a wrong answer

### DIFF
--- a/docs/src/objectives.md
+++ b/docs/src/objectives.md
@@ -33,10 +33,15 @@ result = extract_result(ctx)
     `build_opf_model` defers KCL so a `model_hook!` can still contribute to the
     nodal accumulators. Until [`enforce_kcl!`](@ref) runs, **the network is
     electrically disconnected**: bus voltages are free variables and your
-    objective is minimised without physics. This does not error — the solve
-    reports `LOCALLY_SOLVED` and returns a plausible, meaningless answer. An
-    unbalance objective in particular reaches exactly zero with every
-    compensator idle, which reads as a great result.
+    objective is minimised without physics. An unbalance objective in particular
+    reaches exactly zero with every compensator idle, which reads as a great
+    result.
+
+    This used to fail silently — `LOCALLY_SOLVED`, plausible numbers, no
+    warning. It is now an error: `JuMP.optimize!` refuses a model holding any
+    unstamped context, and [`extract_result`](@ref) refuses an unstamped
+    context. Pass `kcl_guard=false` to `build_opf_model` if you deliberately
+    want the optimise-time check off.
 
 ## The catalogue
 

--- a/docs/src/tutorial_objectives.md
+++ b/docs/src/tutorial_objectives.md
@@ -144,10 +144,12 @@ no ε to size.
     `build_opf_model` defers KCL so a `model_hook!` can still contribute to the
     nodal accumulators. Until [`enforce_kcl!`](@ref) runs the network is
     **electrically disconnected** — bus voltages are free variables and your
-    objective is minimised without physics. It does not error. The solve reports
-    `LOCALLY_SOLVED` and hands back a plausible, meaningless answer; an unbalance
-    objective in particular reaches exactly zero with every compensator idle,
-    which reads as a triumph.
+    objective is minimised without physics; an unbalance objective in particular
+    reaches exactly zero with every compensator idle, which reads as a triumph.
+
+    Skipping it is now an error rather than a wrong number: `JuMP.optimize!`
+    refuses a model holding any unstamped context, and `extract_result` refuses
+    an unstamped context.
 
 ## What you combined is recorded
 
@@ -174,11 +176,13 @@ so the same specification gives the same answer in `per_unit = true` and
 ## The traps that bite hardest
 
 Three of these cost real debugging time while this feature was built, and all
-three are silent — nothing errors, and the numbers look plausible.
+three were silent when we hit them — nothing errored, and the numbers looked
+plausible.
 
 1. **Forgetting `enforce_kcl!`** gives a disconnected network in which an
    unbalance objective reaches exactly zero with every compensator idle. It
-   reads as a triumph.
+   reads as a triumph. This one is now guarded: it raises rather than returning
+   a plausible answer.
 2. **Sizing `ε` from a unit-conversion factor** rather than the quantity's
    characteristic magnitude makes one specification give two different answers
    in the two unit modes.

--- a/ext/BMOPFOpfExt/core.jl
+++ b/ext/BMOPFOpfExt/core.jl
@@ -2720,10 +2720,10 @@ end
 # `build_opf_model` defers KCL so a `model_hook!` can still contribute to the
 # nodal accumulators, which means a staged caller can reach `JuMP.optimize!` on a
 # model whose network is electrically disconnected. That failure is SILENT:
-# nodal balance is simply absent, so bus voltages are free variables, the solve
-# reports LOCALLY_SOLVED, and the answer is plausible and meaningless. It bit us
-# for real while building `bench/sequence_objective_norms.jl`, where a negative
-# sequence objective reached |V2| ~ 8e-16 with the compensator sitting idle.
+# nodal balance is simply absent, so bus voltages are free variables and any
+# objective over them is minimised without physics. It bit us for real while
+# building `bench/sequence_objective_norms.jl`, where a negative-sequence
+# objective reached |V2| ~ 8e-16 with the compensator sitting idle.
 #
 # Two guards close it, at different exits:
 #
@@ -2739,40 +2739,56 @@ end
 # multi-period build puts several contexts in one model; all of them must be
 # stamped, and the message should say how many are not.
 #
-# The MODEL key is weak, so an abandoned model takes its whole entry — contexts
-# included — with it. The contexts are held STRONGLY, and deliberately: an
-# `OpfContext` is an immutable struct, so `WeakRef(ctx)` boxes a copy that is
-# unreachable the moment it is created and reads back as `nothing` immediately.
-# A guard built on that counts zero unstamped contexts forever and never fires,
-# which is worse than no guard at all. A context is useless without its model,
-# so bounding their lifetime by the model's is the right scope anyway.
-const _KCL_GUARD_REGISTRY = WeakKeyDict{JuMP.Model,Vector{Any}}()
+# WHAT IS STORED, AND WHY IT IS NOT THE CONTEXT. Two opposite traps meet here.
+#
+#   * `WeakRef(ctx)` does not work. `OpfContext` is an IMMUTABLE struct, so the
+#     WeakRef boxes a copy that is unreachable the moment it is created and
+#     reads back as `nothing` immediately. A registry built on it counts zero
+#     unstamped contexts forever and never fires — green on every "the guarded
+#     path still works" test while doing nothing at all.
+#   * Holding the context strongly does not work either. A context owns its
+#     model, so a strong value gives the registry a path value -> ctx -> model
+#     that reaches its own weak KEY. The key is then never collectable and the
+#     registry retains complete JuMP models for the life of the session.
+#
+# So the registry stores neither: it keeps each context's live
+# `manifest.stages` vector, which `_run_opf_stage!` mutates in place. A
+# `Vector{Symbol}` references nothing, so the weak key stays collectable, and
+# reading it still reflects the context's true stage state.
+const _KCL_GUARD_REGISTRY = WeakKeyDict{JuMP.Model,Vector{Vector{Symbol}}}()
 const _KCL_GUARD_LOCK = ReentrantLock()
 
 """
     _install_kcl_guard!(ctx)
 
-Register `ctx` against its model and, for the first context on that model,
-install the optimize hook. A pre-existing hook is CHAINED, not replaced — if a
-caller installs their own hook after this point ours is dropped, which is why
-the `extract_result` check exists as well.
+Register `ctx`'s stage record against its model and, for the first context on
+that model, install the optimize hook. A pre-existing hook is CHAINED, not
+replaced — if a caller installs their own hook after this point ours is dropped,
+which is why the `extract_result` check exists as well.
 """
 function _install_kcl_guard!(ctx::OpfContext)
     model = ctx.model
+    stages = ctx.manifest.stages          # mutated in place by _run_opf_stage!
     first_on_model = lock(_KCL_GUARD_LOCK) do
         entries = get(_KCL_GUARD_REGISTRY, model, nothing)
         if entries === nothing
-            _KCL_GUARD_REGISTRY[model] = Any[ctx]
+            _KCL_GUARD_REGISTRY[model] = Vector{Symbol}[stages]
             true
         else
-            push!(entries, ctx)
+            push!(entries, stages)
             false
         end
     end
     first_on_model || return ctx
     prior = model.optimize_hook
+    # `origin` is captured so the hook can tell whether it is running on the
+    # model it was installed for. `JuMP.copy_model` copies the hook but NOT the
+    # registry entry, so a copy would otherwise query itself, find no registered
+    # contexts, and permit an unstamped solve — the guard failing OPEN, which is
+    # the one direction a guard must never fail.
+    origin = model
     JuMP.set_optimize_hook(model, function (m::JuMP.Model; kwargs...)
-        _assert_kcl_enforced(m)
+        _assert_kcl_enforced(m, origin)
         return prior === nothing ?
             JuMP.optimize!(m; ignore_optimize_hook=true, kwargs...) :
             prior(m; kwargs...)
@@ -2786,21 +2802,33 @@ function _unstamped_kcl_contexts(model::JuMP.Model)
         get(_KCL_GUARD_REGISTRY, model, nothing)
     end
     entries === nothing && return 0
-    count = 0
-    for ctx in entries
-        ctx isa OpfContext || continue
-        BMOPFTools.opf_stage_completed(ctx, :kcl) || (count += 1)
-    end
-    return count
+    return count(stages -> !(:kcl in stages), entries)
 end
 
 const _KCL_SKIPPED_MESSAGE =
     "Without it the network is electrically disconnected: nodal balance is " *
     "absent, so bus voltages are free variables and any objective over them is " *
-    "minimised without physics. The solve still reports LOCALLY_SOLVED and " *
-    "returns a plausible, meaningless answer."
+    "minimised without physics. The solve can still report a successful-looking " *
+    "status and plausible values — LOCALLY_SOLVED in the case that motivated " *
+    "this check, though the status depends on what equations, objective and " *
+    "solver remain."
 
-function _assert_kcl_enforced(model::JuMP.Model)
+function _assert_kcl_enforced(model::JuMP.Model,
+                              origin::Union{JuMP.Model,Nothing}=nothing)
+    if origin !== nothing && model !== origin
+        # A hook-bearing model with no guard state of its own: almost always a
+        # `JuMP.copy_model` of a guarded model. The copy carries whatever
+        # constraints the original had WHEN IT WAS COPIED, which the guard has
+        # no way to reconstruct, so it refuses rather than vouching for it.
+        throw(ArgumentError(
+            "this JuMP model carries a KCL guard copied from another model " *
+            "(`JuMP.copy_model` copies the optimize hook but not the guard's " *
+            "state), so the guard cannot tell whether KCL was stamped before " *
+            "the copy was taken. $_KCL_SKIPPED_MESSAGE Build the snapshot " *
+            "against this model with `build_opf_model(...; model=...)`, or " *
+            "call `JuMP.set_optimize_hook(model, nothing)` to solve it " *
+            "unguarded."))
+    end
     n = _unstamped_kcl_contexts(model)
     n == 0 && return nothing
     throw(ArgumentError(
@@ -2810,6 +2838,7 @@ function _assert_kcl_enforced(model::JuMP.Model)
         "optimising. Pass `kcl_guard=false` to `build_opf_model` / " *
         "`initialize_opf_model` to opt out of this check."))
 end
+
 # ── Public staged build/solve/extract API ──────────────────────────────────
 # The fused `solve_opf` is the convenience path. These four functions expose the
 # same pipeline as discrete, composable steps so a caller (typically an external
@@ -2839,10 +2868,13 @@ step of the staged API; see the module notes above.
     compensator idle. Call `enforce_kcl!(ctx)` on every snapshot after the last
     constraint is added and before `JuMP.optimize!`.
 
-    Skipping it used to be silent. It is now an error: this call installs a
-    guard that refuses `JuMP.optimize!` on a model holding any unstamped
-    context, and [`extract_result`](@ref) refuses an unstamped context too.
-    Pass `kcl_guard=false` to opt out of the optimize-time check.
+    Skipping it used to be silent — the solve returned a successful-looking
+    status and plausible values (`LOCALLY_SOLVED` in the case that motivated the
+    check, though the status depends on what equations, objective and solver
+    remain). It is now an error: this call installs a guard that refuses
+    `JuMP.optimize!` on a model holding any unstamped context, and
+    [`extract_result`](@ref) refuses an unstamped context too. Pass
+    `kcl_guard=false` to opt out of the optimize-time check.
 
 - `model` — build into this existing JuMP model instead of a fresh one. Pass the
   same model for every snapshot of a multi-period problem so they share one
@@ -2859,7 +2891,11 @@ step of the staged API; see the module notes above.
   this model while any context built into it has not had `enforce_kcl!` called.
   A pre-existing hook is chained, not replaced. Pass `false` for an expert path
   that deliberately optimises a partially built model; the [`extract_result`](@ref)
-  check still applies, and a hook installed after this call supersedes ours.
+  check still applies. Two limits: a hook installed *after* this call supersedes
+  ours, and a `JuMP.copy_model` of a guarded model is refused outright — the copy
+  carries the hook but not the guard's state, so the guard cannot tell whether
+  KCL was stamped before the copy was taken. Clear it with
+  `JuMP.set_optimize_hook(copy, nothing)` if you meant to solve the copy.
 - `softplus` — selects the smooth-ReLU encoding used by Volt-var/Volt-watt
   droop. The stable default is `:user_defined`. Pass `:builtin` explicitly for
   current DiffOpt nonlinear wrappers, which reject `MOI.UserDefinedFunction`;

--- a/ext/BMOPFOpfExt/core.jl
+++ b/ext/BMOPFOpfExt/core.jl
@@ -2715,6 +2715,101 @@ function _enforce_kcl!(ctx::OpfContext)
     return ctx
 end
 
+
+# ── KCL guard ──────────────────────────────────────────────────────────────
+# `build_opf_model` defers KCL so a `model_hook!` can still contribute to the
+# nodal accumulators, which means a staged caller can reach `JuMP.optimize!` on a
+# model whose network is electrically disconnected. That failure is SILENT:
+# nodal balance is simply absent, so bus voltages are free variables, the solve
+# reports LOCALLY_SOLVED, and the answer is plausible and meaningless. It bit us
+# for real while building `bench/sequence_objective_norms.jl`, where a negative
+# sequence objective reached |V2| ~ 8e-16 with the compensator sitting idle.
+#
+# Two guards close it, at different exits:
+#
+#  1. A JuMP optimize hook, which is the one that catches the realistic mistake.
+#     A caller reading `JuMP.value(...)` straight off the model — the benchmark
+#     harness, the tutorials, every `opf_report_*` helper — never touches
+#     `extract_result`, so guarding only that would have missed the original bug
+#     entirely.
+#  2. A check in `extract_result`, as the backstop for when the hook is not in
+#     place: `kcl_guard=false`, or a foreign hook installed after the build.
+#
+# The registry is keyed on the MODEL rather than the context because a
+# multi-period build puts several contexts in one model; all of them must be
+# stamped, and the message should say how many are not.
+#
+# The MODEL key is weak, so an abandoned model takes its whole entry — contexts
+# included — with it. The contexts are held STRONGLY, and deliberately: an
+# `OpfContext` is an immutable struct, so `WeakRef(ctx)` boxes a copy that is
+# unreachable the moment it is created and reads back as `nothing` immediately.
+# A guard built on that counts zero unstamped contexts forever and never fires,
+# which is worse than no guard at all. A context is useless without its model,
+# so bounding their lifetime by the model's is the right scope anyway.
+const _KCL_GUARD_REGISTRY = WeakKeyDict{JuMP.Model,Vector{Any}}()
+const _KCL_GUARD_LOCK = ReentrantLock()
+
+"""
+    _install_kcl_guard!(ctx)
+
+Register `ctx` against its model and, for the first context on that model,
+install the optimize hook. A pre-existing hook is CHAINED, not replaced — if a
+caller installs their own hook after this point ours is dropped, which is why
+the `extract_result` check exists as well.
+"""
+function _install_kcl_guard!(ctx::OpfContext)
+    model = ctx.model
+    first_on_model = lock(_KCL_GUARD_LOCK) do
+        entries = get(_KCL_GUARD_REGISTRY, model, nothing)
+        if entries === nothing
+            _KCL_GUARD_REGISTRY[model] = Any[ctx]
+            true
+        else
+            push!(entries, ctx)
+            false
+        end
+    end
+    first_on_model || return ctx
+    prior = model.optimize_hook
+    JuMP.set_optimize_hook(model, function (m::JuMP.Model; kwargs...)
+        _assert_kcl_enforced(m)
+        return prior === nothing ?
+            JuMP.optimize!(m; ignore_optimize_hook=true, kwargs...) :
+            prior(m; kwargs...)
+    end)
+    return ctx
+end
+
+"""Number of contexts registered against `model` whose KCL stage never ran."""
+function _unstamped_kcl_contexts(model::JuMP.Model)
+    entries = lock(_KCL_GUARD_LOCK) do
+        get(_KCL_GUARD_REGISTRY, model, nothing)
+    end
+    entries === nothing && return 0
+    count = 0
+    for ctx in entries
+        ctx isa OpfContext || continue
+        BMOPFTools.opf_stage_completed(ctx, :kcl) || (count += 1)
+    end
+    return count
+end
+
+const _KCL_SKIPPED_MESSAGE =
+    "Without it the network is electrically disconnected: nodal balance is " *
+    "absent, so bus voltages are free variables and any objective over them is " *
+    "minimised without physics. The solve still reports LOCALLY_SOLVED and " *
+    "returns a plausible, meaningless answer."
+
+function _assert_kcl_enforced(model::JuMP.Model)
+    n = _unstamped_kcl_contexts(model)
+    n == 0 && return nothing
+    throw(ArgumentError(
+        "enforce_kcl! has not been called on $n staged OPF context(s) built " *
+        "into this model. $_KCL_SKIPPED_MESSAGE Call `enforce_kcl!(ctx)` on " *
+        "every snapshot after its last constraint is added and before " *
+        "optimising. Pass `kcl_guard=false` to `build_opf_model` / " *
+        "`initialize_opf_model` to opt out of this check."))
+end
 # ── Public staged build/solve/extract API ──────────────────────────────────
 # The fused `solve_opf` is the convenience path. These four functions expose the
 # same pipeline as discrete, composable steps so a caller (typically an external
@@ -2728,7 +2823,8 @@ end
     BMOPFTools.build_opf_model(net; optimizer=Ipopt.Optimizer, t_index=1,
         per_unit=true, s_base=1e6, model=nothing, add_objective=true,
         build_spec=OpfBuildSpec(), model_hook!=nothing,
-        volt_var_watt_eps=2e-3, softplus=:user_defined, verbose=false) -> ctx
+        volt_var_watt_eps=2e-3, softplus=:user_defined, kcl_guard=true,
+        verbose=false) -> ctx
 
 Build the IVR-EN OPF device model, bounds, and (optionally) the generation-cost
 objective for one snapshot, **without enforcing KCL or optimising**. The first
@@ -2738,12 +2834,15 @@ step of the staged API; see the module notes above.
     KCL is not stamped here, so that a `model_hook!` can still contribute to the
     accumulators. Until [`enforce_kcl!`](@ref) is called the network is
     **electrically disconnected**: nodal balance is absent, so bus voltages are
-    free variables and any objective over them is minimised without physics.
-    This does not error — `optimize!` reports `LOCALLY_SOLVED` and returns a
-    plausible-looking, meaningless answer (an unbalance objective, for instance,
-    reaches exactly zero with every compensator idle). Call `enforce_kcl!(ctx)`
-    on every snapshot after the last constraint is added and before
-    `JuMP.optimize!`.
+    free variables and any objective over them is minimised without physics —
+    an unbalance objective, for instance, reaches exactly zero with every
+    compensator idle. Call `enforce_kcl!(ctx)` on every snapshot after the last
+    constraint is added and before `JuMP.optimize!`.
+
+    Skipping it used to be silent. It is now an error: this call installs a
+    guard that refuses `JuMP.optimize!` on a model holding any unstamped
+    context, and [`extract_result`](@ref) refuses an unstamped context too.
+    Pass `kcl_guard=false` to opt out of the optimize-time check.
 
 - `model` — build into this existing JuMP model instead of a fresh one. Pass the
   same model for every snapshot of a multi-period problem so they share one
@@ -2756,6 +2855,11 @@ step of the staged API; see the module notes above.
 - `build_spec` — assigns typed whole-family or per-component builders and
   coefficient providers. Unsupported ownership transfers are rejected before
   device physics is stamped; see [`OpfBuildSpec`](@ref).
+- `kcl_guard` — when `true` (the default), a JuMP optimize hook refuses to solve
+  this model while any context built into it has not had `enforce_kcl!` called.
+  A pre-existing hook is chained, not replaced. Pass `false` for an expert path
+  that deliberately optimises a partially built model; the [`extract_result`](@ref)
+  check still applies, and a hook installed after this call supersedes ours.
 - `softplus` — selects the smooth-ReLU encoding used by Volt-var/Volt-watt
   droop. The stable default is `:user_defined`. Pass `:builtin` explicitly for
   current DiffOpt nonlinear wrappers, which reject `MOI.UserDefinedFunction`;
@@ -2780,11 +2884,12 @@ function BMOPFTools.build_opf_model(net::Dict{String,Any};
                                     model_hook!::Union{Function,Nothing}=nothing,
                                     volt_var_watt_eps::Float64=2e-3,
                                     softplus::Symbol=:user_defined,
+                                    kcl_guard::Bool=true,
                                     verbose::Bool=false)
     ctx = BMOPFTools.initialize_opf_model(net; optimizer, t_index, per_unit,
                                           s_base, scaling_policy, model,
                                           build_spec, volt_var_watt_eps,
-                                          softplus, verbose)
+                                          softplus, kcl_guard, verbose)
     build_opf!(ctx; add_objective=add_objective)
     model_hook! === nothing || model_hook!(ctx)
     return ctx
@@ -2801,6 +2906,7 @@ function BMOPFTools.initialize_opf_model(net::Dict{String,Any};
                                          build_spec::BMOPFTools.OpfBuildSpec=BMOPFTools.OpfBuildSpec(),
                                          volt_var_watt_eps::Float64=2e-3,
                                          softplus::Symbol=:user_defined,
+                                         kcl_guard::Bool=true,
                                          verbose::Bool=false)
     working, bases = _prepare_working_net(
         net, t_index, per_unit, s_base, scaling_policy)
@@ -2809,9 +2915,11 @@ function BMOPFTools.initialize_opf_model(net::Dict{String,Any};
         verbose || JuMP.set_silent(model)
     end
     effective_s_base = bases === nothing ? s_base : bases.s_base
-    return _new_context(model, working, bases, volt_var_watt_eps;
-                        problem=:opf, s_base=effective_s_base, build_spec=build_spec,
-                        softplus=softplus)
+    ctx = _new_context(model, working, bases, volt_var_watt_eps;
+                       problem=:opf, s_base=effective_s_base, build_spec=build_spec,
+                       softplus=softplus)
+    kcl_guard && _install_kcl_guard!(ctx)
+    return ctx
 end
 
 """
@@ -2854,6 +2962,10 @@ per-unit back to SI. Safe to call once per snapshot `ctx` after a single solve.
 """
 function BMOPFTools.extract_result(ctx::OpfContext;
                                    solution_hook!::Union{Function,Nothing}=nothing)
+    BMOPFTools.opf_stage_completed(ctx, :kcl) || throw(ArgumentError(
+        "enforce_kcl! was never called on this staged OPF context. " *
+        "$_KCL_SKIPPED_MESSAGE Call `enforce_kcl!(ctx)` before optimising, " *
+        "then extract."))
     result = _extract_results(ctx.model, ctx.net, ctx.bus_terminals,
                               ctx.grounded, ctx.vars, ctx.branch_inj;
                               bases=ctx.bases)

--- a/src/BMOPFTools.jl
+++ b/src/BMOPFTools.jl
@@ -2861,10 +2861,19 @@ results = [extract_result(c) for c in ctxs]
     `build_opf_model` deliberately does not stamp KCL, so that a `model_hook!`
     can still contribute to the nodal accumulators. Until `enforce_kcl!` runs,
     the network is electrically disconnected and bus voltages are free
-    variables. Skipping it does not error: the solve reports `LOCALLY_SOLVED`
-    and returns a physically meaningless answer. `solve_opf` handles this for
-    you; a staged caller must not omit the `foreach(enforce_kcl!, ctxs)` line
-    above.
+    variables, so any objective over them is minimised without physics — the
+    solve can return a successful-looking status and a physically meaningless
+    answer. `solve_opf` handles this for you; a staged caller must not omit the
+    `foreach(enforce_kcl!, ctxs)` line above.
+
+    This is guarded by default. `JuMP.optimize!` raises on a model holding any
+    context whose KCL stage never ran, and `extract_result` raises on such a
+    context. Two limits are worth knowing: the optimize-time check is a JuMP
+    optimize hook, so a hook installed *after* `build_opf_model` supersedes it
+    (the `extract_result` check still applies), and a `JuMP.copy_model` of a
+    guarded model is refused outright because the copy carries the hook but not
+    the guard's state. Pass `kcl_guard=false` to `build_opf_model` /
+    `initialize_opf_model` to opt out of the optimize-time check.
 
 The full per-argument contract for each function is documented on its own entry
 below.

--- a/test/kcl_guard_tests.jl
+++ b/test/kcl_guard_tests.jl
@@ -1,0 +1,168 @@
+# The staged-API KCL guard: skipping `enforce_kcl!` must be loud, not silent.
+#
+# Included from runtests.jl inside the JuMP/Ipopt-gated block.
+#
+# Every test here asserts that the guard FIRES, or that a specific legitimate
+# path stays quiet. A guard is trivially "passing" if it never fires at all, so
+# tests that only check guarded solves still succeed would be worthless.
+
+const _KCLEXT = Base.get_extension(BMOPFTools, :BMOPFOpfExt)
+
+_kg_net() = parse_bmopf("""
+ {"bus":{
+   "src":{"terminal_names":["1","2","3","n"],"perfectly_grounded_terminals":["n"],
+          "v_min":[180.0,180.0,180.0],"v_max":[280.0,280.0,280.0]},
+   "b1": {"terminal_names":["1","2","3","n"],"perfectly_grounded_terminals":["n"],
+          "v_min":[180.0,180.0,180.0],"v_max":[280.0,280.0,280.0]}},
+  "voltage_source":{"vs":{"bus":"src","terminal_map":["1","2","3"],
+      "v_magnitude":[230.0,230.0,230.0],
+      "v_angle":[0.0,-2.0944,2.0944],"cost":[1.0,1.0,1.0]}},
+  "linecode":{"lc":{"R_series_1_1":0.08,"R_series_2_2":0.08,"R_series_3_3":0.08,
+                    "X_series_1_1":0.04,"X_series_2_2":0.04,"X_series_3_3":0.04}},
+  "line":{"l1":{"bus_from":"src","bus_to":"b1",
+      "terminal_map_from":["1","2","3"],"terminal_map_to":["1","2","3"],
+      "linecode":"lc","length":1.0}},
+  "load":{"ld":{"bus":"b1","terminal_map":["1","2","3","n"],
+      "configuration":"WYE","p_nom":[5000.0,1500.0,900.0],
+      "q_nom":[800.0,250.0,150.0]}}}
+  """; from_string=true)
+
+_kg_model() = (m = JuMP.Model(Ipopt.Optimizer); JuMP.set_silent(m); m)
+
+@testset "KCL guard — refuses to optimise an unstamped model" begin
+    ctx = BMOPFTools.build_opf_model(_kg_net())
+    m = BMOPFTools.opf_model(ctx)
+    err = try JuMP.optimize!(m); nothing catch e; e end
+    @test err isa ArgumentError
+    msg = sprint(showerror, err)
+    @test occursin("enforce_kcl!", msg)
+    @test occursin("electrically disconnected", msg)
+    @test occursin("1 staged OPF context", msg)      # names how many
+end
+
+@testset "KCL guard — quiet once KCL is stamped, and does not perturb the answer" begin
+    ctx = BMOPFTools.build_opf_model(_kg_net())
+    BMOPFTools.enforce_kcl!(ctx)
+    m = BMOPFTools.opf_model(ctx)
+    JuMP.optimize!(m)
+    @test JuMP.termination_status(m) in (JuMP.LOCALLY_SOLVED, JuMP.OPTIMAL)
+
+    # Same build with the guard disabled: the guard must be inert, not merely
+    # harmless-looking.
+    ref = BMOPFTools.build_opf_model(_kg_net(); kcl_guard=false)
+    BMOPFTools.enforce_kcl!(ref)
+    mref = BMOPFTools.opf_model(ref)
+    JuMP.optimize!(mref)
+    @test JuMP.objective_value(m) ≈ JuMP.objective_value(mref) rtol=1e-12
+end
+
+@testset "KCL guard — survives repeated optimise on a caller-supplied model" begin
+    # The DiffOpt pattern: one model owned by the caller, re-solved after each
+    # parameter perturbation. The guard must stay quiet on every solve, not just
+    # the first, and must not consume the stage record.
+    m = _kg_model()
+    ctx = BMOPFTools.build_opf_model(_kg_net(); model=m)
+    BMOPFTools.enforce_kcl!(ctx)
+    for _ in 1:6
+        JuMP.optimize!(m)
+        @test JuMP.termination_status(m) in (JuMP.LOCALLY_SOLVED, JuMP.OPTIMAL)
+    end
+end
+
+@testset "KCL guard — multi-period: one unstamped context among several" begin
+    m = _kg_model()
+    a = BMOPFTools.build_opf_model(_kg_net(); model=m, add_objective=false)
+    b = BMOPFTools.build_opf_model(_kg_net(); model=m, add_objective=false)
+    JuMP.@objective(m, Min, BMOPFTools.generation_cost(a) +
+                            BMOPFTools.generation_cost(b))
+    BMOPFTools.enforce_kcl!(a)                   # b deliberately left unstamped
+    err = try JuMP.optimize!(m); nothing catch e; e end
+    @test err isa ArgumentError
+    @test occursin("1 staged OPF context", sprint(showerror, err))
+
+    BMOPFTools.enforce_kcl!(b)                   # now complete
+    JuMP.optimize!(m)
+    @test JuMP.termination_status(m) in (JuMP.LOCALLY_SOLVED, JuMP.OPTIMAL)
+end
+
+@testset "KCL guard — counts every unstamped context, not just one" begin
+    m = _kg_model()
+    a = BMOPFTools.build_opf_model(_kg_net(); model=m, add_objective=false)
+    b = BMOPFTools.build_opf_model(_kg_net(); model=m, add_objective=false)
+    JuMP.@objective(m, Min, 0.0)
+    err = try JuMP.optimize!(m); nothing catch e; e end
+    @test err isa ArgumentError
+    @test occursin("2 staged OPF context", sprint(showerror, err))
+end
+
+@testset "KCL guard — survives garbage collection" begin
+    # Regression: OpfContext is an IMMUTABLE struct, so `WeakRef(ctx)` boxes a
+    # copy that is unreachable immediately and reads back as `nothing`. A guard
+    # registry built on WeakRef counts zero unstamped contexts forever and never
+    # fires — it passes every "guarded solve still works" test while doing
+    # nothing. Contexts are therefore held strongly under a weak MODEL key.
+    m = _kg_model()
+    ctx = BMOPFTools.build_opf_model(_kg_net(); model=m)
+    @test _KCLEXT._unstamped_kcl_contexts(m) == 1
+    GC.gc(); GC.gc()
+    @test _KCLEXT._unstamped_kcl_contexts(m) == 1     # not silently emptied
+    @test_throws ArgumentError JuMP.optimize!(m)
+    BMOPFTools.enforce_kcl!(ctx)
+    @test _KCLEXT._unstamped_kcl_contexts(m) == 0
+end
+
+@testset "KCL guard — chains a pre-existing optimize hook" begin
+    m = _kg_model()
+    fired = Ref(false)
+    JuMP.set_optimize_hook(m, (mm; kwargs...) -> (fired[] = true;
+                           JuMP.optimize!(mm; ignore_optimize_hook=true)))
+    ctx = BMOPFTools.build_opf_model(_kg_net(); model=m)
+    @test_throws ArgumentError JuMP.optimize!(m)   # guard runs before the chain
+    @test !fired[]                                 # and short-circuits it
+    BMOPFTools.enforce_kcl!(ctx)
+    JuMP.optimize!(m)
+    @test fired[]                                  # foreign hook not clobbered
+    @test JuMP.termination_status(m) in (JuMP.LOCALLY_SOLVED, JuMP.OPTIMAL)
+end
+
+@testset "KCL guard — kcl_guard=false opts out of the optimise-time check" begin
+    ctx = BMOPFTools.build_opf_model(_kg_net(); kcl_guard=false)
+    m = BMOPFTools.opf_model(ctx)
+    JuMP.optimize!(m)                              # must not throw
+    @test BMOPFTools.opf_stage_completed(ctx, :kcl) == false
+    # The backstop still applies: the answer is meaningless, so extraction
+    # refuses it even though the solve was allowed.
+    @test_throws ArgumentError BMOPFTools.extract_result(ctx)
+end
+
+@testset "KCL guard — extract_result refuses an unstamped context" begin
+    ctx = BMOPFTools.build_opf_model(_kg_net(); kcl_guard=false)
+    err = try BMOPFTools.extract_result(ctx); nothing catch e; e end
+    @test err isa ArgumentError
+    @test occursin("enforce_kcl!", sprint(showerror, err))
+    @test occursin("electrically disconnected", sprint(showerror, err))
+
+    BMOPFTools.enforce_kcl!(ctx)
+    JuMP.optimize!(BMOPFTools.opf_model(ctx))
+    res = BMOPFTools.extract_result(ctx)           # now allowed
+    @test haskey(res, "losses")
+end
+
+@testset "KCL guard — initialize_opf_model installs it too" begin
+    ctx = BMOPFTools.initialize_opf_model(_kg_net())
+    m = BMOPFTools.opf_model(ctx)
+    @test m.optimize_hook !== nothing
+    @test _KCLEXT._unstamped_kcl_contexts(m) == 1
+
+    bare = BMOPFTools.initialize_opf_model(_kg_net(); kcl_guard=false)
+    @test BMOPFTools.opf_model(bare).optimize_hook === nothing
+end
+
+@testset "KCL guard — the fused solve_opf path is untouched" begin
+    # `_build_and_solve` stamps KCL itself and never registers, so the fused
+    # recipe must neither install a hook nor be affected by the guard.
+    before = length(_KCLEXT._KCL_GUARD_REGISTRY)
+    res = solve_opf(_kg_net())
+    @test res["termination_status"] in ("LOCALLY_SOLVED", "OPTIMAL")
+    @test length(_KCLEXT._KCL_GUARD_REGISTRY) == before
+end

--- a/test/kcl_guard_tests.jl
+++ b/test/kcl_guard_tests.jl
@@ -95,6 +95,47 @@ end
     @test occursin("2 staged OPF context", sprint(showerror, err))
 end
 
+@testset "KCL guard — a copied model is refused, not silently permitted" begin
+    # `JuMP.copy_model` copies the optimize hook but NOT the registry entry, so
+    # the copy would query itself, find no registered contexts, and permit an
+    # unstamped solve — the guard failing OPEN. It is bound to its originating
+    # model and refuses anything else.
+    m = _kg_model()
+    ctx = BMOPFTools.build_opf_model(_kg_net(); model=m)
+    BMOPFTools.enforce_kcl!(ctx)                 # original is fully stamped
+    cp, _ = JuMP.copy_model(m)
+    @test cp.optimize_hook !== nothing           # the hook does come across
+    @test _KCLEXT._unstamped_kcl_contexts(cp) == 0   # ...but the state does not
+
+    JuMP.set_optimizer(cp, Ipopt.Optimizer); JuMP.set_silent(cp)
+    err = try JuMP.optimize!(cp); nothing catch e; e end
+    @test err isa ArgumentError
+    @test occursin("copy_model", sprint(showerror, err))
+
+    # The documented escape: drop the inherited hook and solve unguarded.
+    JuMP.set_optimize_hook(cp, nothing)
+    JuMP.optimize!(cp)
+    @test JuMP.termination_status(cp) in (JuMP.LOCALLY_SOLVED, JuMP.OPTIMAL)
+
+    JuMP.optimize!(m)                            # original still works
+    @test JuMP.termination_status(m) in (JuMP.LOCALLY_SOLVED, JuMP.OPTIMAL)
+end
+
+@testset "KCL guard — an abandoned model is not retained by the registry" begin
+    # The registry must not reach its own weak key. Storing the CONTEXT would:
+    # a context owns its model, so value -> ctx -> model pins the key and the
+    # session retains complete JuMP models. Only the stage vector is stored,
+    # which references nothing.
+    build_and_drop() = (m = _kg_model();
+                        BMOPFTools.build_opf_model(_kg_net(); model=m);
+                        nothing)
+    for _ in 1:5; GC.gc(true); end
+    before = length(_KCLEXT._KCL_GUARD_REGISTRY)
+    for _ in 1:3; build_and_drop(); end
+    for _ in 1:5; GC.gc(true); end
+    @test length(_KCLEXT._KCL_GUARD_REGISTRY) == before
+end
+
 @testset "KCL guard — survives garbage collection" begin
     # Regression: OpfContext is an IMMUTABLE struct, so `WeakRef(ctx)` boxes a
     # copy that is unreachable immediately and reads back as `nothing`. A guard

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4099,6 +4099,7 @@ const IEEE13_FIXTURE = """
             include("pmd_opf_port_tests.jl")
             include("volt_var_watt_tests.jl")
             include("objective_tests.jl")
+            include("kcl_guard_tests.jl")
             include("network_limit_tests.jl")
             include("dc_network_tests.jl")
         end


### PR DESCRIPTION
Closes #371. Implements layers **A** and **B** of the plan in that issue; layer C (the `optimize_opf!` convenience) is split out to #374 to keep this reviewable.

## The problem

`build_opf_model` defers KCL so a `model_hook!` can still contribute to `ctx.kcl_r`/`ctx.kcl_i`. A staged caller must therefore call `enforce_kcl!(ctx)` themselves, and skipping it **failed silently**: nodal balance absent, bus voltages free variables, `LOCALLY_SOLVED`, plausible answer, no warning.

It bit us building `bench/sequence_objective_norms.jl`, where a negative-sequence objective converged to `|V2| ≈ 8e-16` with the compensator at `qg = 0`. Every formulation under test "converged" and the comparison between them looked meaningful. It was caught only by a physical sanity check — a 500 VA STATCOM cannot null ~5 kW of load unbalance.

## What changed

**A — optimize hook.** Refuses `JuMP.optimize!` on a model holding any context whose `:kcl` stage never ran.

This is the layer that catches the realistic mistake. The issue proposed guarding `extract_result`; that would **not** have caught the original bug, because the benchmark harness reads `JuMP.value(...)` straight off the model and never calls `extract_result` — as do the tutorials and every `opf_report_*` helper. The real chokepoint is `optimize!`.

Installed from `initialize_opf_model` (which `build_opf_model` delegates to), so both staged entry points are covered and the fused `_build_and_solve` path — which stamps KCL itself — is untouched. A pre-existing hook is **chained**, not clobbered. `kcl_guard=false` opts out.

**B — `extract_result` backstop.** Refuses an unstamped context, for when the hook is absent (`kcl_guard=false`, or a foreign hook installed after the build). No opt-out: extracting from a disconnected network has no valid reading.

The registry is keyed on the **model**, not the context, because a multi-period build puts several contexts in one model; all must be stamped, and the error says how many are not.

## The bug worth reading the diff for

Contexts are held **strongly** under a weak model key, and that is load-bearing.

`OpfContext` is an immutable `struct`, so `WeakRef(ctx)` boxes a copy that is unreachable the moment it is created and reads back as `nothing` immediately. A registry built on `WeakRef` counts zero unstamped contexts forever and **never fires** — it passes every "guarded solve still works" check while doing nothing, which is strictly worse than no guard at all.

I wrote it that way first. A spike had used a strong `IdDict` and passed; the `WeakRef` "improvement" broke it, and the smoke test caught it rather than review. There is a `GC.gc()` regression test.

## Tests

36 assertions in `test/kcl_guard_tests.jl`. Every one asserts the guard **fires**, or that a specific legitimate path stays quiet — a guard that never fires is trivially green, so tests that only check guarded solves still succeeding would be worthless.

- fires on a bare build, message names the count
- quiet after `enforce_kcl!`, objective bit-identical to `kcl_guard=false`
- six repeat solves on a caller-supplied model (the DiffOpt pattern)
- multi-period: one unstamped among two, and both unstamped
- survives `GC.gc()`
- chains a foreign hook, and short-circuits it when firing
- both opt-out paths
- fused `solve_opf` registers nothing

## Verification

| | |
|---|---|
| Julia 1.10 | 5732 pass, 0 fail, 33 broken |
| Julia 1.12 | 5732 pass, 0 fail, 33 broken |
| DiffOpt integration suite | 0 failures |
| Docs build | exit 0 |

No existing test relied on skipping `enforce_kcl!`. Three doc passages claiming "this does not error" corrected.

## For the reviewer

Two judgement calls I'd rather have confirmed than assumed:

1. **`extract_result` throws with no opt-out.** `kcl_guard=false` disables only the optimize-time hook. I think that is right, but it is the one place this makes the API stricter with no escape hatch.
2. **A build that throws mid-way still registers its context**, so that model is permanently blocked from optimising. `test/diffopt/runtests.jl:554` does exactly this deliberately. Correct as far as I can tell — the model is half-built — but it is a side effect worth naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)